### PR TITLE
fix(kraken/money-mode-router): port SerenDB MCP target resolution updates

### DIFF
--- a/kraken/money-mode-router/.env.example
+++ b/kraken/money-mode-router/.env.example
@@ -1,10 +1,17 @@
 # Seren API key for Kraken publisher calls
 SEREN_API_KEY=sb_your_key_here
 
-# Required: SerenDB/Postgres connection string
-# Example: postgresql://user:password@host:5432/database
-SERENDB_CONNECTION_STRING=postgresql://serendb_owner:password@localhost:5432/serendb
+# MCP-native SerenDB target (optional, resolved via local seren-mcp)
+# If SERENDB_DATABASE is unset:
+# 1) Reuse an existing Kraken-related database if found
+# 2) Otherwise auto-create project/database: krakent/krakent
+# SERENDB_PROJECT_NAME=
+# SERENDB_DATABASE=
+# SERENDB_BRANCH=
+SERENDB_REGION=aws-us-east-1
+SERENDB_AUTO_CREATE=true
 
 # Optional overrides
 SEREN_GATEWAY_BASE_URL=https://api.serendb.com
 KRAKEN_SPOT_PUBLISHER=kraken-spot-trading
+SEREN_MCP_COMMAND=seren-mcp

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -31,10 +31,13 @@ Use this skill when a user asks things like:
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Set `SERENDB_CONNECTION_STRING` (required).
-3. Set `SEREN_API_KEY` (required for Kraken account context).
-4. Copy `config.example.json` to `config.json`.
-5. Install dependencies: `pip install -r requirements.txt`.
+2. Ensure `seren-mcp` is available locally and authenticated (Seren Desktop login context).
+3. Set `SEREN_API_KEY` (required for Kraken account context and MCP auth when running standalone).
+4. Optionally set MCP DB target env vars (`SERENDB_PROJECT_NAME`, `SERENDB_DATABASE`, optional branch/region).
+   - If `SERENDB_DATABASE` is not set, the router first tries to reuse an existing Kraken-related database.
+   - If none exists, it auto-creates `krakent` project + `krakent` database (when `SERENDB_AUTO_CREATE=true`).
+5. Copy `config.example.json` to `config.json`.
+6. Install dependencies: `pip install -r requirements.txt`.
 
 ## Commands
 

--- a/kraken/money-mode-router/scripts/serendb_store.py
+++ b/kraken/money-mode-router/scripts/serendb_store.py
@@ -1,21 +1,207 @@
-"""SerenDB persistence for Kraken Money Mode Router."""
+"""SerenDB persistence for Kraken Money Mode Router via local seren-mcp."""
 
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List
+import os
+import select
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
 
-import psycopg
+
+class SerenMCPError(RuntimeError):
+    """Raised when a local seren-mcp tool call fails."""
+
+
+@dataclass
+class DBTarget:
+    project_id: str
+    branch_id: str
+    database: str
+    endpoint_id: Optional[str] = None
+
+
+class _SerenMCPClient:
+    def __init__(self, api_key: str, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
+        self.api_key = api_key
+        self.mcp_command = mcp_command
+        self.timeout_seconds = timeout_seconds
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._next_id = 1
+
+    def start(self) -> None:
+        if self._process is not None:
+            return
+
+        env = os.environ.copy()
+        env["API_KEY"] = self.api_key
+
+        self._process = subprocess.Popen(
+            [self.mcp_command, "start"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+
+        if self._process.stdin is None or self._process.stdout is None:
+            raise SerenMCPError("Failed to open stdio pipes for seren-mcp")
+
+        init_response = self._request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "kraken-money-mode-router", "version": "1.0.0"},
+            },
+        )
+        if "error" in init_response:
+            raise SerenMCPError(init_response["error"].get("message", "seren-mcp initialize failed"))
+
+        self._notify("notifications/initialized", {})
+
+    def close(self) -> None:
+        if self._process is None:
+            return
+
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+
+        self._process = None
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        response = self._request("tools/call", {"name": name, "arguments": arguments})
+        if "error" in response:
+            message = response["error"].get("message", "Unknown MCP tool error")
+            raise SerenMCPError(f"{name} failed: {message}")
+
+        result = response.get("result", {})
+        if isinstance(result, dict) and result.get("isError"):
+            payload = self._parse_tool_result(result)
+            raise SerenMCPError(f"{name} returned isError: {payload}")
+        return self._parse_tool_result(result)
+
+    def _notify(self, method: str, params: Dict[str, Any]) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+
+        deadline = time.time() + self.timeout_seconds
+        while time.time() < deadline:
+            message = self._read_message(timeout=0.5)
+            if message is None:
+                continue
+            if message.get("id") == request_id:
+                return message
+
+        raise SerenMCPError(f"Timed out waiting for MCP response to {method}")
+
+    def _send(self, message: Dict[str, Any]) -> None:
+        if self._process is None or self._process.stdin is None:
+            raise SerenMCPError("seren-mcp process is not started")
+        self._process.stdin.write(json.dumps(message) + "\n")
+        self._process.stdin.flush()
+
+    def _read_message(self, timeout: float) -> Optional[Dict[str, Any]]:
+        if self._process is None or self._process.stdout is None:
+            raise SerenMCPError("seren-mcp process is not started")
+
+        ready, _, _ = select.select([self._process.stdout], [], [], timeout)
+        if not ready:
+            if self._process.poll() is not None:
+                raise SerenMCPError("seren-mcp exited unexpectedly")
+            return None
+
+        line = self._process.stdout.readline()
+        if line == "":
+            if self._process.poll() is not None:
+                raise SerenMCPError("seren-mcp closed stdout unexpectedly")
+            return None
+
+        payload = line.strip()
+        if not payload:
+            return None
+
+        try:
+            parsed = json.loads(payload)
+            if isinstance(parsed, dict):
+                return parsed
+            return None
+        except json.JSONDecodeError:
+            return None
+
+    @staticmethod
+    def _parse_tool_result(result: Any) -> Dict[str, Any]:
+        if not isinstance(result, dict):
+            return {"raw": result}
+
+        structured = result.get("structuredContent")
+        if isinstance(structured, dict):
+            return structured
+        if isinstance(structured, list):
+            return {"data": structured}
+
+        content = result.get("content")
+        if isinstance(content, list):
+            text_parts: List[str] = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text_parts.append(str(item.get("text", "")))
+            if len(text_parts) == 1:
+                text = text_parts[0].strip()
+                if text.startswith("{") or text.startswith("["):
+                    try:
+                        parsed = json.loads(text)
+                        if isinstance(parsed, dict):
+                            return parsed
+                        return {"data": parsed}
+                    except json.JSONDecodeError:
+                        return {"text": text_parts[0]}
+                return {"text": text_parts[0]}
+            if text_parts:
+                return {"text": "\n".join(text_parts)}
+
+        return result
 
 
 class SerenDBStore:
-    """Stores router sessions, answers, recommendations, and events in SerenDB."""
+    """Stores router sessions, answers, recommendations, and events in SerenDB via MCP."""
 
-    def __init__(self, connection_string: str):
-        self.connection_string = connection_string
+    DEFAULT_KRAKEN_PROJECT = "krakent"
+    DEFAULT_KRAKEN_DATABASE = "krakent"
 
-    def _connect(self):
-        return psycopg.connect(self.connection_string)
+    def __init__(
+        self,
+        api_key: str,
+        project_name: Optional[str] = None,
+        database_name: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        project_region: str = "aws-us-east-1",
+        auto_create: bool = True,
+        mcp_command: str = "seren-mcp",
+    ):
+        self.project_name = project_name.strip() if project_name else None
+        self.database_name = database_name.strip() if database_name else None
+        self.branch_name = branch_name.strip() if branch_name else None
+        self.project_region = project_region
+        self.auto_create = auto_create
+        self._target: Optional[DBTarget] = None
+        self._mcp = _SerenMCPClient(api_key=api_key, mcp_command=mcp_command)
+        self._mcp.start()
+
+    def close(self) -> None:
+        self._mcp.close()
 
     def ensure_schema(self) -> None:
         ddl = """
@@ -62,34 +248,42 @@ class SerenDBStore:
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );
         """
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.execute(ddl)
-            conn.commit()
+        self._execute_sql(ddl)
 
     def create_session(self, session_id: str, profile_name: str) -> None:
-        query = """
+        query = f"""
         INSERT INTO kraken_skill_sessions (session_id, profile_name)
-        VALUES (%s::uuid, %s);
+        VALUES ({self._sql_text(session_id)}::uuid, {self._sql_text(profile_name)});
         """
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.execute(query, (session_id, profile_name))
-            conn.commit()
+        self._execute_sql(query)
 
     def save_answers(self, session_id: str, answers: Dict[str, str]) -> None:
-        query = """
+        if not answers:
+            return
+        values = ", ".join(
+            f"({self._sql_text(session_id)}::uuid, {self._sql_text(key)}, {self._sql_text(value)})"
+            for key, value in answers.items()
+        )
+        query = f"""
         INSERT INTO kraken_skill_answers (session_id, question_key, answer_value)
-        VALUES (%s::uuid, %s, %s);
+        VALUES {values};
         """
-        rows = [(session_id, key, value) for key, value in answers.items()]
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.executemany(query, rows)
-            conn.commit()
+        self._execute_sql(query)
 
     def save_recommendations(self, session_id: str, recommendations: List[Dict[str, Any]]) -> None:
-        query = """
+        if not recommendations:
+            return
+        values: List[str] = []
+        for idx, rec in enumerate(recommendations, start=1):
+            score = float(rec.get("score", 0.0))
+            values.append(
+                (
+                    f"({self._sql_text(session_id)}::uuid, {idx}, {self._sql_text(str(rec['mode_id']))}, "
+                    f"{score}, {self._sql_text(str(rec['label']))}, {self._sql_text(str(rec['summary']))}, "
+                    f"{self._sql_json(rec.get('reasons', []))})"
+                )
+            )
+        query = f"""
         INSERT INTO kraken_skill_recommendations (
             session_id,
             rank_index,
@@ -99,44 +293,289 @@ class SerenDBStore:
             summary,
             reasons
         )
-        VALUES (%s::uuid, %s, %s, %s, %s, %s, %s::jsonb);
+        VALUES {", ".join(values)};
         """
-        rows = []
-        for idx, rec in enumerate(recommendations, start=1):
-            rows.append(
+        self._execute_sql(query)
+
+    def save_actions(self, session_id: str, mode_id: str, actions: List[str]) -> None:
+        if not actions:
+            return
+        values = ", ".join(
+            f"({self._sql_text(session_id)}::uuid, {self._sql_text(mode_id)}, {idx}, {self._sql_text(text)})"
+            for idx, text in enumerate(actions, start=1)
+        )
+        query = f"""
+        INSERT INTO kraken_skill_actions (session_id, mode_id, step_index, action_text)
+        VALUES {values};
+        """
+        self._execute_sql(query)
+
+    def save_event(self, session_id: str, event_type: str, payload: Dict[str, Any]) -> None:
+        query = f"""
+        INSERT INTO kraken_skill_events (session_id, event_type, payload)
+        VALUES ({self._sql_text(session_id)}::uuid, {self._sql_text(event_type)}, {self._sql_json(payload)});
+        """
+        self._execute_sql(query)
+
+    def _execute_sql(self, query: str) -> None:
+        target = self._resolve_target()
+        last_error: Optional[Exception] = None
+        for _ in range(3):
+            try:
+                self._mcp.call_tool(
+                    "run_sql",
+                    {
+                        "project_id": target.project_id,
+                        "branch_id": target.branch_id,
+                        "database": target.database,
+                        "query": query,
+                    },
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                self._attempt_endpoint_recovery(target)
+                time.sleep(2)
+        raise SerenMCPError(f"run_sql failed after retries: {last_error}")
+
+    def _resolve_target(self) -> DBTarget:
+        if self._target is not None:
+            return self._target
+
+        all_dbs = self._mcp.call_tool("list_all_databases", {})
+        candidates = all_dbs.get("databases", [])
+        if not isinstance(candidates, list):
+            candidates = []
+
+        if self.database_name:
+            self._target = self._find_target(
+                candidates=candidates,
+                project_name=self.project_name,
+                database_name=self.database_name,
+                branch_name=self.branch_name,
+            )
+        else:
+            self._target = self._find_existing_kraken_target(candidates=candidates)
+
+        if self._target is not None:
+            self._attempt_endpoint_recovery(self._target)
+            return self._target
+
+        if not self.auto_create:
+            raise SerenMCPError(
+                "Target SerenDB database not found via seren-mcp. "
+                "Set SERENDB_DATABASE/SERENDB_PROJECT_NAME or enable SERENDB_AUTO_CREATE=true."
+            )
+
+        project_name = self.project_name or self.DEFAULT_KRAKEN_PROJECT
+        database_name = self.database_name or self.DEFAULT_KRAKEN_DATABASE
+        self._target = self._provision_target(project_name=project_name, database_name=database_name)
+        self._attempt_endpoint_recovery(self._target)
+        return self._target
+
+    def _provision_target(self, project_name: str, database_name: str) -> DBTarget:
+        projects_payload = self._mcp.call_tool("list_projects", {})
+        projects = projects_payload.get("data", [])
+        if not isinstance(projects, list):
+            projects = []
+
+        project = None
+        for item in projects:
+            if isinstance(item, dict) and item.get("name") == project_name:
+                project = item
+                break
+
+        if project is None:
+            created = self._mcp.call_tool(
+                "create_project",
+                {"name": project_name, "region": self.project_region},
+            )
+            project = created.get("data", created)
+
+        project_id = str(project["id"])
+        branch_id = str(project.get("default_branch_id") or "")
+        if not branch_id:
+            branches_payload = self._mcp.call_tool("list_branches", {"project_id": project_id})
+            branches = branches_payload.get("data", [])
+            if not isinstance(branches, list) or not branches:
+                raise SerenMCPError("No branches found after project provisioning")
+            default_branch = next((b for b in branches if isinstance(b, dict) and b.get("is_default")), branches[0])
+            branch_id = str(default_branch["id"])
+
+        dbs_payload = self._mcp.call_tool(
+            "list_databases",
+            {"project_id": project_id, "branch_id": branch_id},
+        )
+        dbs = dbs_payload.get("databases", dbs_payload.get("data", []))
+        if not isinstance(dbs, list):
+            dbs = []
+        has_database = any(isinstance(db, dict) and db.get("name") == database_name for db in dbs)
+        if not has_database:
+            try:
+                self._mcp.call_tool(
+                    "create_database",
+                    {
+                        "project_id": project_id,
+                        "branch_id": branch_id,
+                        "name": database_name,
+                    },
+                )
+            except Exception:
+                pass
+
+            dbs_payload = self._mcp.call_tool(
+                "list_databases",
+                {"project_id": project_id, "branch_id": branch_id},
+            )
+            dbs = dbs_payload.get("databases", dbs_payload.get("data", []))
+            if not isinstance(dbs, list):
+                dbs = []
+            has_database = any(isinstance(db, dict) and db.get("name") == database_name for db in dbs)
+            if not has_database:
+                raise SerenMCPError(
+                    f"Database '{database_name}' not found after provisioning for project '{project_name}'"
+                )
+
+        return DBTarget(project_id=project_id, branch_id=branch_id, database=database_name)
+
+    def _find_target(
+        self,
+        candidates: List[Any],
+        project_name: Optional[str],
+        database_name: str,
+        branch_name: Optional[str],
+    ) -> Optional[DBTarget]:
+        for db in candidates:
+            if not isinstance(db, dict):
+                continue
+            db_project_name = self._normalize_name(db.get("project"))
+            db_database_name = self._normalize_name(db.get("database") or db.get("name"))
+            db_branch_name = self._normalize_name(db.get("branch"))
+            if project_name and db_project_name != self._normalize_name(project_name):
+                continue
+            if db_database_name != self._normalize_name(database_name):
+                continue
+            if branch_name and db_branch_name != self._normalize_name(branch_name):
+                continue
+            project_id = db.get("project_id")
+            branch_id = db.get("branch_id")
+            if not project_id or not branch_id:
+                continue
+            return DBTarget(
+                project_id=str(project_id),
+                branch_id=str(branch_id),
+                database=str(db.get("database") or db.get("name") or database_name),
+            )
+        return None
+
+    def _find_existing_kraken_target(self, candidates: List[Any]) -> Optional[DBTarget]:
+        scored: List[Tuple[int, DBTarget]] = []
+        requested_project_name = self._normalize_name(self.project_name)
+        requested_branch_name = self._normalize_name(self.branch_name)
+
+        for db in candidates:
+            if not isinstance(db, dict):
+                continue
+            project_id = db.get("project_id")
+            branch_id = db.get("branch_id")
+            if not project_id or not branch_id:
+                continue
+
+            project_name = self._normalize_name(db.get("project"))
+            database_name = self._normalize_name(db.get("database") or db.get("name"))
+            branch_name = self._normalize_name(db.get("branch"))
+            if requested_project_name and project_name != requested_project_name:
+                continue
+            if requested_branch_name and branch_name != requested_branch_name:
+                continue
+
+            score = 0
+            if database_name == "kraken":
+                score += 200
+            if project_name == "kraken":
+                score += 180
+            if database_name == "krakent":
+                score += 170
+            if project_name == "krakent":
+                score += 150
+            if "kraken" in database_name:
+                score += 120
+            if "kraken" in project_name:
+                score += 100
+
+            if score == 0:
+                continue
+
+            scored.append(
                 (
-                    session_id,
-                    idx,
-                    rec["mode_id"],
-                    rec["score"],
-                    rec["label"],
-                    rec["summary"],
-                    json.dumps(rec["reasons"]),
+                    score,
+                    DBTarget(
+                        project_id=str(project_id),
+                        branch_id=str(branch_id),
+                        database=str(db.get("database") or db.get("name") or "kraken"),
+                    ),
                 )
             )
 
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.executemany(query, rows)
-            conn.commit()
+        if not scored:
+            return None
 
-    def save_actions(self, session_id: str, mode_id: str, actions: List[str]) -> None:
-        query = """
-        INSERT INTO kraken_skill_actions (session_id, mode_id, step_index, action_text)
-        VALUES (%s::uuid, %s, %s, %s);
-        """
-        rows = [(session_id, mode_id, idx, text) for idx, text in enumerate(actions, start=1)]
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.executemany(query, rows)
-            conn.commit()
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return scored[0][1]
 
-    def save_event(self, session_id: str, event_type: str, payload: Dict[str, Any]) -> None:
-        query = """
-        INSERT INTO kraken_skill_events (session_id, event_type, payload)
-        VALUES (%s::uuid, %s, %s::jsonb);
-        """
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.execute(query, (session_id, event_type, json.dumps(payload)))
-            conn.commit()
+    def _attempt_endpoint_recovery(self, target: DBTarget) -> None:
+        try:
+            endpoints_payload = self._mcp.call_tool(
+                "list_endpoints",
+                {"project_id": target.project_id, "branch_id": target.branch_id},
+            )
+            endpoints = endpoints_payload.get("data", [])
+            if not isinstance(endpoints, list) or not endpoints:
+                return
+            endpoint = endpoints[0]
+            if not isinstance(endpoint, dict):
+                return
+            endpoint_id = str(endpoint["id"])
+            target.endpoint_id = endpoint_id
+            status = str(endpoint.get("status", ""))
+            if status == "suspended":
+                try:
+                    self._mcp.call_tool(
+                        "start_endpoint",
+                        {
+                            "project_id": target.project_id,
+                            "branch_id": target.branch_id,
+                            "endpoint_id": endpoint_id,
+                        },
+                    )
+                except Exception:
+                    self._mcp.call_tool(
+                        "restart_endpoint",
+                        {
+                            "project_id": target.project_id,
+                            "endpoint_id": endpoint_id,
+                        },
+                    )
+            elif status not in {"active", "running"}:
+                self._mcp.call_tool(
+                    "restart_endpoint",
+                    {
+                        "project_id": target.project_id,
+                        "endpoint_id": endpoint_id,
+                    },
+                )
+        except Exception:
+            return
+
+    @staticmethod
+    def _sql_text(value: Any) -> str:
+        return "'" + str(value).replace("'", "''") + "'"
+
+    @staticmethod
+    def _sql_json(value: Any) -> str:
+        encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False).replace("'", "''")
+        return f"'{encoded}'::jsonb"
+
+    @staticmethod
+    def _normalize_name(value: Any) -> str:
+        return str(value or "").strip().lower()


### PR DESCRIPTION
## Summary
Port the same `kraken-money-mode-router` changes from the installed skill copy into `seren-skills`.

This updates the router’s SerenDB persistence path to use MCP tool calls with database target auto-resolution and provisioning behavior aligned with the local patched version.

## Changes
- `kraken/money-mode-router/scripts/serendb_store.py`
  - Replace direct Postgres/DSN approach with MCP tool client flow.
  - Add DB target resolution by `SERENDB_*` env vars.
  - Add fallback behavior when DB vars are unset:
    1. Reuse an existing Kraken-related database when available.
    2. Otherwise auto-create `krakent` project + `krakent` database (when `SERENDB_AUTO_CREATE=true`).
  - Add endpoint recovery attempts before SQL operations.
- `kraken/money-mode-router/scripts/agent.py`
  - Build `SerenDBStore` from env (`SERENDB_PROJECT_NAME`, `SERENDB_DATABASE`, `SERENDB_BRANCH`, `SERENDB_REGION`, `SERENDB_AUTO_CREATE`, `SEREN_MCP_COMMAND`).
  - Remove hard dependency on connection-string bootstrap helper in this path.
  - Standardize error handling/messages for MCP persistence failures.
  - Keep Kraken publisher default as `kraken-spot-trading`.
- `kraken/money-mode-router/.env.example`
  - Document MCP-native DB target configuration and fallback behavior.
  - Add `SERENDB_REGION`, `SERENDB_AUTO_CREATE`, `SEREN_MCP_COMMAND` defaults.
- `kraken/money-mode-router/SKILL.md`
  - Update setup docs for MCP-native target resolution and optional DB env vars.

## Validation
- `python3 -m py_compile kraken/money-mode-router/scripts/agent.py kraken/money-mode-router/scripts/serendb_store.py kraken/money-mode-router/scripts/kraken_client.py kraken/money-mode-router/scripts/mode_engine.py`

## Notes
- This PR intentionally ports the same behavior that currently exists in the local installed skill copy.
