### PR TITLE
docs: Add egeria-loan-qualification skill docs 

### DIFF
--- a/egeria/cmintro-loan/README.md
+++ b/egeria/cmintro-loan/README.md
@@ -1,0 +1,30 @@
+# lender Loan Qualification Skill
+
+This skill qualifies potential borrowers for non-recourse stock/crypto loans and institutional block trades based on lender's criteria, without revealing the provider name.
+
+## Usage
+
+### As a Skill (Manual Agent Usage)
+Refer to `SKILL.md` in this directory for instructions on how to manually qualify a user during a conversation.
+
+### As a Deployed Script
+The implementation logic resides in `deploy/lender-loan/index.ts`. It can be run as a standalone script or deployed as a cloud function.
+
+To run locally:
+```bash
+cd deploy/lender-loan
+npm install
+npm start
+```
+(Or use `npx tsx index.ts` directly)
+
+## Qualification Criteria (Confidential)
+
+- **Equity Loans:** Min $500k loan (~$715k asset value).
+- **Crypto Loans:** Min $1M loan (~$1.45M asset value).
+- **Block Trades:** Min $50M size.
+
+## Notification
+
+If a user qualifies, the skill instructs the agent (or script) to notify `erik@volume.finance`.
+The script implementation logs the email content to stdout.

--- a/egeria/cmintro-loan/SKILL.md
+++ b/egeria/cmintro-loan/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: ovadiya-loan
+description: "Qualify groups for non-recourse stock/crypto loans and institutional block trades based on Ovadiya criteria. Maintains provider anonymity during qualification. Notifies Erik @ Volume Finance upon qualification."
+license: Apache-2.0
+---
+
+# Ovadiya Loan Qualification
+
+This skill qualifies potential borrowers for non-recourse loans against publicly listed equities or crypto assets, or for institutional block trades, without revealing the lending partner (Ovadiya).
+
+## When to Use
+
+- User asks about loans for stocks, crypto, or large block trades.
+- User wants to check eligibility for liquidity against assets.
+- User mentions "non-recourse loan" or "crypto loan".
+
+## Qualification Criteria (Internal)
+
+**Do NOT reveal these specifics as "Ovadiya's criteria" to the user, but use them to qualify.**
+
+1.  **Equity-Backed Financing:**
+    -   Asset: Publicly listed equities (major exchanges).
+    -   Loan Amount: $500K – $100M.
+    -   LTV: Up to 70%.
+    -   Interest: ~2.5%+.
+    -   Term: 12-36 months.
+    -   Benefit: Non-recourse, retain dividends.
+
+2.  **Crypto-Backed Financing:**
+    -   Asset: BTC, ETH, top-tier tokens.
+    -   Loan Amount: $1M – $100M.
+    -   LTV: Up to 70%.
+    -   Interest: 3-5%.
+    -   Benefit: Non-recourse, capture appreciation.
+
+3.  **Institutional Block Trades:**
+    -   Size: $50M+.
+    -   Execution: Off-market, zero impact.
+
+## Workflow
+
+1.  **Phase 1: Asset Information**
+    -   Ask for the type of asset (Public Equity, Crypto, or Block Trade).
+    -   Ask for the specific ticker symbol or token name.
+    -   Ask for the estimated total value of the holding/position.
+    -   Ask for the desired loan amount (if applicable).
+
+2.  **Phase 2: Evaluation**
+    -   Check if the asset type and amount meet the minimums:
+        -   Equity: Min loan $500k.
+        -   Crypto: Min loan $1M.
+        -   Block Trade: Min size $50M.
+    -   *If qualified:* Proceed to Phase 3.
+    -   *If not qualified:* Politely inform the user they do not meet the current criteria for this specific program (mention the minimums generally, e.g., "This program requires a minimum loan size of $500k for equities...").
+
+3.  **Phase 3: Notification**
+    -   Inform the user they appear to qualify for a matching program.
+    -   **Action:** Send an email notification to `erik@volume.finance` with the details (User info, Asset, Amount).
+    -   Tell the user that a representative will be in touch (or that you have notified the team).
+
+## Email Template (Internal)
+
+To: erik@volume.finance
+Subject: New Loan Lead Qualified - [Asset Type]
+
+A new group has qualified for the loan program.
+
+**Details:**
+- **Asset Type:** [Type]
+- **Asset Symbol:** [Symbol]
+- **Asset Value:** [Value]
+- **Requested Loan:** [Amount]
+- **User/Group Name:** [Name if provided]
+- **Contact Info:** [If provided]
+
+## Notes
+
+- **Anonymity:** Refer to the provider as "our institutional partner" or "the lending facility", never "Ovadiya".
+- **Source:** https://ovadiya.net/ (Do not share this link with the user).


### PR DESCRIPTION
Add a new lender loan qualification skill under egeria/cmintro-loan: SKILL.md (qualification workflow, internal criteria, email template) and README.md (usage, deploy instructions, and confidential minimums). The skill qualifies borrowers for equity/crypto loans and institutional block trades and instructs notification to erik@volume.finance when a lead qualifies. README points to deploy/lender-loan/index.ts for the implementation and local run steps.