### PR TITLE
feat(kraken): add money mode router skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ seren-skills/
 ├── cryptobullseyezone/
 │   └── tax/                     # 1099-DA to Form 8949 reconciliation guide
 ├── kraken/
-│   └── grid-trader/             # Kraken grid trading bot
+│   ├── grid-trader/             # Kraken grid trading bot
+│   └── money-mode-router/       # Kraken product mode recommender
 ├── polymarket/
 │   └── trader/                  # Polymarket prediction market bot
 └── seren/

--- a/kraken/money-mode-router/.env.example
+++ b/kraken/money-mode-router/.env.example
@@ -1,0 +1,10 @@
+# Seren API key for Kraken publisher calls
+SEREN_API_KEY=sb_your_key_here
+
+# Required: SerenDB/Postgres connection string
+# Example: postgresql://user:password@host:5432/database
+SERENDB_CONNECTION_STRING=postgresql://serendb_owner:password@localhost:5432/serendb
+
+# Optional overrides
+SEREN_GATEWAY_BASE_URL=https://api.serendb.com
+KRAKEN_SPOT_PUBLISHER=kraken-spot-trading

--- a/kraken/money-mode-router/.gitignore
+++ b/kraken/money-mode-router/.gitignore
@@ -1,0 +1,5 @@
+.env
+config.json
+__pycache__/
+logs/
+*.pyc

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: money-mode-router
+description: "Kraken customer skill that converts user goals into a concrete Kraken action mode (payments, investing, trading, on-chain, automation) and persists each session to SerenDB"
+---
+
+# Kraken Money Mode Router
+
+Route users to the best Kraken product flow fast.
+
+Use this skill when a user asks things like:
+- "What should I use in Kraken?"
+- "Should I trade, invest, pay, or go on-chain?"
+- "Give me a plan for my money on Kraken"
+
+## What It Does
+
+1. Captures user intent with a short questionnaire.
+2. Scores Kraken money modes against user goals.
+3. Returns a primary mode and backup mode.
+4. Produces a concrete action checklist users can execute immediately.
+5. Stores session, answers, recommendations, and action plan in SerenDB.
+
+## Modes
+
+- `payments` -> Krak-focused everyday money movement
+- `investing` -> multi-asset portfolio building
+- `active-trading` -> hands-on market execution
+- `onchain` -> Kraken spot funding endpoints for deposits, withdrawals, and wallet transfers
+- `automation` -> rules-based, repeatable execution
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Set `SERENDB_CONNECTION_STRING` (required).
+3. Set `SEREN_API_KEY` (required for Kraken account context).
+4. Copy `config.example.json` to `config.json`.
+5. Install dependencies: `pip install -r requirements.txt`.
+
+## Commands
+
+```bash
+# Initialize SerenDB schema
+python scripts/agent.py init-db
+
+# Interactive recommendation flow
+python scripts/agent.py recommend --config config.json --interactive
+
+# Recommendation flow from JSON answers file
+python scripts/agent.py recommend --config config.json --answers-file answers.json
+```
+
+## Output
+
+The agent returns:
+- primary mode
+- backup mode
+- confidence score
+- top reasons
+- action checklist
+- API-backed mode coverage
+- session id for querying SerenDB history
+
+## Data Model (SerenDB)
+
+Tables created by `init-db`:
+- `kraken_skill_sessions`
+- `kraken_skill_answers`
+- `kraken_skill_recommendations`
+- `kraken_skill_actions`
+- `kraken_skill_events`
+
+## Notes
+
+- This skill does not implement compliance policy logic. It routes user intent and lets Kraken API permissions enforce availability.
+- The router only recommends modes backed by currently configured publishers.

--- a/kraken/money-mode-router/config.example.json
+++ b/kraken/money-mode-router/config.example.json
@@ -1,0 +1,91 @@
+{
+  "skill_name": "Kraken Money Mode Router",
+  "available_publishers": [
+    "kraken-spot-trading",
+    "kraken-ramp"
+  ],
+  "mode_order": [
+    "payments",
+    "investing",
+    "active-trading",
+    "onchain",
+    "automation"
+  ],
+  "score_weights": {
+    "primary_goal": {
+      "move-money": {"payments": 6, "onchain": 2},
+      "grow-portfolio": {"investing": 6, "active-trading": 2},
+      "trade-markets": {"active-trading": 6, "automation": 2},
+      "build-onchain": {"onchain": 6, "automation": 2},
+      "automate": {"automation": 6, "active-trading": 2}
+    },
+    "time_horizon": {
+      "today": {"payments": 3, "active-trading": 2},
+      "weeks": {"active-trading": 2, "automation": 2},
+      "months": {"investing": 3, "automation": 2},
+      "years": {"investing": 4, "onchain": 2}
+    },
+    "risk_level": {
+      "low": {"payments": 2, "investing": 3},
+      "medium": {"investing": 2, "automation": 2, "active-trading": 1},
+      "high": {"active-trading": 3, "onchain": 3, "automation": 2}
+    },
+    "hands_on": {
+      "hands-off": {"automation": 4, "investing": 2},
+      "balanced": {"investing": 2, "automation": 2, "active-trading": 1},
+      "hands-on": {"active-trading": 4, "onchain": 2}
+    },
+    "portfolio_focus": {
+      "multi-asset": {"investing": 4},
+      "crypto": {"active-trading": 3, "onchain": 3},
+      "equities": {"investing": 4},
+      "payments": {"payments": 4}
+    },
+    "activity_frequency": {
+      "daily": {"payments": 3, "active-trading": 2},
+      "weekly": {"automation": 3, "active-trading": 1},
+      "monthly": {"investing": 3, "automation": 2}
+    }
+  },
+  "publisher_requirements": {
+    "payments": ["kraken-ramp"],
+    "investing": ["kraken-spot-trading"],
+    "active-trading": ["kraken-spot-trading"],
+    "onchain": ["kraken-spot-trading"],
+    "automation": ["kraken-spot-trading"]
+  },
+  "mode_endpoint_catalog": {
+    "payments": [
+      {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/buy/crypto"},
+      {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/payment-methods"},
+      {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/limits"},
+      {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/quotes/prospective"},
+      {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/checkout"}
+    ],
+    "investing": [
+      {"publisher": "kraken-spot-trading", "method": "GET", "path": "/public/AssetPairs"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/Balance"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrder"}
+    ],
+    "active-trading": [
+      {"publisher": "kraken-spot-trading", "method": "GET", "path": "/public/Ticker"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/OpenOrders"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrder"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelOrder"}
+    ],
+    "onchain": [
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/DepositMethods"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/DepositAddresses"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WithdrawMethods"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WithdrawInfo"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/Withdraw"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WalletTransfer"}
+    ],
+    "automation": [
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrderBatch"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelOrderBatch"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelAllOrdersAfter"},
+      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/GetWebSocketsToken"}
+    ]
+  }
+}

--- a/kraken/money-mode-router/requirements.txt
+++ b/kraken/money-mode-router/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+python-dotenv>=1.0.1
+psycopg[binary]>=3.1.18

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Kraken Money Mode Router agent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+from dotenv import load_dotenv
+
+from kraken_client import KrakenClient
+from mode_engine import ModeEngine
+from serendb_store import SerenDBStore
+
+
+QUESTION_SET: List[Dict[str, Any]] = [
+    {
+        "key": "primary_goal",
+        "prompt": "What is your primary goal right now?",
+        "options": [
+            ("move-money", "Move money and payments"),
+            ("grow-portfolio", "Grow a long-term portfolio"),
+            ("trade-markets", "Trade markets actively"),
+            ("build-onchain", "Build on-chain positions"),
+            ("automate", "Automate strategy execution"),
+        ],
+    },
+    {
+        "key": "time_horizon",
+        "prompt": "What time horizon matters most?",
+        "options": [
+            ("today", "Today"),
+            ("weeks", "This month"),
+            ("months", "3-12 months"),
+            ("years", "1+ years"),
+        ],
+    },
+    {
+        "key": "risk_level",
+        "prompt": "What risk level fits you?",
+        "options": [
+            ("low", "Lower volatility"),
+            ("medium", "Balanced"),
+            ("high", "Higher risk/higher upside"),
+        ],
+    },
+    {
+        "key": "hands_on",
+        "prompt": "How hands-on do you want to be?",
+        "options": [
+            ("hands-off", "Hands-off"),
+            ("balanced", "Balanced"),
+            ("hands-on", "Hands-on"),
+        ],
+    },
+    {
+        "key": "portfolio_focus",
+        "prompt": "What product focus do you want?",
+        "options": [
+            ("multi-asset", "Multi-asset"),
+            ("crypto", "Crypto-first"),
+            ("equities", "Equities-forward"),
+            ("payments", "Payments-first"),
+        ],
+    },
+    {
+        "key": "activity_frequency",
+        "prompt": "How often will you use this flow?",
+        "options": [
+            ("daily", "Daily"),
+            ("weekly", "Weekly"),
+            ("monthly", "Monthly"),
+        ],
+    },
+]
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def ask_questions_interactive() -> Dict[str, str]:
+    answers: Dict[str, str] = {}
+    print("\nKraken Money Mode Router\n")
+    for question in QUESTION_SET:
+        print(question["prompt"])
+        for idx, (_, label) in enumerate(question["options"], start=1):
+            print(f"  {idx}. {label}")
+
+        while True:
+            raw = input("Select option number: ").strip()
+            if not raw:
+                print("Please choose a number.")
+                continue
+
+            if not raw.isdigit():
+                print("Numbers only.")
+                continue
+
+            selection = int(raw)
+            if 1 <= selection <= len(question["options"]):
+                value = question["options"][selection - 1][0]
+                answers[question["key"]] = value
+                print()
+                break
+
+            print("Selection out of range.")
+
+    return answers
+
+
+def load_answers_file(path: str) -> Dict[str, str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+
+    if not isinstance(raw, dict):
+        raise ValueError("answers file must contain a JSON object")
+
+    answers = {str(k): str(v) for k, v in raw.items()}
+    return answers
+
+
+def validate_answers(answers: Dict[str, str]) -> None:
+    valid_by_key = {q["key"]: {value for value, _ in q["options"]} for q in QUESTION_SET}
+
+    missing = [key for key in valid_by_key if key not in answers]
+    if missing:
+        raise ValueError(f"Missing answers for: {', '.join(missing)}")
+
+    invalid = []
+    for key, value in answers.items():
+        if key in valid_by_key and value not in valid_by_key[key]:
+            invalid.append((key, value))
+
+    if invalid:
+        rendered = ", ".join([f"{key}={value}" for key, value in invalid])
+        raise ValueError(f"Invalid answer values: {rendered}")
+
+
+def format_report(
+    session_id: str,
+    recommendations: List[Dict[str, Any]],
+    actions: List[str],
+    mode_coverage: Dict[str, Any],
+) -> str:
+    primary = recommendations[0]
+    backup = recommendations[1] if len(recommendations) > 1 else None
+
+    positive_scores = sum(max(r["score"], 0.0) for r in recommendations)
+    confidence = (primary["score"] / positive_scores) if positive_scores else 0.0
+
+    lines = []
+    lines.append("============================================================")
+    lines.append("KRAKEN MONEY MODE ROUTER")
+    lines.append("============================================================")
+    lines.append("")
+    lines.append(f"Session ID:   {session_id}")
+    lines.append(f"Primary:      {primary['label']} ({primary['mode_id']})")
+    lines.append(f"Backup:       {backup['label']} ({backup['mode_id']})" if backup else "Backup:       n/a")
+    lines.append(f"Confidence:   {confidence:.1%}")
+    lines.append("")
+    lines.append("Why this mode:")
+    if primary["reasons"]:
+        for reason in primary["reasons"]:
+            lines.append(f"  - {reason}")
+    else:
+        lines.append("  - Default mode selection (no scoring signal).")
+
+    lines.append("")
+    lines.append("Action plan:")
+    for index, step in enumerate(actions, start=1):
+        lines.append(f"  {index}. {step}")
+
+    lines.append("")
+    lines.append("API-backed mode coverage:")
+    lines.append(
+        f"  Publishers:  {', '.join(mode_coverage['available_publishers']) or 'none'}"
+    )
+    lines.append(
+        "  Enabled:     "
+        + (", ".join(mode_coverage["supported_modes"]) or "none")
+    )
+    lines.append("")
+    lines.append("Primary mode API endpoints:")
+    primary_endpoints = mode_coverage.get("supported_mode_endpoints", {}).get(primary["mode_id"], [])
+    if primary_endpoints:
+        for endpoint in primary_endpoints:
+            method = endpoint.get("method", "GET")
+            path = endpoint.get("path", "/")
+            publisher = endpoint.get("publisher", "unknown")
+            lines.append(f"  - {publisher} {method} {path}")
+    else:
+        lines.append("  - No endpoint catalog configured for this mode.")
+    lines.append("")
+    lines.append("============================================================")
+
+    return "\n".join(lines)
+
+
+def run_init_db(args: argparse.Namespace) -> int:
+    load_dotenv()
+    connection_string = os.getenv("SERENDB_CONNECTION_STRING")
+    if not connection_string:
+        print("SERENDB_CONNECTION_STRING is required", file=sys.stderr)
+        return 1
+
+    store = SerenDBStore(connection_string)
+    store.ensure_schema()
+    print("SerenDB schema initialized.")
+    return 0
+
+
+def run_recommend(args: argparse.Namespace) -> int:
+    load_dotenv()
+
+    connection_string = os.getenv("SERENDB_CONNECTION_STRING")
+    if not connection_string:
+        print("SERENDB_CONNECTION_STRING is required", file=sys.stderr)
+        return 1
+
+    config_path = args.config
+    if not Path(config_path).exists():
+        print(f"Config not found: {config_path}", file=sys.stderr)
+        return 1
+
+    config = load_config(config_path)
+
+    if args.answers_file and args.interactive:
+        print("Use either --answers-file or --interactive, not both.", file=sys.stderr)
+        return 1
+
+    if not args.answers_file and not args.interactive:
+        print("Use --interactive or provide --answers-file.", file=sys.stderr)
+        return 1
+
+    if args.answers_file:
+        answers = load_answers_file(args.answers_file)
+    else:
+        answers = ask_questions_interactive()
+
+    validate_answers(answers)
+
+    session_id = str(uuid.uuid4())
+    profile_name = args.profile_name
+
+    store = SerenDBStore(connection_string)
+    store.ensure_schema()
+    store.create_session(session_id, profile_name)
+    store.save_answers(session_id, answers)
+
+    account_snapshot: Dict[str, Any] = {}
+    api_key = os.getenv("SEREN_API_KEY")
+
+    if api_key:
+        kraken = KrakenClient(
+            api_key=api_key,
+            base_url=os.getenv("SEREN_GATEWAY_BASE_URL", "https://api.serendb.com"),
+            publisher=os.getenv("KRAKEN_SPOT_PUBLISHER", "kraken-spot-trading"),
+        )
+        account_snapshot = kraken.get_account_snapshot()
+        store.save_event(session_id, "account_snapshot", account_snapshot)
+    else:
+        store.save_event(session_id, "account_snapshot", {"skipped": "SEREN_API_KEY not set"})
+
+    engine = ModeEngine(config)
+    ranked, mode_coverage = engine.recommend(answers)
+
+    recommendations = [asdict(item) for item in ranked]
+    store.save_recommendations(session_id, recommendations)
+
+    primary_mode = recommendations[0]["mode_id"]
+    action_plan = engine.build_action_plan(primary_mode)
+    store.save_actions(session_id, primary_mode, action_plan)
+
+    store.save_event(session_id, "mode_coverage", mode_coverage)
+    store.save_event(
+        session_id,
+        "final_result",
+        {
+            "primary_mode": primary_mode,
+            "backup_mode": recommendations[1]["mode_id"] if len(recommendations) > 1 else None,
+            "answers": answers,
+        },
+    )
+
+    report = format_report(
+        session_id=session_id,
+        recommendations=recommendations,
+        actions=action_plan,
+        mode_coverage=mode_coverage,
+    )
+    print(report)
+
+    if args.json:
+        result_payload = {
+            "session_id": session_id,
+            "answers": answers,
+            "account_snapshot": account_snapshot,
+            "recommendations": recommendations,
+            "action_plan": action_plan,
+            "mode_coverage": mode_coverage,
+        }
+        print(json.dumps(result_payload, indent=2))
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Kraken Money Mode Router")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_db = subparsers.add_parser("init-db", help="Create SerenDB tables")
+    init_db.set_defaults(func=run_init_db)
+
+    recommend = subparsers.add_parser("recommend", help="Run mode recommendation")
+    recommend.add_argument("--config", required=True, help="Path to config JSON")
+    recommend.add_argument("--answers-file", help="Path to answers JSON")
+    recommend.add_argument("--interactive", action="store_true", help="Use interactive prompt")
+    recommend.add_argument("--profile-name", default="default", help="Profile label stored in SerenDB")
+    recommend.add_argument("--json", action="store_true", help="Print JSON payload")
+    recommend.set_defaults(func=run_recommend)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kraken/money-mode-router/scripts/kraken_client.py
+++ b/kraken/money-mode-router/scripts/kraken_client.py
@@ -1,0 +1,94 @@
+"""Kraken publisher wrapper for Money Mode Router context collection."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class KrakenClient:
+    """Reads account and market context from Kraken via Seren Gateway."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.serendb.com",
+        publisher: str = "kraken-spot-trading",
+    ):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.publisher = publisher
+
+    def _call(
+        self,
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}/publishers/{self.publisher}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            json=body,
+            params=params,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        payload = response.json()
+        if isinstance(payload, dict) and "body" in payload:
+            return payload["body"]
+        return payload
+
+    def get_balance(self) -> Dict[str, Any]:
+        return self._call(method="POST", path="/private/Balance", body={})
+
+    def get_open_orders(self) -> Dict[str, Any]:
+        return self._call(method="POST", path="/private/OpenOrders", body={})
+
+    def get_ticker(self, pair: str = "XBTUSD") -> Dict[str, Any]:
+        return self._call(method="GET", path="/public/Ticker", params={"pair": pair})
+
+    def get_account_snapshot(self) -> Dict[str, Any]:
+        """Best-effort account snapshot used as recommendation context."""
+        snapshot: Dict[str, Any] = {
+            "balances": {},
+            "open_order_count": 0,
+            "market_hint": {},
+            "errors": [],
+        }
+
+        try:
+            balances = self.get_balance()
+            snapshot["balances"] = balances.get("result", balances)
+        except Exception as exc:  # noqa: BLE001
+            snapshot["errors"].append(f"balance_error: {exc}")
+
+        try:
+            open_orders = self.get_open_orders()
+            open_orders_result = open_orders.get("result", {}).get("open", {})
+            snapshot["open_order_count"] = len(open_orders_result)
+        except Exception as exc:  # noqa: BLE001
+            snapshot["errors"].append(f"open_orders_error: {exc}")
+
+        try:
+            ticker = self.get_ticker("XBTUSD")
+            ticker_result = ticker.get("result", {})
+            if ticker_result:
+                first_key = list(ticker_result.keys())[0]
+                snapshot["market_hint"] = {
+                    "pair": first_key,
+                    "last_trade": ticker_result[first_key].get("c", [None])[0],
+                }
+        except Exception as exc:  # noqa: BLE001
+            snapshot["errors"].append(f"ticker_error: {exc}")
+
+        return snapshot

--- a/kraken/money-mode-router/scripts/mode_engine.py
+++ b/kraken/money-mode-router/scripts/mode_engine.py
@@ -1,0 +1,157 @@
+"""Mode scoring engine for Kraken Money Mode Router."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+
+MODE_COPY: Dict[str, Dict[str, Any]] = {
+    "payments": {
+        "label": "Krak Payments",
+        "summary": "Use Kraken for everyday money movement and fast transfers.",
+        "actions": [
+            "Open Krak and complete profile setup.",
+            "Add primary funding method and test a small transfer.",
+            "Set your default send path for repeat payments.",
+            "Enable alerts for inbound and outbound transfers."
+        ]
+    },
+    "investing": {
+        "label": "Multi-Asset Investing",
+        "summary": "Build a diversified portfolio across available Kraken asset classes.",
+        "actions": [
+            "Define your target allocation and rebalance cadence.",
+            "Fund your base portfolio positions in your core assets.",
+            "Set recurring buys for long-term compounding.",
+            "Track drift and rebalance on schedule."
+        ]
+    },
+    "active-trading": {
+        "label": "Active Trading",
+        "summary": "Execute directional or tactical trades with high control.",
+        "actions": [
+            "Select a tight watchlist and define setup criteria.",
+            "Set order templates with entry, stop, and take-profit levels.",
+            "Run one session with strict sizing and journal every trade.",
+            "Review execution quality after each session."
+        ]
+    },
+    "onchain": {
+        "label": "On-Chain Operations",
+        "summary": "Use Kraken funding and wallet APIs to move assets on-chain.",
+        "actions": [
+            "Select asset/network using DepositMethods and WithdrawMethods.",
+            "Create or verify destination details with DepositAddresses or WithdrawInfo.",
+            "Submit a controlled transfer using Withdraw and track status until settlement.",
+            "Use WalletTransfer for internal account routing when available."
+        ]
+    },
+    "automation": {
+        "label": "Automation",
+        "summary": "Automate recurring execution so your strategy runs consistently.",
+        "actions": [
+            "Choose one repeatable strategy to automate first.",
+            "Define entry/exit logic, sizing rules, and cooldown intervals.",
+            "Run a dry-run cycle and confirm expected order behavior.",
+            "Deploy with monitoring and weekly parameter review."
+        ]
+    }
+}
+
+
+@dataclass
+class Recommendation:
+    mode_id: str
+    score: float
+    label: str
+    summary: str
+    reasons: List[str]
+
+
+class ModeEngine:
+    """Scores user intent against Kraken product modes."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self.mode_order: List[str] = config.get("mode_order", list(MODE_COPY.keys()))
+        self.weights: Dict[str, Dict[str, Dict[str, float]]] = config.get("score_weights", {})
+        self.publisher_requirements: Dict[str, List[str]] = config.get("publisher_requirements", {})
+        self.mode_endpoint_catalog: Dict[str, List[Dict[str, str]]] = config.get("mode_endpoint_catalog", {})
+
+    def recommend(self, answers: Dict[str, str]) -> Tuple[List[Recommendation], Dict[str, Any]]:
+        available_publishers = set(self.config.get("available_publishers", []))
+        supported_modes, hidden_modes = self._resolve_mode_support(available_publishers)
+
+        modes_to_score = supported_modes if supported_modes else list(self.mode_order)
+        scores = {mode_id: 0.0 for mode_id in modes_to_score}
+        reasons_by_mode: Dict[str, List[str]] = {mode_id: [] for mode_id in self.mode_order}
+
+        for dimension, answer_value in answers.items():
+            mappings = self.weights.get(dimension, {})
+            mode_boosts = mappings.get(answer_value, {})
+            for mode_id, boost in mode_boosts.items():
+                if mode_id not in scores:
+                    continue
+                scores[mode_id] += float(boost)
+                reasons_by_mode[mode_id].append(
+                    f"{dimension}={answer_value} (+{boost:g})"
+                )
+
+        ranked = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        recommendations: List[Recommendation] = []
+        for mode_id, score in ranked:
+            mode_copy = MODE_COPY.get(mode_id, {})
+            recommendations.append(
+                Recommendation(
+                    mode_id=mode_id,
+                    score=score,
+                    label=mode_copy.get("label", mode_id),
+                    summary=mode_copy.get("summary", ""),
+                    reasons=reasons_by_mode.get(mode_id, [])[:4],
+                )
+            )
+
+        gap_report = self._build_gap_report(
+            available_publishers=available_publishers,
+            supported_modes=modes_to_score,
+            hidden_modes=hidden_modes,
+        )
+        return recommendations, gap_report
+
+    def build_action_plan(self, mode_id: str) -> List[str]:
+        return MODE_COPY.get(mode_id, {}).get("actions", [])
+
+    def _build_gap_report(
+        self,
+        available_publishers: set[str],
+        supported_modes: List[str],
+        hidden_modes: Dict[str, List[str]],
+    ) -> Dict[str, Any]:
+        return {
+            "available_publishers": sorted(available_publishers),
+            "supported_modes": supported_modes,
+            "hidden_modes": hidden_modes,
+            "publisher_requirements": self.publisher_requirements,
+            "supported_mode_endpoints": {
+                mode_id: self.mode_endpoint_catalog.get(mode_id, [])
+                for mode_id in supported_modes
+            },
+        }
+
+    def _resolve_mode_support(
+        self,
+        available_publishers: set[str],
+    ) -> Tuple[List[str], Dict[str, List[str]]]:
+        supported: List[str] = []
+        hidden: Dict[str, List[str]] = {}
+
+        for mode_id in self.mode_order:
+            required = self.publisher_requirements.get(mode_id, [])
+            missing = [slug for slug in required if slug not in available_publishers]
+            if missing:
+                hidden[mode_id] = missing
+            else:
+                supported.append(mode_id)
+
+        return supported, hidden

--- a/kraken/money-mode-router/scripts/serendb_store.py
+++ b/kraken/money-mode-router/scripts/serendb_store.py
@@ -1,0 +1,142 @@
+"""SerenDB persistence for Kraken Money Mode Router."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import psycopg
+
+
+class SerenDBStore:
+    """Stores router sessions, answers, recommendations, and events in SerenDB."""
+
+    def __init__(self, connection_string: str):
+        self.connection_string = connection_string
+
+    def _connect(self):
+        return psycopg.connect(self.connection_string)
+
+    def ensure_schema(self) -> None:
+        ddl = """
+        CREATE TABLE IF NOT EXISTS kraken_skill_sessions (
+            session_id UUID PRIMARY KEY,
+            profile_name TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+
+        CREATE TABLE IF NOT EXISTS kraken_skill_answers (
+            id BIGSERIAL PRIMARY KEY,
+            session_id UUID NOT NULL REFERENCES kraken_skill_sessions(session_id) ON DELETE CASCADE,
+            question_key TEXT NOT NULL,
+            answer_value TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+
+        CREATE TABLE IF NOT EXISTS kraken_skill_recommendations (
+            id BIGSERIAL PRIMARY KEY,
+            session_id UUID NOT NULL REFERENCES kraken_skill_sessions(session_id) ON DELETE CASCADE,
+            rank_index INTEGER NOT NULL,
+            mode_id TEXT NOT NULL,
+            score NUMERIC NOT NULL,
+            label TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            reasons JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+
+        CREATE TABLE IF NOT EXISTS kraken_skill_actions (
+            id BIGSERIAL PRIMARY KEY,
+            session_id UUID NOT NULL REFERENCES kraken_skill_sessions(session_id) ON DELETE CASCADE,
+            mode_id TEXT NOT NULL,
+            step_index INTEGER NOT NULL,
+            action_text TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+
+        CREATE TABLE IF NOT EXISTS kraken_skill_events (
+            id BIGSERIAL PRIMARY KEY,
+            session_id UUID NOT NULL REFERENCES kraken_skill_sessions(session_id) ON DELETE CASCADE,
+            event_type TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(ddl)
+            conn.commit()
+
+    def create_session(self, session_id: str, profile_name: str) -> None:
+        query = """
+        INSERT INTO kraken_skill_sessions (session_id, profile_name)
+        VALUES (%s::uuid, %s);
+        """
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (session_id, profile_name))
+            conn.commit()
+
+    def save_answers(self, session_id: str, answers: Dict[str, str]) -> None:
+        query = """
+        INSERT INTO kraken_skill_answers (session_id, question_key, answer_value)
+        VALUES (%s::uuid, %s, %s);
+        """
+        rows = [(session_id, key, value) for key, value in answers.items()]
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.executemany(query, rows)
+            conn.commit()
+
+    def save_recommendations(self, session_id: str, recommendations: List[Dict[str, Any]]) -> None:
+        query = """
+        INSERT INTO kraken_skill_recommendations (
+            session_id,
+            rank_index,
+            mode_id,
+            score,
+            label,
+            summary,
+            reasons
+        )
+        VALUES (%s::uuid, %s, %s, %s, %s, %s, %s::jsonb);
+        """
+        rows = []
+        for idx, rec in enumerate(recommendations, start=1):
+            rows.append(
+                (
+                    session_id,
+                    idx,
+                    rec["mode_id"],
+                    rec["score"],
+                    rec["label"],
+                    rec["summary"],
+                    json.dumps(rec["reasons"]),
+                )
+            )
+
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.executemany(query, rows)
+            conn.commit()
+
+    def save_actions(self, session_id: str, mode_id: str, actions: List[str]) -> None:
+        query = """
+        INSERT INTO kraken_skill_actions (session_id, mode_id, step_index, action_text)
+        VALUES (%s::uuid, %s, %s, %s);
+        """
+        rows = [(session_id, mode_id, idx, text) for idx, text in enumerate(actions, start=1)]
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.executemany(query, rows)
+            conn.commit()
+
+    def save_event(self, session_id: str, event_type: str, payload: Dict[str, Any]) -> None:
+        query = """
+        INSERT INTO kraken_skill_events (session_id, event_type, payload)
+        VALUES (%s::uuid, %s, %s::jsonb);
+        """
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (session_id, event_type, json.dumps(payload)))
+            conn.commit()


### PR DESCRIPTION
## Summary
- add new `kraken/money-mode-router` skill to route users into Kraken product modes
- persist sessions, answers, recommendations, actions, and events in SerenDB
- map `onchain` mode to existing `kraken-spot-trading` funding endpoints for immediate support
- include API-backed mode filtering and primary-mode endpoint catalog in output
- add `kraken-ramp` support for payments mode

## Included
- interactive and file-based recommendation flow
- config-driven score weights and mode endpoint catalog
- Kraken account context snapshot via `kraken-spot-trading`
- README skill index update

## Validation
- `python3 -m py_compile kraken/money-mode-router/scripts/agent.py kraken/money-mode-router/scripts/mode_engine.py kraken/money-mode-router/scripts/kraken_client.py kraken/money-mode-router/scripts/serendb_store.py`
