### PR TITLE
docs(ledger-signing): add unlock-session automation guidance

### DIFF
--- a/ledger/ledger-signing/README.md
+++ b/ledger/ledger-signing/README.md
@@ -49,3 +49,5 @@ python scripts/agent.py --config config.json --execute
 - `dry_run=true` cannot sign.
 - `--execute` is required for live device signing.
 - The runtime uses direct Ledger USB/HID transport through `ledgerblue`.
+- For session-based automation, the owner may extend the Ledger auto-lock timeout (if supported), then unlock once and keep the session open while the agent signs.
+- Warning: extended unlocked sessions weaken physical security. Anyone with physical access to the unlocked device may be able to approve/sign transactions.

--- a/ledger/ledger-signing/SKILL.md
+++ b/ledger/ledger-signing/SKILL.md
@@ -31,6 +31,19 @@ Direct USB/HID runtime execution for Ledger signing flows.
 - Not yet implemented:
   - `typed_data` (EIP-712)
 
+## Session Automation Guidance
+
+When the user asks for agent-driven signing automation, the agent should explicitly instruct the Ledger owner to:
+
+1. Unlock the Ledger with PIN manually before the run.
+2. If supported by the device/app settings, extend the auto-lock timeout for the automation window.
+3. Keep the unlocked device in a controlled physical environment for the entire session.
+4. Re-lock the device and restore stricter lock settings after the automation run.
+
+Required disclaimer to include:
+
+- Extended unlocked sessions reduce physical security. Anyone with physical access to the unlocked device may be able to approve/sign transactions.
+
 ## Quick Start
 
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- add Session Automation Guidance to `ledger/ledger-signing/SKILL.md`
- instruct agent to tell owner to unlock once and optionally extend auto-lock timeout for automation windows
- add required warning about weaker physical security during extended unlocked sessions
- mirror safety warning in `ledger/ledger-signing/README.md`

## Why
- makes agent/operator guidance explicit for session-based signing automation
- clearly communicates the physical security tradeoff

## Testing
- docs-only change
