### PR TITLE
feat: implement EIP-712 typed_data signing for ledger-signing

### DIFF
--- a/ledger/ledger-signing/HITL_TESTS.md
+++ b/ledger/ledger-signing/HITL_TESTS.md
@@ -36,6 +36,23 @@
    - Ledger prompts to review/sign transaction fields.
    - Output contains `status=signed` and `signature_hex`.
 
+## Test 3: EIP-712 typed data signing (hashed mode)
+
+1. Copy config:
+   - `cp config.example.json config.live-typed-data.json`
+2. Edit config:
+   - `"dry_run": false`
+   - `"inputs.payload_kind": "typed_data"`
+   - `"inputs.derivation_path": "44'/60'/0'/0/0"`
+   - `"inputs.domain_separator_hex": "<32-byte domain separator hex>"`
+   - `"inputs.hash_struct_message_hex": "<32-byte hashStruct(message) hex>"`
+   - leave `"inputs.payload_hex": ""` (or set 64-byte combined fallback)
+3. Run:
+   - `python scripts/agent.py --config config.live-typed-data.json --execute`
+4. Expect:
+   - Ledger prompts to review/sign typed data hash payload.
+   - Output contains `status=signed` and `signature_hex`.
+
 ## Safety Gate Check
 
 Run with default config:

--- a/ledger/ledger-signing/README.md
+++ b/ledger/ledger-signing/README.md
@@ -12,9 +12,6 @@ USB/HID runtime skill for signing transactions and messages on a Ledger device.
 
 - `transaction`
 - `message`
-
-Not yet implemented:
-
 - `typed_data` (EIP-712)
 
 ## Quick Start
@@ -36,7 +33,11 @@ cp config.example.json config.json
 - `dry_run`: `false`
 - `inputs.payload_kind`
 - `inputs.derivation_path`
-- `inputs.payload_hex`
+- `inputs.payload_hex` for `transaction` / `message`
+- EIP-712 `typed_data`:
+  - preferred: `inputs.domain_separator_hex` + `inputs.hash_struct_message_hex` (32-byte each)
+  - compatible fallback: `inputs.payload_hex` as 64-byte combined blob
+    `[domainSeparator(32) || hashStruct(message)(32)]`
 
 4. Run execute mode:
 

--- a/ledger/ledger-signing/SKILL.md
+++ b/ledger/ledger-signing/SKILL.md
@@ -28,7 +28,6 @@ Direct USB/HID runtime execution for Ledger signing flows.
 - Supported payload kinds:
   - `transaction`
   - `message`
-- Not yet implemented:
   - `typed_data` (EIP-712)
 
 ## Session Automation Guidance
@@ -54,7 +53,11 @@ Required disclaimer to include:
    - `dry_run=false`
    - `inputs.payload_kind`
    - `inputs.derivation_path`
-   - `inputs.payload_hex`
+   - `inputs.payload_hex` for `transaction` / `message`
+   - EIP-712 `typed_data`:
+     - preferred: `inputs.domain_separator_hex` + `inputs.hash_struct_message_hex`
+     - compatible fallback: `inputs.payload_hex` as 64-byte combined
+       `[domainSeparator || hashStruct(message)]`
 4. Run live signing:
    - `python scripts/agent.py --config config.json --execute`
 

--- a/ledger/ledger-signing/config.example.json
+++ b/ledger/ledger-signing/config.example.json
@@ -6,6 +6,8 @@
     "blind_sign_allowed": true,
     "clear_sign_required": true,
     "derivation_path": "44'/60'/0'/0/0",
+    "domain_separator_hex": "",
+    "hash_struct_message_hex": "",
     "payload_hex": "",
     "payload_kind": "transaction",
     "request_summary": "",


### PR DESCRIPTION
## Summary
- implement `typed_data` (EIP-712 hashed signing) in `ledger/ledger-signing/scripts/agent.py`
- add APDU support for `INS=0x0C` with payload `path + domainSeparator(32) + hashStruct(message)(32)`
- parse EIP-712 response format (`v || r || s`) and normalize output keys
- add explicit config fields: `domain_separator_hex`, `hash_struct_message_hex`
- keep compatibility fallback for `payload_hex` as 64-byte combined blob
- update README/SKILL/HITL docs to remove "not implemented" gap and add typed_data runbook

## Validation
- `python3 -m py_compile ledger/ledger-signing/scripts/agent.py`
- `python3 ledger/ledger-signing/scripts/agent.py --config ledger/ledger-signing/config.example.json`
- inline validation of typed-data parsing helper for explicit + fallback inputs
