### PR TITLE
feat: make alpaca/saas-short-trader MCP-native by default

### DIFF
--- a/alpaca/saas-short-trader/.env.example
+++ b/alpaca/saas-short-trader/.env.example
@@ -1,3 +1,5 @@
+# Legacy Python/API fallback env vars.
+# MCP-native runs in agent mode do not require this file.
 SEREN_API_KEY=your_seren_api_key_here
 SEREN_GATEWAY_URL=https://api.serendb.com
 SEREN_PROJECT_NAME=alpaca-short-trader

--- a/alpaca/saas-short-trader/README.md
+++ b/alpaca/saas-short-trader/README.md
@@ -2,6 +2,8 @@
 
 Production-oriented autonomous skill for shorting AI-vulnerable SaaS equities via Alpaca.
 
+Default execution backend is MCP-native (`mcp__seren-mcp` tools). Python scripts are fallback.
+
 ## Directory
 
 ```
@@ -15,6 +17,7 @@ alpaca/saas-short-trader/
 └── scripts/
     ├── dry_run_checklist.md
     ├── dry_run_prompt.txt
+    ├── mcp_native_runbook.md
     ├── run_agent_server.py
     ├── setup_cron.py
     ├── setup_serendb.py
@@ -28,6 +31,17 @@ alpaca/saas-short-trader/
 
 ## Quick Start
 
+### MCP-native (Recommended)
+
+Use the single prompt in `scripts/dry_run_prompt.txt` with your agent.  
+It will:
+- Use Seren MCP to resolve/create the project + database
+- Apply schemas via MCP SQL
+- Pull feed data via MCP publishers
+- Persist scan/orders/PnL/learning rows via MCP SQL
+
+### Legacy Python/API Fallback
+
 ```bash
 python3 -m pip install -r requirements.txt
 cp .env.example .env
@@ -37,6 +51,12 @@ python3 scripts/strategy_engine.py --api-key "$SEREN_API_KEY" --run-type scan --
 ```
 
 ## Continuous Operation
+
+### MCP-native
+
+Run from agent automation (for example via `seren-cron` publisher) and keep all writes in `alpaca_short_bot` through MCP SQL operations.
+
+### Legacy Python Runner
 
 ```bash
 SEREN_API_KEY="$SEREN_API_KEY" SAAS_SHORT_TRADER_WEBHOOK_SECRET="$SAAS_SHORT_TRADER_WEBHOOK_SECRET" \
@@ -52,6 +72,7 @@ python3 scripts/setup_cron.py \
 ## Notes
 
 - Use `paper-sim` first.
+- MCP-native is the primary and preferred path.
 - Self-learning promotion requires gate checks; it does not auto-promote to live.
 - Use `scripts/dry_run_prompt.txt` for a single copy/paste test run.
 

--- a/alpaca/saas-short-trader/config.example.json
+++ b/alpaca/saas-short-trader/config.example.json
@@ -1,4 +1,5 @@
 {
+  "execution_backend": "mcp",
   "mode": "paper-sim",
   "run_profile": "continuous",
   "learning_mode": "adaptive-paper",

--- a/alpaca/saas-short-trader/scripts/dry_run_checklist.md
+++ b/alpaca/saas-short-trader/scripts/dry_run_checklist.md
@@ -2,16 +2,19 @@
 
 Use this checklist before every strategy dry run.
 
-## 1) Environment
+## 1) MCP Environment
 
-- Confirm `SEREN_API_KEY` is set (database target is auto-resolved/created).
-- Confirm Python dependencies are installed:
-  - `python3 -m pip install -r requirements.txt`
+- Confirm Seren MCP connectivity is available.
+- Confirm your MCP identity can access the target Seren org/project.
+- Confirm payment method/balance is available for publisher calls.
 
 ## 2) Data + Storage Readiness
 
-- Apply schemas:
-  - `python3 scripts/setup_serendb.py --api-key "$SEREN_API_KEY"`
+- Ensure project exists: `alpaca-short-trader`.
+- Ensure database exists: `alpaca_short_bot`.
+- Apply schemas via MCP SQL using:
+  - `scripts/serendb_schema.sql`
+  - `scripts/self_learning_schema.sql`
 - Verify key tables exist:
   - `trading.strategy_runs`
   - `trading.candidate_scores`
@@ -22,7 +25,7 @@ Use this checklist before every strategy dry run.
 
 ## 3) Publisher Readiness
 
-- Ensure these publishers are active and authorized:
+- Ensure these publishers are active and callable through MCP:
   - `alpaca`
   - `sec-filings-intelligence`
   - `google-trends`
@@ -39,11 +42,10 @@ Use this checklist before every strategy dry run.
 ## 5) Execute One Full Dry Run
 
 - Use `scripts/dry_run_prompt.txt` as a single copy/paste prompt.
-- Run sequence:
-  - `scan`
-  - `monitor`
-  - `post-close`
-  - self-learning bootstrap (`action=full`)
+- Execute with MCP-native tools only:
+  - publisher calls via `call_publisher`
+  - DB writes via `run_sql` / `run_sql_transaction`
+  - no Python script execution for the default path
 
 ## 6) Validate Outputs
 
@@ -63,4 +65,5 @@ Use this checklist before every strategy dry run.
 ## 7) Failure Handling
 
 - If a required publisher fails, run should be blocked when strict mode is on.
-- Fix publisher issue, then rerun full dry run.
+- If `perplexity` fails, use `exa` fallback and capture this in run metadata.
+- Fix upstream issue, then rerun full dry run.

--- a/alpaca/saas-short-trader/scripts/dry_run_prompt.txt
+++ b/alpaca/saas-short-trader/scripts/dry_run_prompt.txt
@@ -1,31 +1,34 @@
-Run a complete dry run for `saas-short-trader` in `paper-sim` mode with strict feeds enabled.
+Run a complete dry run for `saas-short-trader` using MCP-native execution only (no Python script execution).
 
 Requirements:
-- Score 30 SaaS names (`max_names_scored=30`)
+- Mode: `paper-sim`
+- Score exactly 30 SaaS names (`max_names_scored=30`)
 - Cap planned shorts at 8 (`max_names_orders=8`)
-- Use publishers: `alpaca`, `sec-filings-intelligence`, `google-trends`, `perplexity` (fallback `exa`)
-- Persist all data and PnL to the connected SerenDB instance
+- Use publishers:
+  - `alpaca`
+  - `sec-filings-intelligence`
+  - `google-trends`
+  - `perplexity` (fallback `exa`)
+- Persist all state in SerenDB database `alpaca_short_bot` under project `alpaca-short-trader`
 
-Execute these commands in order:
+Execution steps:
+1. Use Seren MCP to resolve/create project `alpaca-short-trader`, default branch, and database `alpaca_short_bot`.
+2. Apply schemas from:
+   - `scripts/serendb_schema.sql`
+   - `scripts/self_learning_schema.sql`
+3. Pull data from publishers (MCP calls), score 30 names, select top 8 with conviction >= 65.
+4. Write rows into:
+   - `trading.strategy_runs`
+   - `trading.candidate_scores`
+   - `trading.order_events` (planned simulated shorts)
+   - `trading.position_marks_daily`
+   - `trading.pnl_daily` (`paper-sim`, `paper`, `live`)
+   - learning tables (`learning_feature_snapshots`, `learning_outcome_labels`, `learning_policy_versions`, `learning_policy_assignments`, `learning_events`)
+5. Mark run status completed and return summary.
 
-python3 scripts/setup_serendb.py --api-key "$SEREN_API_KEY"
-python3 scripts/strategy_engine.py --api-key "$SEREN_API_KEY" --run-type scan --mode paper-sim --strict-required-feeds --config config.example.json
-python3 scripts/strategy_engine.py --api-key "$SEREN_API_KEY" --run-type monitor --mode paper-sim --config config.example.json
-python3 scripts/strategy_engine.py --api-key "$SEREN_API_KEY" --run-type post-close --mode paper-sim --config config.example.json
-python3 scripts/self_learning.py --api-key "$SEREN_API_KEY" --action full --mode paper-sim
-
-Then return:
-1. The 8 selected names (ticker + conviction + rank)
-2. Feed status per publisher
-3. Simulated 5D/10D/20D net PnL and hit rate
-4. Confirmation that rows were written to:
-   - trading.strategy_runs
-   - trading.candidate_scores
-   - trading.order_events
-   - trading.position_marks_daily
-   - trading.pnl_daily
-   - trading.learning_feature_snapshots
-   - trading.learning_outcome_labels
-   - trading.learning_policy_versions
-   - trading.learning_policy_assignments
-   - trading.learning_events
+Return:
+1. `run_id`
+2. The 8 selected names (ticker + conviction + rank)
+3. Feed status per publisher
+4. Simulated 5D/10D/20D net PnL and hit rate
+5. Proof-of-write counts for each table listed above

--- a/alpaca/saas-short-trader/scripts/mcp_native_runbook.md
+++ b/alpaca/saas-short-trader/scripts/mcp_native_runbook.md
@@ -1,0 +1,47 @@
+# MCP-Native Runbook
+
+This skill should run with Seren MCP tools as the default backend.
+
+## Required MCP Capabilities
+
+- Project/database lifecycle:
+  - `list_projects`, `list_branches`, `list_databases`, `create_database`
+- SQL execution:
+  - `run_sql`, `run_sql_transaction`
+- Publisher calls:
+  - `call_publisher`
+
+## Target Resources
+
+- Project: `alpaca-short-trader`
+- Database: `alpaca_short_bot`
+- Mode: `paper-sim`
+- Universe size: `30`
+- Order cap: `8`
+
+## Publisher Set
+
+- `alpaca`
+- `sec-filings-intelligence`
+- `google-trends`
+- `perplexity` (fallback: `exa`)
+
+## Persistence Contract
+
+Every run must write to:
+
+- `trading.strategy_runs`
+- `trading.candidate_scores`
+- `trading.order_events`
+- `trading.position_marks_daily`
+- `trading.pnl_daily`
+- `trading.learning_feature_snapshots`
+- `trading.learning_outcome_labels`
+- `trading.learning_policy_versions`
+- `trading.learning_policy_assignments`
+- `trading.learning_events`
+
+## Notes
+
+- Use `scripts/serendb_schema.sql` and `scripts/self_learning_schema.sql` for schema apply.
+- Treat Python scripts in this directory as fallback/legacy path when MCP execution is unavailable.


### PR DESCRIPTION
## Summary
- switch `alpaca/saas-short-trader` default execution path to MCP-native
- keep Python/API path as explicit legacy fallback
- add MCP-native runbook and update dry-run assets for one-prompt execution

## Changes
- updated `alpaca/saas-short-trader/SKILL.md`
- updated `alpaca/saas-short-trader/README.md`
- updated `alpaca/saas-short-trader/scripts/dry_run_prompt.txt`
- updated `alpaca/saas-short-trader/scripts/dry_run_checklist.md`
- added `alpaca/saas-short-trader/scripts/mcp_native_runbook.md`
- updated `alpaca/saas-short-trader/.env.example` (legacy fallback note)
- updated `alpaca/saas-short-trader/config.example.json` (`execution_backend: mcp`)

## Why
MCP execution has been materially more reliable in this environment than shell/Python network paths, and it aligns with required access patterns for data + DB operations.

## Validation
- MCP paper-sim bootstrap run was executed and persisted to `alpaca_short_bot`
- selected basket and PnL rows were written successfully via MCP SQL