### PR TITLE
fix(polymarket): restore Polymarket Bot name

### DIFF
--- a/polymarket/trader/SKILL.md
+++ b/polymarket/trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: trader
+name: Polymarket Bot
+display-name: Polymarket Bot
 description: "Autonomous trading agent for Polymarket prediction markets using Seren ecosystem"
 ---
 


### PR DESCRIPTION
## Summary
- Restores `name: Polymarket Bot` and adds `display-name: Polymarket Bot` to the polymarket/trader SKILL.md frontmatter
- Fixes name collision introduced by commit 2f2c787 which renamed it to `trader`
- Prevents confusion with the separate Polymarket Trading Skill

## Test plan
- [ ] Verify SKILL.md frontmatter has correct `name` and `display-name` fields

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com