### PR TITLE
docs: Add grant-intake skill docs and env example

### DIFF
--- a/seren/grant-intake/.env.example
+++ b/seren/grant-intake/.env.example
@@ -1,0 +1,8 @@
+# Optional: endpoint and auth for grant-intake cloud agent
+# Copy to .env and set values when using scripts or tools that call the agent.
+
+# Seren Cloud invoke URL (POST with { "state", "input" })
+GRANT_INTAKE_ENDPOINT_URL=https://api.serendb.com/publishers/seren-cloud/agents/bc2491df-5ca0-466e-8acb-3dafd1b32bec/runs
+
+# Seren API key (Bearer token for the endpoint above)
+SEREN_API_KEY=

--- a/seren/grant-intake/README.md
+++ b/seren/grant-intake/README.md
@@ -1,0 +1,43 @@
+# Grant Intake — Extended docs
+
+This skill backs the **grant-intake** Seren Cloud agent: a five-phase state machine that collects org info, sectors, logic models, and sector metrics, then exports a Grant Readiness Summary and intake state JSON.
+
+## API contract
+
+- **Request:** `POST` with JSON body `{ "state": <object or null>, "input": { ... } }`.
+- **Response:** `{ "state", "prompt", "outputs?" }`. Use `state` on the next request to continue; when phase 5 is confirmed, `outputs` includes `grant-readiness-summary.md` and `intake-state.json`.
+
+## Phase 1 input
+
+- `org_name` (string)
+- `mission` (string)
+- `key_programs` (array of strings)
+- Optional: `docs_analyzed` (array of strings)
+
+## Phase 2 input
+
+- `sectors` (array of sector ids, e.g. `["workforce","health"]`)
+- Optional: `custom_sector` — `{ "name": "...", "questions": [{ "id", "text", "hint" }] }`
+
+## Phase 3 input
+
+- `logic_model` — `{ "inputs", "activities", "outputs", "outcomes" }` for the current program
+- Or `new_programs` (array of names) if no programs were set in phase 1
+
+## Phase 4 input
+
+- `question_id` (string), `answer` (string)
+- Optional: `want_hint` (boolean) for hint text
+
+## Phase 5 input
+
+- `confirmed` (boolean)
+- Optional: `edits` (string) if not confirming
+
+## Deploy and invoke
+
+- **Agent ID (current):** `bc2491df-5ca0-466e-8acb-3dafd1b32bec`
+- **Invoke URL:** `https://api.serendb.com/publishers/seren-cloud/agents/bc2491df-5ca0-466e-8acb-3dafd1b32bec/runs`
+- **Auth:** `Authorization: Bearer $SEREN_API_KEY`
+
+See [docs/seren/README.md](https://github.com/serendb/seren-sql-interface-402mcp-server/blob/main/docs/seren/README.md) in the source repo for full control-plane and deploy steps.

--- a/seren/grant-intake/SKILL.md
+++ b/seren/grant-intake/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: grant-intake
+description: "Five-phase grant consultant intake for grant readiness. Use when a user needs structured intake for org name, mission, programs, sector selection (workforce, health, green economy, education, housing, arts, agriculture), logic models per program, sector-specific questions, and a Grant Readiness Summary plus Organizational Profile export."
+license: Apache-2.0
+---
+
+# Grant Intake
+
+Structured five-phase grant consultant intake to produce a Grant Readiness Summary and Organizational Profile.
+
+## When to Use
+
+- User wants grant readiness or funder alignment
+- User needs to capture org mission, programs, and logic models (inputs, activities, outputs, outcomes)
+- User is preparing for grant applications and needs sector-specific metrics and a summary document
+
+## Workflow Summary
+
+1. **Phase 1** — Org name, mission, key programs
+2. **Phase 2** — Sector selection (Workforce Development, Health/Human Services, Green Economy, Education/Youth, Housing, Arts/Culture, Agriculture, or custom)
+3. **Phase 3** — Logic model per program (inputs, activities, outputs, outcomes)
+4. **Phase 4** — Sector-specific thematic questions with optional hints
+5. **Phase 5** — Review, confirm, and export Grant Readiness Summary + intake state
+
+## How to Run
+
+- **Seren Cloud agent:** If the grant-intake cloud agent is available (e.g. via Seren Gateway or MCP), invoke it with a JSON body: `{ "state": null, "input": { "org_name": "...", "mission": "...", "key_programs": ["..."] } }`. Response is `{ "state", "prompt", "outputs?" }`; pass `state` back on each step to advance phases.
+- **Docs and deploy:** See [grant-intake deploy and invoke docs](https://github.com/serendb/seren-sql-interface-402mcp-server/blob/main/docs/seren/README.md) for endpoint URL, agent ID, and scripts.
+
+## Sectors
+
+Predefined sectors: Workforce Development, Health/Human Services, Green Economy, Education/Youth, Housing, Arts/Culture, Agriculture. Custom sectors are supported.


### PR DESCRIPTION
Add a new grant-intake skill: includes SKILL.md (skill metadata and workflow summary) and README.md (detailed five-phase intake docs, API contract, phase inputs, deploy/invoke info and agent ID). Also add .env.example with the Seren Cloud agent invoke URL and SEREN_API_KEY placeholder for local scripts and deployments.