### PR TITLE
feat: add spectra PT yield trader skill with mcp-spectra and seren-cron flow

### DIFF
--- a/spectra/spectra-pt-yield-trader/.env.example
+++ b/spectra/spectra-pt-yield-trader/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for spectra-pt-yield-trader
+SEREN_API_KEY=
+

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: spectra-pt-yield-trader
+description: "Plan and evaluate Spectra PT yield trades using the Spectra MCP server across 10 chains. Use when you need fixed-yield opportunity scans, PT quoting, portfolio simulation, and risk-gated execution handoff."
+---
+
+# Spectra Pt Yield Trader
+
+## Workflow Summary
+
+1. `validate_inputs` validates chain, size, slippage, and safety caps.
+2. `scan_opportunities` uses `mcp-spectra.scan_opportunities` for capital-aware ranking.
+3. `select_candidate` filters by symbol, liquidity, maturity window, and impact constraints.
+4. `quote_trade` uses `mcp-spectra.quote_trade` for executable PT pricing and min-out.
+5. `simulate_portfolio` uses `mcp-spectra.simulate_portfolio_after_trade` to preview deltas.
+6. `looping_check` optionally uses `mcp-spectra.get_looping_strategy` for PT+Morpho leverage context.
+7. `risk_guard` enforces notional/slippage limits and blocks unsafe requests.
+8. `execution_handoff` emits a structured execution intent for a separate signer/executor.
+
+## Key Constraint
+
+The Spectra MCP server is read-only. This skill does not sign or broadcast on-chain transactions.
+`live_mode` only controls whether the skill emits an execution handoff payload after passing risk gates.
+
+## Safety Rules
+
+- Default mode is dry-run (`live_mode=false`).
+- Handoff requires both:
+  - `inputs.live_mode=true`
+  - `execution.confirm_live_handoff=true` in config
+- Risk caps are enforced before handoff:
+  - `policies.max_notional_usd`
+  - `policies.max_slippage_bps`
+- If any guard fails, return a policy block instead of an execution intent.
+
+## Tooling
+
+- Primary connector: `mcp-spectra` publisher backed by the Spectra MCP server (`npx spectra-mcp-server`).
+- Optional scheduling connector: `seren-cron` for periodic scans.
+- Tool reference: `references/spectra-mcp-tools.md`.
+
+## Quick Start
+
+1. Copy `config.example.json` to `config.json`.
+2. Run dry-run planning:
+   - `python scripts/agent.py --config config.json`
+3. Enable execution handoff only after review:
+   - set `inputs.live_mode=true`
+   - set `execution.confirm_live_handoff=true`
+   - run `python scripts/agent.py --config config.json`
+
+## Autonomous Scheduling with seren-cron
+
+1. Start trigger server:
+   - `python scripts/run_agent_server.py --config config.json --port 8080`
+2. Create cron job:
+   - `python scripts/setup_cron.py create --url http://localhost:8080/run --schedule "*/30 * * * *"`
+3. Manage jobs:
+   - `python scripts/setup_cron.py list`
+   - `python scripts/setup_cron.py pause --job-id <job_id>`
+   - `python scripts/setup_cron.py resume --job-id <job_id>`
+   - `python scripts/setup_cron.py delete --job-id <job_id>`
+
+Each scheduled run executes one full planning cycle:
+- scan opportunities
+- quote candidate PT trade
+- simulate post-trade portfolio
+- emit execution handoff only when enabled by config guards

--- a/spectra/spectra-pt-yield-trader/config.example.json
+++ b/spectra/spectra-pt-yield-trader/config.example.json
@@ -1,0 +1,36 @@
+{
+  "connectors": [
+    "mcp_spectra",
+    "seren_cron"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "capital_usd": 100,
+    "chain": "base",
+    "include_looping": false,
+    "live_mode": false,
+    "max_price_impact_pct": 2,
+    "min_liquidity_usd": 50000,
+    "pt_address": "",
+    "side": "buy",
+    "target_maturity_days_max": 365,
+    "target_maturity_days_min": 7,
+    "top_n": 5,
+    "underlying_symbol": "USDC",
+    "ve_spectra_balance": 0,
+    "wallet_address": "",
+    "wallet_mode": "delegated"
+  },
+  "execution": {
+    "confirm_live_handoff": false,
+    "executor": {
+      "name": "",
+      "type": "manual"
+    }
+  },
+  "policies": {
+    "max_notional_usd": 1000,
+    "max_slippage_bps": 200
+  },
+  "skill": "spectra-pt-yield-trader"
+}

--- a/spectra/spectra-pt-yield-trader/references/spectra-mcp-tools.md
+++ b/spectra/spectra-pt-yield-trader/references/spectra-mcp-tools.md
@@ -1,0 +1,20 @@
+# Spectra MCP Tools Used By This Skill
+
+This skill assumes the `mcp-spectra` publisher for the Spectra MCP server from:
+`https://github.com/Finanzgoblin/spectra-mcp-server`
+
+Core tools used:
+- `scan_opportunities`: capital-aware PT ranking by chain and size
+- `quote_trade`: PT trade quote with impact/slippage context
+- `simulate_portfolio_after_trade`: before/after portfolio deltas
+- `get_looping_strategy` (optional): PT + Morpho looping context
+
+Utility tools commonly paired during analysis:
+- `get_supported_chains`
+- `get_pt_details`
+- `compare_yield`
+- `get_morpho_markets`
+
+Constraint:
+- Spectra MCP is read-only. It does not sign or broadcast transactions.
+- Execution must be handled by an external signer/executor.

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""SkillForge runtime for Spectra PT yield planning and execution handoff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_DRY_RUN = True
+SUPPORTED_CHAINS = {
+    "ethereum",
+    "base",
+    "arbitrum",
+    "optimism",
+    "avalanche",
+    "bsc",
+    "sonic",
+    "flare",
+    "katana",
+    "monad",
+}
+
+
+class ConfigError(Exception):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Spectra PT yield planner runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        raise ConfigError(f"Config file not found: {config_path}")
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid config JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ConfigError("Config root must be a JSON object.")
+    return parsed
+
+
+def _as_number(raw: object, *, field: str) -> float:
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    raise ConfigError(f"{field} must be numeric.")
+
+
+def _as_int(raw: object, *, field: str) -> int:
+    if isinstance(raw, bool):
+        raise ConfigError(f"{field} must be an integer.")
+    if isinstance(raw, int):
+        return raw
+    raise ConfigError(f"{field} must be an integer.")
+
+
+def _resolve_inputs(config: dict) -> dict:
+    inputs = config.get("inputs", {})
+    if not isinstance(inputs, dict):
+        raise ConfigError("inputs must be an object.")
+
+    chain = str(inputs.get("chain", "base")).lower()
+    if chain not in SUPPORTED_CHAINS:
+        raise ConfigError(f"Unsupported chain '{chain}'.")
+
+    wallet_mode = str(inputs.get("wallet_mode", "delegated")).lower()
+    if wallet_mode != "delegated":
+        raise ConfigError("wallet_mode must be 'delegated'.")
+
+    side = str(inputs.get("side", "buy")).lower()
+    if side not in {"buy", "sell"}:
+        raise ConfigError("side must be 'buy' or 'sell'.")
+
+    capital_usd = _as_number(inputs.get("capital_usd", 100), field="inputs.capital_usd")
+    if capital_usd <= 0:
+        raise ConfigError("inputs.capital_usd must be > 0.")
+
+    top_n = _as_int(inputs.get("top_n", 5), field="inputs.top_n")
+    if top_n < 1 or top_n > 20:
+        raise ConfigError("inputs.top_n must be in [1, 20].")
+
+    min_liquidity_usd = _as_number(
+        inputs.get("min_liquidity_usd", 50_000),
+        field="inputs.min_liquidity_usd",
+    )
+    if min_liquidity_usd < 0:
+        raise ConfigError("inputs.min_liquidity_usd must be >= 0.")
+
+    max_price_impact_pct = _as_number(
+        inputs.get("max_price_impact_pct", 2),
+        field="inputs.max_price_impact_pct",
+    )
+    if max_price_impact_pct < 0 or max_price_impact_pct > 10:
+        raise ConfigError("inputs.max_price_impact_pct must be in [0, 10].")
+
+    maturity_min = _as_int(
+        inputs.get("target_maturity_days_min", 7),
+        field="inputs.target_maturity_days_min",
+    )
+    maturity_max = _as_int(
+        inputs.get("target_maturity_days_max", 365),
+        field="inputs.target_maturity_days_max",
+    )
+    if maturity_min < 0:
+        raise ConfigError("inputs.target_maturity_days_min must be >= 0.")
+    if maturity_max < 1:
+        raise ConfigError("inputs.target_maturity_days_max must be >= 1.")
+    if maturity_min > maturity_max:
+        raise ConfigError("inputs target maturity min cannot exceed max.")
+
+    include_looping = bool(inputs.get("include_looping", False))
+    live_mode = bool(inputs.get("live_mode", False))
+
+    return {
+        "chain": chain,
+        "wallet_mode": wallet_mode,
+        "side": side,
+        "capital_usd": capital_usd,
+        "top_n": top_n,
+        "underlying_symbol": str(inputs.get("underlying_symbol", "USDC")).upper(),
+        "min_liquidity_usd": min_liquidity_usd,
+        "max_price_impact_pct": max_price_impact_pct,
+        "target_maturity_days_min": maturity_min,
+        "target_maturity_days_max": maturity_max,
+        "pt_address": str(inputs.get("pt_address", "")).strip(),
+        "wallet_address": str(inputs.get("wallet_address", "")).strip(),
+        "ve_spectra_balance": _as_number(
+            inputs.get("ve_spectra_balance", 0),
+            field="inputs.ve_spectra_balance",
+        ),
+        "include_looping": include_looping,
+        "live_mode": live_mode,
+    }
+
+
+def _resolve_policies(config: dict) -> dict:
+    policies = config.get("policies", {})
+    if not isinstance(policies, dict):
+        raise ConfigError("policies must be an object.")
+
+    max_notional_usd = _as_number(
+        policies.get("max_notional_usd", 1_000),
+        field="policies.max_notional_usd",
+    )
+    max_slippage_bps = _as_int(
+        policies.get("max_slippage_bps", 200),
+        field="policies.max_slippage_bps",
+    )
+
+    if max_notional_usd <= 0:
+        raise ConfigError("policies.max_notional_usd must be > 0.")
+    if max_slippage_bps < 1:
+        raise ConfigError("policies.max_slippage_bps must be >= 1.")
+
+    return {
+        "max_notional_usd": max_notional_usd,
+        "max_slippage_bps": max_slippage_bps,
+    }
+
+
+def _resolve_execution(config: dict) -> dict:
+    execution = config.get("execution", {})
+    if not isinstance(execution, dict):
+        raise ConfigError("execution must be an object.")
+
+    executor = execution.get("executor", {})
+    if executor is None:
+        executor = {}
+    if not isinstance(executor, dict):
+        raise ConfigError("execution.executor must be an object.")
+
+    executor_type = str(executor.get("type", "manual")).strip().lower()
+    if not executor_type:
+        executor_type = "manual"
+
+    return {
+        "confirm_live_handoff": bool(execution.get("confirm_live_handoff", False)),
+        "executor": {
+            "name": str(executor.get("name", "")).strip(),
+            "type": executor_type,
+        },
+    }
+
+
+def _build_mcp_plan(inputs: dict) -> list[dict]:
+    plan = [
+        {
+            "step": "scan_opportunities",
+            "tool": "scan_opportunities",
+            "args": {
+                "chain": inputs["chain"],
+                "underlying_symbol": inputs["underlying_symbol"],
+                "capital_usd": inputs["capital_usd"],
+                "top_n": inputs["top_n"],
+                "min_liquidity_usd": inputs["min_liquidity_usd"],
+                "max_price_impact_pct": inputs["max_price_impact_pct"],
+                "ve_spectra_balance": inputs["ve_spectra_balance"],
+                "compact": True,
+            },
+        },
+        {
+            "step": "select_candidate",
+            "tool": "transform.select_top_pt_candidate",
+            "args": {
+                "underlying_symbol": inputs["underlying_symbol"],
+                "target_maturity_days_min": inputs["target_maturity_days_min"],
+                "target_maturity_days_max": inputs["target_maturity_days_max"],
+                "pt_address_override": inputs["pt_address"],
+            },
+        },
+        {
+            "step": "quote_trade",
+            "tool": "quote_trade",
+            "args": {
+                "chain": inputs["chain"],
+                "side": inputs["side"],
+                "capital_usd": inputs["capital_usd"],
+                "pt_address": inputs["pt_address"] or "<selected_pt_address>",
+            },
+        },
+        {
+            "step": "simulate_portfolio_after_trade",
+            "tool": "simulate_portfolio_after_trade",
+            "args": {
+                "chain": inputs["chain"],
+                "side": inputs["side"],
+                "capital_usd": inputs["capital_usd"],
+                "pt_address": inputs["pt_address"] or "<selected_pt_address>",
+                "wallet_address": inputs["wallet_address"] or "<required_for_personal_simulation>",
+            },
+        },
+    ]
+
+    if inputs["include_looping"]:
+        plan.append(
+            {
+                "step": "looping_context",
+                "tool": "get_looping_strategy",
+                "args": {
+                    "chain": inputs["chain"],
+                    "pt_address": inputs["pt_address"] or "<selected_pt_address>",
+                    "capital_usd": inputs["capital_usd"],
+                },
+            }
+        )
+
+    return plan
+
+
+def _guard_policy(inputs: dict, policies: dict) -> list[dict]:
+    violations = []
+    if inputs["capital_usd"] > policies["max_notional_usd"]:
+        violations.append(
+            {
+                "policy": "max_notional_usd",
+                "message": "Requested notional exceeds configured cap.",
+                "value": inputs["capital_usd"],
+                "limit": policies["max_notional_usd"],
+            }
+        )
+
+    requested_slippage_bps = int(round(inputs["max_price_impact_pct"] * 100))
+    if requested_slippage_bps > policies["max_slippage_bps"]:
+        violations.append(
+            {
+                "policy": "max_slippage_bps",
+                "message": "Requested price impact exceeds configured slippage cap.",
+                "value": requested_slippage_bps,
+                "limit": policies["max_slippage_bps"],
+            }
+        )
+
+    return violations
+
+
+def run_once(config: dict) -> dict:
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    inputs = _resolve_inputs(config)
+    policies = _resolve_policies(config)
+    execution = _resolve_execution(config)
+
+    violations = _guard_policy(inputs, policies)
+    if violations:
+        first = violations[0]
+        return {
+            "status": "error",
+            "skill": "spectra-pt-yield-trader",
+            "error_code": "policy_violation",
+            "policy": first["policy"],
+            "message": first["message"],
+            "violations": violations,
+        }
+
+    mcp_plan = _build_mcp_plan(inputs)
+
+    live_requested = bool(inputs["live_mode"] and not dry_run)
+    live_confirmed = bool(execution["confirm_live_handoff"])
+
+    if live_requested and not live_confirmed:
+        return {
+            "status": "ok",
+            "skill": "spectra-pt-yield-trader",
+            "dry_run": True,
+            "mode": "analysis-only",
+            "blocked_action": "execution_handoff",
+            "message": "Live handoff requested but execution.confirm_live_handoff is false.",
+            "workflow_step_count": len(mcp_plan),
+            "mcp_plan": mcp_plan,
+        }
+
+    execution_handoff = {
+        "enabled": live_requested and live_confirmed,
+        "executor": execution["executor"],
+        "warning": "Spectra MCP is read-only. Use external signer/executor for transaction submission.",
+    }
+
+    return {
+        "status": "ok",
+        "skill": "spectra-pt-yield-trader",
+        "dry_run": not execution_handoff["enabled"],
+        "mode": "analysis-only",
+        "workflow_step_count": len(mcp_plan),
+        "mcp_plan": mcp_plan,
+        "execution_handoff": execution_handoff,
+        "connectors": {
+            "mcp_spectra": "mcp-spectra",
+            "seren_cron": "seren-cron",
+        },
+        "inputs": inputs,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        config = load_config(args.config)
+        result = run_once(config=config)
+    except ConfigError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectra/spectra-pt-yield-trader/scripts/run_agent_server.py
+++ b/spectra/spectra-pt-yield-trader/scripts/run_agent_server.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""HTTP trigger server so seren-cron can run the Spectra planner on schedule."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import traceback
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from agent import ConfigError, load_config, run_once
+
+
+class SpectraAgentRequestHandler(BaseHTTPRequestHandler):
+    config_path = "config.json"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/health":
+            self.send_error(404, "Endpoint not found")
+            return
+
+        payload = {
+            "status": "ok",
+            "service": "spectra-pt-yield-trader",
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "config_path": self.config_path,
+        }
+        self._send_json(200, payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/run":
+            self.send_error(404, "Endpoint not found")
+            return
+
+        try:
+            config = load_config(self.config_path)
+            result = run_once(config=config)
+            self._send_json(200, result)
+        except ConfigError as exc:
+            self._send_json(400, {"status": "error", "error": str(exc)})
+        except Exception as exc:  # pragma: no cover - defensive surface
+            traceback.print_exc()
+            self._send_json(500, {"status": "error", "error": str(exc)})
+
+    def log_message(self, format: str, *args: object) -> None:
+        ts = datetime.now(tz=UTC).isoformat()
+        print(f"[{ts}] {format % args}")
+
+    def _send_json(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an HTTP trigger server for seren-cron scheduled execution."
+    )
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to config JSON (default: config.json).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Port for HTTP server (default: 8080).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    SpectraAgentRequestHandler.config_path = args.config
+
+    server = HTTPServer(("0.0.0.0", args.port), SpectraAgentRequestHandler)
+    print(f"Spectra planner server listening on port {args.port}")
+    print(f"Health:  http://localhost:{args.port}/health")
+    print(f"Trigger: http://localhost:{args.port}/run")
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectra/spectra-pt-yield-trader/scripts/setup_cron.py
+++ b/spectra/spectra-pt-yield-trader/scripts/setup_cron.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Create/manage seren-cron jobs for the Spectra PT Yield Trader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_API_BASE = "https://api.serendb.com"
+
+
+class PublisherError(Exception):
+    pass
+
+
+class SerenPublisherClient:
+    def __init__(self, api_key: str, base_url: str = DEFAULT_API_BASE):
+        self.api_key = api_key
+        normalized = base_url.rstrip("/")
+        for suffix in ("/v1/publishers", "/publishers"):
+            if normalized.endswith(suffix):
+                normalized = normalized[: -len(suffix)]
+        self.base_url = normalized.rstrip("/")
+
+    def _request(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized_path = path if path.startswith("/") else f"/{path}"
+        url = f"{self.base_url}{normalized_path}"
+        method_upper = method.upper()
+
+        data: bytes | None = None
+        if method_upper != "GET":
+            data = json.dumps(body or {}).encode("utf-8")
+
+        request = Request(
+            url=url,
+            data=data,
+            method=method_upper,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+
+        try:
+            with urlopen(request, timeout=30) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            raise PublisherError(f"HTTP {exc.code} on {normalized_path}: {details}") from exc
+        except URLError as exc:
+            raise PublisherError(f"Connection failed on {normalized_path}: {exc}") from exc
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise PublisherError(f"Invalid JSON from {normalized_path}: {raw[:200]}") from exc
+        if not isinstance(parsed, dict):
+            raise PublisherError(f"Response from {normalized_path} was not an object")
+        return parsed
+
+    def call(self, publisher: str, method: str, path: str, body: dict[str, Any]) -> dict[str, Any]:
+        cleaned_path = path.strip()
+        if cleaned_path in {"", "/"}:
+            normalized_path = ""
+        else:
+            normalized_path = cleaned_path if cleaned_path.startswith("/") else f"/{cleaned_path}"
+
+        try:
+            return self._request(
+                method=method,
+                path=f"/publishers/{publisher}{normalized_path}",
+                body=body,
+            )
+        except PublisherError as exc:
+            raise PublisherError(f"{publisher} {exc}") from exc
+
+
+def _build_client() -> SerenPublisherClient:
+    api_key = os.environ.get("SEREN_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError("SEREN_API_KEY is required in the environment.")
+    base_url = os.environ.get("SEREN_API_BASE_URL", DEFAULT_API_BASE)
+    return SerenPublisherClient(api_key=api_key, base_url=base_url)
+
+
+def create_job(
+    client: SerenPublisherClient,
+    *,
+    name: str,
+    schedule: str,
+    url: str,
+    method: str,
+) -> dict:
+    return client.call(
+        publisher="seren-cron",
+        method="POST",
+        path="/api/v1/jobs",
+        body={
+            "name": name,
+            "schedule": schedule,
+            "url": url,
+            "method": method,
+        },
+    )
+
+
+def list_jobs(client: SerenPublisherClient) -> dict:
+    return client.call(
+        publisher="seren-cron",
+        method="GET",
+        path="/api/v1/jobs",
+        body={},
+    )
+
+
+def pause_job(client: SerenPublisherClient, job_id: str) -> dict:
+    return client.call(
+        publisher="seren-cron",
+        method="POST",
+        path=f"/api/v1/jobs/{job_id}/pause",
+        body={},
+    )
+
+
+def resume_job(client: SerenPublisherClient, job_id: str) -> dict:
+    return client.call(
+        publisher="seren-cron",
+        method="POST",
+        path=f"/api/v1/jobs/{job_id}/resume",
+        body={},
+    )
+
+
+def delete_job(client: SerenPublisherClient, job_id: str) -> dict:
+    return client.call(
+        publisher="seren-cron",
+        method="DELETE",
+        path=f"/api/v1/jobs/{job_id}",
+        body={},
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Manage seren-cron jobs for spectra-pt-yield-trader."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="Create a cron job.")
+    create.add_argument("--url", required=True, help="Trigger URL, e.g. http://localhost:8080/run")
+    create.add_argument("--schedule", default="*/30 * * * *", help="Cron schedule expression.")
+    create.add_argument("--name", default="spectra-pt-yield-trader", help="Cron job name.")
+    create.add_argument("--method", default="POST", help="HTTP method (default: POST).")
+
+    sub.add_parser("list", help="List cron jobs.")
+
+    pause = sub.add_parser("pause", help="Pause a cron job.")
+    pause.add_argument("--job-id", required=True, help="Cron job id.")
+
+    resume = sub.add_parser("resume", help="Resume a paused cron job.")
+    resume.add_argument("--job-id", required=True, help="Cron job id.")
+
+    delete = sub.add_parser("delete", help="Delete a cron job.")
+    delete.add_argument("--job-id", required=True, help="Cron job id.")
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        client = _build_client()
+        if args.command == "create":
+            result = create_job(
+                client,
+                name=args.name,
+                schedule=args.schedule,
+                url=args.url,
+                method=args.method.upper(),
+            )
+        elif args.command == "list":
+            result = list_jobs(client)
+        elif args.command == "pause":
+            result = pause_job(client, args.job_id)
+        elif args.command == "resume":
+            result = resume_job(client, args.job_id)
+        elif args.command == "delete":
+            result = delete_job(client, args.job_id)
+        else:  # pragma: no cover - argparse guards this
+            raise RuntimeError(f"Unknown command: {args.command}")
+    except (RuntimeError, PublisherError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectra/spectra-pt-yield-trader/skill.spec.yaml
+++ b/spectra/spectra-pt-yield-trader/skill.spec.yaml
@@ -1,0 +1,168 @@
+skill: spectra-pt-yield-trader
+description: Plan and evaluate Spectra PT yield trades using the Spectra MCP server across 10 chains. Read-only analytics with risk-gated execution handoff.
+triggers:
+  - find the best fixed yield opportunities on spectra
+  - paper trade spectra principal tokens
+  - quote and simulate spectra pt trades before execution
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  chain:
+    type: string
+    enum:
+      - ethereum
+      - base
+      - arbitrum
+      - optimism
+      - avalanche
+      - bsc
+      - sonic
+      - flare
+      - katana
+      - monad
+    default: base
+  wallet_mode:
+    type: string
+    enum:
+      - delegated
+    default: delegated
+  live_mode:
+    type: boolean
+    default: false
+  side:
+    type: string
+    enum:
+      - buy
+      - sell
+    default: buy
+  underlying_symbol:
+    type: string
+    default: USDC
+  capital_usd:
+    type: number
+    min: 1
+    default: 100
+  top_n:
+    type: integer
+    min: 1
+    max: 20
+    default: 5
+  min_liquidity_usd:
+    type: number
+    min: 0
+    default: 50000
+  max_price_impact_pct:
+    type: number
+    min: 0
+    max: 10
+    default: 2
+  include_looping:
+    type: boolean
+    default: false
+  target_maturity_days_min:
+    type: integer
+    min: 0
+    default: 7
+  target_maturity_days_max:
+    type: integer
+    min: 1
+    default: 365
+  pt_address:
+    type: string
+    default: ""
+  wallet_address:
+    type: string
+    default: ""
+  ve_spectra_balance:
+    type: number
+    min: 0
+    default: 0
+secrets:
+  - SEREN_API_KEY
+connectors:
+  mcp_spectra:
+    kind: seren_publisher
+    publisher: mcp-spectra
+  seren_cron:
+    kind: seren_publisher
+    publisher: seren-cron
+state:
+  trades:
+    kind: sqlite
+    file: state/trades.db
+policies:
+  dry_run_default: true
+  idempotency_required: true
+  max_daily_spend_usd: 250
+  max_notional_usd: 1000
+  max_slippage_bps: 200
+workflow:
+  steps:
+    - id: validate_inputs
+      use: transform.validate_trade_inputs
+      with:
+        chain: "{chain}"
+        capital_usd: "{capital_usd}"
+        max_price_impact_pct: "{max_price_impact_pct}"
+    - id: scan_opportunities
+      use: connector.mcp_spectra.call
+      with:
+        tool: scan_opportunities
+        chain: "{chain}"
+        capital_usd: "{capital_usd}"
+        underlying_symbol: "{underlying_symbol}"
+        max_price_impact_pct: "{max_price_impact_pct}"
+        min_liquidity_usd: "{min_liquidity_usd}"
+        top_n: "{top_n}"
+        ve_spectra_balance: "{ve_spectra_balance}"
+    - id: select_candidate
+      use: transform.select_top_pt_candidate
+      with:
+        from_step: scan_opportunities
+        underlying_symbol: "{underlying_symbol}"
+        target_maturity_days_min: "{target_maturity_days_min}"
+        target_maturity_days_max: "{target_maturity_days_max}"
+        pt_address: "{pt_address}"
+    - id: quote_trade
+      use: connector.mcp_spectra.call
+      with:
+        tool: quote_trade
+        from_step: select_candidate
+        side: "{side}"
+        capital_usd: "{capital_usd}"
+    - id: simulate_portfolio
+      use: connector.mcp_spectra.call
+      with:
+        tool: simulate_portfolio_after_trade
+        from_step: quote_trade
+        wallet_address: "{wallet_address}"
+    - id: optional_looping_check
+      use: connector.mcp_spectra.call
+      with:
+        tool: get_looping_strategy
+        from_step: select_candidate
+        enabled: "{include_looping}"
+    - id: risk_guard
+      use: transform.guard_execution_handoff
+      with:
+        from_step: quote_trade
+        live_mode: "{live_mode}"
+        max_notional_usd: "{capital_usd}"
+        max_slippage_bps: 200
+    - id: execution_handoff
+      use: transform.emit_execution_intent
+      with:
+        from_step: risk_guard
+tests:
+  quick:
+    - validates_chain_and_maturity_ranges
+    - enforces_risk_caps
+  smoke:
+    - dry_run_plan_is_successful
+    - live_handoff_requires_explicit_opt_in
+publish:
+  org: spectra
+  slug: spectra-pt-yield-trader
+metadata:
+  category: trading

--- a/spectra/spectra-pt-yield-trader/tests/fixtures/connector_failure.json
+++ b/spectra/spectra-pt-yield-trader/tests/fixtures/connector_failure.json
@@ -1,0 +1,8 @@
+{
+  "status": "error",
+  "skill": "spectra-pt-yield-trader",
+  "error_code": "connector_failure",
+  "connector": "mcp_spectra",
+  "message": "Spectra MCP connector failed during smoke test.",
+  "connectors": {}
+}

--- a/spectra/spectra-pt-yield-trader/tests/fixtures/dry_run_guard.json
+++ b/spectra/spectra-pt-yield-trader/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "spectra-pt-yield-trader",
+  "dry_run": true,
+  "blocked_action": "execution_handoff"
+}

--- a/spectra/spectra-pt-yield-trader/tests/fixtures/happy_path.json
+++ b/spectra/spectra-pt-yield-trader/tests/fixtures/happy_path.json
@@ -1,0 +1,28 @@
+{
+  "status": "ok",
+  "skill": "spectra-pt-yield-trader",
+  "workflow_step_count": 4,
+  "dry_run": true,
+  "mode": "analysis-only",
+  "inputs": {
+    "capital_usd": 100,
+    "chain": "base",
+    "include_looping": false,
+    "live_mode": false,
+    "max_price_impact_pct": 2,
+    "min_liquidity_usd": 50000,
+    "pt_address": "",
+    "side": "buy",
+    "target_maturity_days_max": 365,
+    "target_maturity_days_min": 7,
+    "top_n": 5,
+    "underlying_symbol": "USDC",
+    "ve_spectra_balance": 0,
+    "wallet_address": "",
+    "wallet_mode": "delegated"
+  },
+  "connectors": {
+    "mcp_spectra": "mcp-spectra",
+    "seren_cron": "seren-cron"
+  }
+}

--- a/spectra/spectra-pt-yield-trader/tests/fixtures/policy_violation.json
+++ b/spectra/spectra-pt-yield-trader/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "spectra-pt-yield-trader",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/spectra/spectra-pt-yield-trader/tests/test_smoke.py
+++ b/spectra/spectra-pt-yield-trader/tests/test_smoke.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "spectra-pt-yield-trader"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "execution_handoff"


### PR DESCRIPTION
## Summary
- add new `spectra/spectra-pt-yield-trader` skill scaffold and runtime
- wire the skill to live Spectra publisher `mcp-spectra` (not legacy `spectra-finance`)
- implement read-only PT trading workflow: scan opportunities, select candidate, quote trade, simulate portfolio, optional looping context, guarded execution handoff
- add `seren-cron` automation flow parity with other skills:
  - `scripts/run_agent_server.py`
  - `scripts/setup_cron.py` (`create/list/pause/resume/delete`)
- include fixtures and smoke tests for happy path, policy violations, connector failure, and dry-run guard

## Notes
- this skill is intentionally read-only on execution: `mcp-spectra` provides analysis/quotes/simulation and the runtime emits execution handoff metadata only.

## Validation
- `python3 spectra/spectra-pt-yield-trader/scripts/agent.py --config spectra/spectra-pt-yield-trader/config.example.json`
- `cd spectra/spectra-pt-yield-trader && pytest -q` (4 passed)
- manual live checks against `mcp-spectra` publisher:
  - `list_mcp_tools`
  - `get_supported_chains`
  - `get_best_fixed_yields`
  - `scan_opportunities`
  - `quote_trade`
  - `simulate_portfolio_after_trade`
