### PR TITLE
feat: desktop auth + MCP-native persistence for trading skills

### DIFF
--- a/coinbase/grid-trader/.env.example
+++ b/coinbase/grid-trader/.env.example
@@ -1,7 +1,14 @@
 SEREN_API_KEY=sb_your_key_here
-CB_ACCESS_KEY=your_coinbase_api_key
-CB_ACCESS_SECRET=your_coinbase_api_secret_base64
-CB_ACCESS_PASSPHRASE=your_coinbase_passphrase
+
+# Desktop sidecar/keychain mode (recommended)
+# If true, Coinbase credentials are read from Seren Desktop publisher keychain flow.
+SEREN_DESKTOP_PUBLISHER_AUTH=true
+
+# Legacy direct Coinbase header-signing mode (optional fallback)
+# Set SEREN_DESKTOP_PUBLISHER_AUTH=false to force this mode.
+# CB_ACCESS_KEY=your_coinbase_api_key
+# CB_ACCESS_SECRET=your_coinbase_api_secret_base64
+# CB_ACCESS_PASSPHRASE=your_coinbase_passphrase
 
 # Optional: SerenDB target for MCP-native persistence
 # If omitted, the bot will try existing Coinbase-related databases first,

--- a/coinbase/grid-trader/README.md
+++ b/coinbase/grid-trader/README.md
@@ -41,10 +41,13 @@ cp .env.example .env
 Edit `.env`:
 
 ```
-SEREN_API_KEY=sb_...        # Get at app.serendb.com → API Keys
-CB_ACCESS_KEY=...           # Coinbase Exchange API key
-CB_ACCESS_SECRET=...        # Base64-encoded secret
-CB_ACCESS_PASSPHRASE=...    # Passphrase set when creating API key
+SEREN_API_KEY=sb_...                 # Get at app.serendb.com → API Keys
+SEREN_DESKTOP_PUBLISHER_AUTH=true    # Recommended: Desktop sidecar/keychain flow
+
+# Legacy fallback (optional):
+# CB_ACCESS_KEY=...                   # Coinbase Exchange API key
+# CB_ACCESS_SECRET=...                # Base64-encoded secret
+# CB_ACCESS_PASSPHRASE=...            # Passphrase set when creating API key
 
 # Optional SerenDB target (MCP-native persistence)
 SERENDB_PROJECT_NAME=coinbase
@@ -55,8 +58,14 @@ SERENDB_AUTO_CREATE=true
 SEREN_MCP_COMMAND=seren-mcp
 ```
 
-To create a Coinbase Exchange API key: [Coinbase Exchange → Profile → API](https://pro.coinbase.com/profile/api)
-- Required permissions: **View**, **Trade**
+Desktop flow requirements:
+- Configure Coinbase publisher credentials in Seren Desktop Settings → Publisher MCPs
+- Keep `SEREN_DESKTOP_PUBLISHER_AUTH=true`
+
+Legacy fallback (optional):
+- Set `SEREN_DESKTOP_PUBLISHER_AUTH=false`
+- Provide `CB_ACCESS_KEY`, `CB_ACCESS_SECRET`, `CB_ACCESS_PASSPHRASE` in `.env`
+- Required Coinbase API permissions: **View**, **Trade**
 
 When SerenDB target vars are unset, the bot first tries existing Coinbase-related SerenDB databases and then auto-creates `coinbase/coinbase` (if `SERENDB_AUTO_CREATE=true`).
 
@@ -199,7 +208,9 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 
 ## Troubleshooting
 
-**`CB-ACCESS-SIGN` errors**: Ensure `CB_ACCESS_SECRET` is the raw base64-encoded secret, not URL-decoded.
+**Desktop auth 401/403 errors**: Configure Coinbase publisher credentials in Seren Desktop Settings → Publisher MCPs and ensure the publisher is enabled.
+
+**Legacy `CB-ACCESS-SIGN` errors**: Ensure `CB_ACCESS_SECRET` is the raw base64-encoded secret, not URL-decoded.
 
 **Orders rejected**: Check that your Coinbase API key has **Trade** permissions and is not IP-restricted to a different address.
 

--- a/coinbase/grid-trader/SKILL.md
+++ b/coinbase/grid-trader/SKILL.md
@@ -20,10 +20,12 @@ Grid trading places a ladder of buy orders below the market price and sell order
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in your Seren API credentials
-2. Copy `config.example.json` to `config.json` and configure your grid parameters
-3. Install dependencies: `pip install -r requirements.txt`
-4. Run: `python scripts/agent.py`
+1. Configure Coinbase publisher credentials in Seren Desktop Settings → Publisher MCPs (desktop sidecar/keychain flow)
+2. Copy `.env.example` to `.env` and set `SEREN_API_KEY` (`SEREN_DESKTOP_PUBLISHER_AUTH=true` is recommended)
+3. Optional legacy fallback: set `SEREN_DESKTOP_PUBLISHER_AUTH=false` and fill `CB_ACCESS_*` values
+4. Copy `config.example.json` to `config.json` and configure your grid parameters
+5. Install dependencies: `pip install -r requirements.txt`
+6. Run: `python scripts/agent.py`
 
 ## SerenDB Persistence (MCP-native)
 

--- a/kraken/grid-trader/.env.example
+++ b/kraken/grid-trader/.env.example
@@ -2,6 +2,12 @@
 # Get your API key at: https://serendb.com
 SEREN_API_KEY=sb_your_key_here
 
+# Desktop sidecar/keychain mode is the default for Kraken publisher auth.
+# Configure Kraken publisher API key in Seren Desktop Settings > Publisher MCPs.
+# Optional slug override if needed:
+# KRAKEN_SPOT_PUBLISHER=kraken-trading
+# KRAKEN_SPOT_PUBLISHER_FALLBACK=kraken-spot-trading
+
 # Optional: SerenDB target for MCP-native persistence
 # If omitted, the bot will try existing Kraken-related databases first,
 # then auto-create project/database "krakent" when SERENDB_AUTO_CREATE=true.

--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -47,6 +47,10 @@ cp .env.example .env
 echo "SEREN_API_KEY=sb_your_key_here" > .env
 ```
 
+Desktop sidecar/keychain flow (recommended):
+- Configure Kraken publisher credentials in Seren Desktop Settings → Publisher MCPs
+- Keep default publisher slug order (`kraken-trading`, fallback `kraken-spot-trading`)
+
 Get your Seren API key at: https://serendb.com
 
 Optional MCP-native SerenDB settings in `.env`:
@@ -234,6 +238,15 @@ Create a `.env` file with your API key:
 ```bash
 echo "SEREN_API_KEY=sb_your_key_here" > .env
 ```
+
+### "Kraken publisher authentication failed"
+
+This means Desktop publisher credentials are not configured/authorized.
+
+1. Open Seren Desktop → Settings → Publisher MCPs
+2. Configure Kraken publisher API key
+3. Ensure publisher is enabled
+4. Retry the bot
 
 ### "Insufficient funds"
 

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -20,10 +20,11 @@ Grid trading places buy and sell orders at regular price intervals (the "grid").
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in your Seren API credentials
-2. Copy `config.example.json` to `config.json` and configure your grid parameters
-3. Install dependencies: `pip install -r requirements.txt`
-4. Run: `python scripts/agent.py`
+1. Configure Kraken publisher credentials in Seren Desktop Settings → Publisher MCPs (desktop sidecar/keychain flow)
+2. Copy `.env.example` to `.env` and set `SEREN_API_KEY`
+3. Copy `config.example.json` to `config.json` and configure your grid parameters
+4. Install dependencies: `pip install -r requirements.txt`
+5. Run: `python scripts/agent.py`
 
 ## SerenDB Persistence (MCP-native)
 

--- a/kraken/money-mode-router/config.example.json
+++ b/kraken/money-mode-router/config.example.json
@@ -1,7 +1,7 @@
 {
   "skill_name": "Kraken Money Mode Router",
   "available_publishers": [
-    "kraken-spot-trading",
+    "kraken-trading",
     "kraken-ramp"
   ],
   "mode_order": [
@@ -49,10 +49,10 @@
   },
   "publisher_requirements": {
     "payments": ["kraken-ramp"],
-    "investing": ["kraken-spot-trading"],
-    "active-trading": ["kraken-spot-trading"],
-    "onchain": ["kraken-spot-trading"],
-    "automation": ["kraken-spot-trading"]
+    "investing": ["kraken-trading"],
+    "active-trading": ["kraken-trading"],
+    "onchain": ["kraken-trading"],
+    "automation": ["kraken-trading"]
   },
   "mode_endpoint_catalog": {
     "payments": [
@@ -63,29 +63,29 @@
       {"publisher": "kraken-ramp", "method": "GET", "path": "/b2b/ramp/checkout"}
     ],
     "investing": [
-      {"publisher": "kraken-spot-trading", "method": "GET", "path": "/public/AssetPairs"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/Balance"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrder"}
+      {"publisher": "kraken-trading", "method": "GET", "path": "/public/AssetPairs"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/Balance"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/AddOrder"}
     ],
     "active-trading": [
-      {"publisher": "kraken-spot-trading", "method": "GET", "path": "/public/Ticker"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/OpenOrders"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrder"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelOrder"}
+      {"publisher": "kraken-trading", "method": "GET", "path": "/public/Ticker"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/OpenOrders"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/AddOrder"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/CancelOrder"}
     ],
     "onchain": [
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/DepositMethods"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/DepositAddresses"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WithdrawMethods"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WithdrawInfo"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/Withdraw"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/WalletTransfer"}
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/DepositMethods"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/DepositAddresses"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/WithdrawMethods"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/WithdrawInfo"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/Withdraw"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/WalletTransfer"}
     ],
     "automation": [
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/AddOrderBatch"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelOrderBatch"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/CancelAllOrdersAfter"},
-      {"publisher": "kraken-spot-trading", "method": "POST", "path": "/private/GetWebSocketsToken"}
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/AddOrderBatch"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/CancelOrderBatch"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/CancelAllOrdersAfter"},
+      {"publisher": "kraken-trading", "method": "POST", "path": "/private/GetWebSocketsToken"}
     ]
   }
 }

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -217,9 +217,6 @@ def _env_flag(name: str, default: bool = True) -> bool:
 
 def _build_store_from_env() -> SerenDBStore:
     api_key = _get_seren_api_key()
-    if not api_key:
-        raise ValueError("SEREN_API_KEY is required (or API_KEY when launched by Seren Desktop).")
-
     return SerenDBStore(
         api_key=api_key,
         project_name=os.getenv("SERENDB_PROJECT_NAME"),

--- a/kraken/money-mode-router/scripts/serendb_store.py
+++ b/kraken/money-mode-router/scripts/serendb_store.py
@@ -24,7 +24,7 @@ class DBTarget:
 
 
 class _SerenMCPClient:
-    def __init__(self, api_key: str, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
+    def __init__(self, api_key: Optional[str] = None, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
         self.api_key = api_key
         self.mcp_command = mcp_command
         self.timeout_seconds = timeout_seconds
@@ -36,7 +36,8 @@ class _SerenMCPClient:
             return
 
         env = os.environ.copy()
-        env["API_KEY"] = self.api_key
+        if self.api_key:
+            env["API_KEY"] = self.api_key
 
         self._process = subprocess.Popen(
             [self.mcp_command, "start"],
@@ -183,7 +184,7 @@ class SerenDBStore:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: Optional[str] = None,
         project_name: Optional[str] = None,
         database_name: Optional[str] = None,
         branch_name: Optional[str] = None,

--- a/polymarket/bot/.env.example
+++ b/polymarket/bot/.env.example
@@ -2,12 +2,20 @@
 # Get your API key from: https://app.serendb.com/settings/api-keys
 SEREN_API_KEY=your_seren_api_key_here
 
-# Polymarket API Credentials
-# Get these from: https://polymarket.com (Settings > API Keys > Derive API Key)
-POLY_API_KEY=your_polymarket_api_key_here
-POLY_PASSPHRASE=your_polymarket_passphrase_here
-POLY_SECRET=your_polymarket_secret_here
-POLY_ADDRESS=your_wallet_address_here
+# Desktop sidecar/keychain mode (recommended)
+# In Seren Desktop, configure Polymarket publisher credentials in Settings > Publisher MCPs.
+# No POLY_* vars are required in this mode.
+SEREN_DESKTOP_PUBLISHER_AUTH=true
+
+# Optional publisher slug override (default tries sidecar slug first, then legacy fallback)
+# POLYMARKET_TRADING_PUBLISHERS=polymarket-trading,polymarket-trading-serenai
+
+# Legacy direct header mode (optional fallback)
+# Set SEREN_DESKTOP_PUBLISHER_AUTH=false to force this mode.
+# POLY_API_KEY=your_polymarket_api_key_here
+# POLY_PASSPHRASE=your_polymarket_passphrase_here
+# POLY_SECRET=your_polymarket_secret_here
+# POLY_ADDRESS=your_wallet_address_here
 
 # Optional: Specify custom Seren gateway URL
 # SEREN_GATEWAY_URL=https://api.serendb.com

--- a/polymarket/bot/IMPLEMENTATION_STATUS.md
+++ b/polymarket/bot/IMPLEMENTATION_STATUS.md
@@ -20,7 +20,8 @@
 
 ### Configuration
 - ✅ **config.example.json** - Risk parameter template
-- ✅ Environment variable-based credential management
+- ✅ Desktop sidecar/keychain auth mode (default)
+- ✅ Environment variable-based legacy credential fallback
 - ✅ Dry-run mode support
 
 ### Features Implemented
@@ -35,7 +36,7 @@
 - ✅ Dry-run mode
 - ✅ Configuration validation
 - ✅ Market scanning via polymarket-data publisher
-- ✅ Order placement via polymarket-trading-serenai (handles EIP-712 signing server-side)
+- ✅ Order placement via sidecar-first trading publisher path (legacy fallback included)
 
 ### Legal & Compliance
 - ✅ Geographic restriction warnings (US ban)
@@ -67,21 +68,21 @@
 ---
 
 #### 2. Order Placement ✅ **COMPLETED**
-**Status:** Fully implemented via polymarket-trading-serenai publisher
+**Status:** Fully implemented with sidecar-first publisher routing and legacy fallback
 
 **What was added:**
-- Order placement via polymarket-trading-serenai Seren MCP publisher
+- Order placement via sidecar slug (`polymarket-trading`) with fallback to `polymarket-trading-serenai`
 - EIP-712 signing handled server-side by the publisher
 - Simplified client-side code (no cryptography needed)
-- Uses Polymarket API credentials for authentication
+- Supports desktop keychain auth by default, legacy `POLY_*` headers as fallback
 
 **Implementation:**
-- `place_order()` calls polymarket-trading-serenai publisher with order params
+- `place_order()` routes through `PolymarketClient._call_trading()` publisher fallback chain
 - Publisher handles all EIP-712 signing, nonce management, and submission
-- Credentials passed via headers (POLY_API_KEY, POLY_PASSPHRASE, POLY_ADDRESS)
+- Desktop mode uses configured publisher credentials; legacy mode passes `POLY_*` headers
 - No client-side private key or signing library required
 
-**Note:** The polymarket-trading-serenai MCP server abstracts away all cryptographic complexity
+**Note:** Polymarket trading publishers abstract away cryptographic complexity
 
 ---
 

--- a/polymarket/bot/QUICKSTART.md
+++ b/polymarket/bot/QUICKSTART.md
@@ -37,13 +37,20 @@ pip3 install -r requirements.txt
 cp .env.example .env
 ```
 
-Edit `.env` and add your SEREN_API_KEY:
+Edit `.env` and add:
 
 ```bash
 SEREN_API_KEY=your_actual_key_here
+SEREN_DESKTOP_PUBLISHER_AUTH=true
 ```
 
-For testing, you can use mock Polymarket credentials. For live trading, get real ones from [polymarket.com/settings/api](https://polymarket.com/settings/api).
+Desktop sidecar/keychain mode (recommended):
+- Configure Polymarket publisher credentials in Seren Desktop Settings → Publisher MCPs
+- No `POLY_*` vars required in this mode
+
+Legacy fallback:
+- Set `SEREN_DESKTOP_PUBLISHER_AUTH=false`
+- Add `POLY_API_KEY`, `POLY_PASSPHRASE`, `POLY_SECRET`, `POLY_ADDRESS`
 
 ### 3. Create `config.json`
 
@@ -81,7 +88,7 @@ The bot will:
 
 ### Live Trading Mode
 
-⚠️ **Only use this with real Polymarket credentials and $550+ budget**
+⚠️ **Only use this with real Polymarket publisher credentials and $550+ budget**
 
 1. Start the agent server:
 
@@ -122,6 +129,13 @@ cat .env | grep SEREN_API_KEY
 ```
 
 Make sure it's set and the file is in the same directory as the bot scripts.
+
+### "Polymarket desktop publisher authentication failed"
+
+Open Seren Desktop → Settings → Publisher MCPs and:
+1. Configure Polymarket publisher credentials
+2. Ensure the publisher is enabled
+3. Retry the bot
 
 ### "SSL Warning about LibreSSL"
 

--- a/polymarket/bot/README.md
+++ b/polymarket/bot/README.md
@@ -30,7 +30,16 @@ cp .env.example .env
 
 Edit `.env` and add:
 - **SEREN_API_KEY**: Get from [app.serendb.com/settings/api-keys](https://app.serendb.com/settings/api-keys)
-- **POLY_API_KEY, POLY_PASSPHRASE, POLY_ADDRESS**: Get from [polymarket.com](https://polymarket.com) (Settings > API Keys > Derive API Key)
+- **SEREN_DESKTOP_PUBLISHER_AUTH=true** (recommended): desktop sidecar/keychain auth flow
+
+Desktop sidecar/keychain flow (recommended):
+- Configure Polymarket publisher credentials in Seren Desktop Settings → Publisher MCPs
+- Keep `SEREN_DESKTOP_PUBLISHER_AUTH=true`
+- No `POLY_*` vars are required in this mode
+
+Legacy fallback (optional):
+- Set `SEREN_DESKTOP_PUBLISHER_AUTH=false`
+- Provide `POLY_API_KEY, POLY_PASSPHRASE, POLY_SECRET, POLY_ADDRESS` from [polymarket.com](https://polymarket.com) (Settings > API Keys > Derive API Key)
 
 ### 3. Create Configuration
 
@@ -119,7 +128,7 @@ polymarket-bot/
 - Caps at max_kelly_fraction of bankroll
 
 ### 6. Execution
-- Places orders via polymarket-trading-serenai publisher
+- Places orders via Polymarket trading publisher (desktop slug first, legacy fallback)
 - Tracks positions with entry price and size
 - Logs all activity to JSONL files
 

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -155,7 +155,8 @@ This skill helps users set up and manage an autonomous trading agent that:
 
 **Pure Python Implementation**
 - Python agent calls Seren publishers via HTTP
-- Credentials stored in `.env` file (environment variables)
+- Desktop sidecar/keychain publisher auth is the default path
+- Legacy direct `POLY_*` headers remain as fallback
 - Logs written to JSONL files
 - Seren-cron executes Python script on schedule
 
@@ -173,10 +174,11 @@ This skill helps users set up and manage an autonomous trading agent that:
   - Response includes: market IDs, questions, token IDs, prices, liquidity
   - Verified working with 100+ markets returned
 
-- `polymarket-trading-serenai` - Polymarket CLOB trading API
+- `polymarket-trading` (preferred) / `polymarket-trading-serenai` (fallback) - Polymarket CLOB trading API
   - Place/cancel orders with server-side EIP-712 signing
   - Query positions, open orders, balances
-  - Requires Polymarket L2 credentials (API key, passphrase, secret, address)
+  - Desktop mode: uses keychain-backed publisher credentials
+  - Legacy mode: requires Polymarket L2 credentials (API key, passphrase, secret, address)
 
 - `perplexity` - Perplexity AI research (via OpenRouter)
   - Model: `sonar` for fast research
@@ -219,21 +221,27 @@ Create `.env` file from template:
 cp .env.example .env
 ```
 
-Edit `.env` and add your credentials:
+Edit `.env`:
 
 ```bash
 # Seren API key - get from https://app.serendb.com/settings/api-keys
 SEREN_API_KEY=your_seren_api_key_here
 
-# Polymarket credentials - get from https://polymarket.com
-# (Settings > API Keys > Derive API Key)
-POLY_API_KEY=your_polymarket_api_key_here
-POLY_PASSPHRASE=your_polymarket_passphrase_here
-POLY_SECRET=your_polymarket_secret_here
-POLY_ADDRESS=your_wallet_address_here
+# Desktop sidecar/keychain mode (recommended)
+SEREN_DESKTOP_PUBLISHER_AUTH=true
 ```
 
-**How to get Polymarket credentials:**
+**Desktop sidecar flow (recommended):**
+1. Open Seren Desktop
+2. Go to Settings > Publisher MCPs
+3. Configure Polymarket publisher credentials
+4. Ensure publisher is enabled
+
+**Legacy fallback mode (optional):**
+Set `SEREN_DESKTOP_PUBLISHER_AUTH=false` and provide:
+`POLY_API_KEY`, `POLY_PASSPHRASE`, `POLY_SECRET`, `POLY_ADDRESS`
+
+**How to derive Polymarket credentials (legacy mode):**
 1. Visit [polymarket.com](https://polymarket.com)
 2. Connect your wallet
 3. Navigate to Settings > API Keys
@@ -846,19 +854,20 @@ def calculate_position_size(fair_value, market_price, bankroll, max_kelly=0.06):
 - ✅ AI research via `perplexity` publisher (Perplexity AI integration)
 - ✅ Fair value estimation via `seren-models` publisher (Claude Sonnet 4.5)
 - ✅ Kelly Criterion position sizing
-- ✅ Order placement via `polymarket-trading-serenai` publisher (server-side EIP-712 signing)
+- ✅ Order placement via sidecar-first trading publisher path (`polymarket-trading` with legacy fallback)
 - ✅ Position tracking with unrealized P&L calculation
 - ✅ Comprehensive JSONL logging (trades, scans, positions)
 
 **Infrastructure:**
 - ✅ Seren API client with publisher routing
-- ✅ Environment variable credential management
+- ✅ Desktop sidecar/keychain publisher auth support
+- ✅ Legacy environment-variable credential fallback
 - ✅ Dry-run mode (simulation without placing trades)
 - ✅ Configuration system (JSON-based risk parameters)
 
 **Seren Publishers Used:**
 - `polymarket-data` - Real-time market data (prices, liquidity, volumes)
-- `polymarket-trading-serenai` - Order placement with server-side signing
+- `polymarket-trading` / `polymarket-trading-serenai` - Order placement with server-side signing
 - `perplexity` - AI-powered market research
 - `seren-models` - LLM inference (Claude, GPT, Gemini, etc.)
 - `seren-cron` - Autonomous job scheduling
@@ -904,15 +913,17 @@ Per scan cycle:
 - Add your Seren API key
 
 ### "Polymarket credentials required"
-- Add `POLY_API_KEY`, `POLY_PASSPHRASE`, `POLY_ADDRESS` to `.env`
+- Recommended: enable desktop keychain mode in `.env` with `SEREN_DESKTOP_PUBLISHER_AUTH=true`
+- Then configure Polymarket publisher credentials in Seren Desktop Settings > Publisher MCPs
+- Legacy mode only: add `POLY_API_KEY`, `POLY_PASSPHRASE`, `POLY_ADDRESS` to `.env`
 
 ### "Low SerenBucks balance"
 - Deposit at: https://app.serendb.com/wallet/deposit
 - Maintain at least $20 for smooth operation
 
 ### "Publisher call failed: 401"
-- Check your API keys are correct
-- Verify credentials haven't expired
+- In desktop mode: verify Polymarket publisher credentials are configured/enabled in Seren Desktop
+- In legacy mode: check `POLY_*` values and verify credentials haven't expired
 
 ---
 

--- a/polymarket/bot/requirements.txt
+++ b/polymarket/bot/requirements.txt
@@ -2,7 +2,7 @@
 #
 # This skill uses Seren publishers for all Polymarket operations:
 # - polymarket-data: Market data (prices, volume, liquidity)
-# - polymarket-trading-serenai: Trading operations (orders, positions, balance)
+# - polymarket-trading / polymarket-trading-serenai: Trading operations
 
 # Core dependencies
 requests>=2.31.0

--- a/polymarket/bot/scripts/seren_client.py
+++ b/polymarket/bot/scripts/seren_client.py
@@ -2,7 +2,7 @@
 Seren Client - HTTP client for calling Seren MCP publishers
 
 Handles authentication and routing to Seren publishers:
-- polymarket-trading-serenai (market data + trading)
+- polymarket-trading / polymarket-trading-serenai (trading)
 - perplexity (AI-powered research)
 - seren-models (LLM inference)
 - seren-cron (job scheduling)
@@ -28,7 +28,7 @@ class SerenClient:
         if not self.api_key:
             raise ValueError("SEREN_API_KEY is required")
 
-        self.gateway_url = "https://api.serendb.com"
+        self.gateway_url = os.getenv('SEREN_GATEWAY_URL', "https://api.serendb.com")
         self.session = requests.Session()
         self.session.headers.update({
             'Authorization': f'Bearer {self.api_key}',

--- a/polymarket/bot/scripts/setup_test.sh
+++ b/polymarket/bot/scripts/setup_test.sh
@@ -51,12 +51,14 @@ else
 # Seren API credentials (REQUIRED)
 SEREN_API_KEY=$SEREN_API_KEY
 
-# Polymarket credentials (optional for dry-run testing)
-# For live trading, get these from https://polymarket.com/settings/api
-POLY_API_KEY=mock_key_for_testing
-POLY_PASSPHRASE=mock_passphrase_for_testing
-POLY_SECRET=mock_secret_for_testing
-POLY_ADDRESS=0xMockAddressForTesting
+# Desktop sidecar/keychain mode (recommended)
+SEREN_DESKTOP_PUBLISHER_AUTH=true
+
+# Optional legacy fallback (set SEREN_DESKTOP_PUBLISHER_AUTH=false)
+# POLY_API_KEY=mock_key_for_testing
+# POLY_PASSPHRASE=mock_passphrase_for_testing
+# POLY_SECRET=mock_secret_for_testing
+# POLY_ADDRESS=0xMockAddressForTesting
 EOF2
 
     echo "✅ .env created"
@@ -107,7 +109,8 @@ echo "2. Run a single dry-run scan (no live trades):"
 echo "   python3 scripts/agent.py --config config.json --dry-run"
 echo ""
 echo "3. When ready for live trading:"
-echo "   - Update .env with real Polymarket API credentials"
+echo "   - Configure Polymarket publisher credentials in Seren Desktop Settings > Publisher MCPs"
+echo "     (or set SEREN_DESKTOP_PUBLISHER_AUTH=false and provide POLY_* in .env)"
 echo "   - Review config.json risk parameters"
 echo "   - Ensure you have $550+ total budget (see SKILL.md Phase 4)"
 echo "   - Start the agent server: python3 scripts/run_agent_server.py --config config.json"

--- a/polymarket/bot/scripts/test_dry_run.py
+++ b/polymarket/bot/scripts/test_dry_run.py
@@ -38,28 +38,33 @@ print()
 # Test 2: Check environment
 print("Test 2: Checking environment...")
 required_vars = ['SEREN_API_KEY']
-optional_vars = ['POLY_API_KEY', 'POLY_PASSPHRASE', 'POLY_ADDRESS']
+legacy_optional_vars = ['POLY_API_KEY', 'POLY_PASSPHRASE', 'POLY_ADDRESS']
 
 missing_required = []
-missing_optional = []
+missing_legacy_optional = []
 
 for var in required_vars:
     if not os.getenv(var):
         missing_required.append(var)
 
-for var in optional_vars:
+for var in legacy_optional_vars:
     if not os.getenv(var):
-        missing_optional.append(var)
+        missing_legacy_optional.append(var)
 
 if missing_required:
     print(f"❌ Missing required: {', '.join(missing_required)}")
     print("   Set SEREN_API_KEY in .env file or environment")
     sys.exit(1)
 
-if missing_optional:
-    print(f"⚠️  Missing optional (Polymarket trading disabled): {', '.join(missing_optional)}")
+desktop_auth = os.getenv('SEREN_DESKTOP_PUBLISHER_AUTH', 'true').strip().lower() in (
+    '1', 'true', 'yes', 'y', 'on'
+)
+if desktop_auth:
+    print("✅ Desktop publisher-auth mode enabled (SEREN_DESKTOP_PUBLISHER_AUTH=true)")
+elif missing_legacy_optional:
+    print(f"⚠️  Missing optional legacy POLY_* vars: {', '.join(missing_legacy_optional)}")
 else:
-    print("✅ All Polymarket credentials found")
+    print("✅ Legacy Polymarket credentials found")
 
 print("✅ SEREN_API_KEY found")
 print()

--- a/polymarket/bot/scripts/test_polymarket_client_auth.py
+++ b/polymarket/bot/scripts/test_polymarket_client_auth.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for PolymarketClient auth mode and trading publisher fallback behavior.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from polymarket_client import PolymarketClient
+
+
+def _mock_seren():
+    client = MagicMock()
+    client.call_publisher = MagicMock()
+    return client
+
+
+class TestPolymarketClientAuthMode:
+    def test_defaults_to_desktop_mode_without_poly_credentials(self):
+        seren = _mock_seren()
+        client = PolymarketClient(
+            seren_client=seren,
+            poly_api_key=None,
+            poly_passphrase=None,
+            poly_secret=None,
+            poly_address=None,
+        )
+        assert client.desktop_publisher_auth is True
+        assert client.auth_mode == 'desktop_publisher_auth'
+        assert client._get_auth_headers() == {}
+
+    def test_legacy_header_mode_when_credentials_present(self):
+        seren = _mock_seren()
+        client = PolymarketClient(
+            seren_client=seren,
+            poly_api_key='k',
+            poly_passphrase='p',
+            poly_secret='s',
+            poly_address='0xabc',
+        )
+        assert client.desktop_publisher_auth is False
+        assert client.auth_mode == 'direct_polymarket_headers'
+        assert client._get_auth_headers()['POLY_API_KEY'] == 'k'
+
+    def test_forced_legacy_mode_requires_credentials(self):
+        seren = _mock_seren()
+        with pytest.raises(ValueError, match=r"Polymarket credentials required"):
+            PolymarketClient(
+                seren_client=seren,
+                desktop_publisher_auth=False,
+            )
+
+
+class TestPolymarketClientTradingFallback:
+    def test_falls_back_to_legacy_slug_on_404(self):
+        seren = _mock_seren()
+        seren.call_publisher.side_effect = [
+            Exception("Publisher call failed: 404 - not found"),
+            {'data': []},
+        ]
+        client = PolymarketClient(seren_client=seren)
+
+        result = client._call_trading(method='GET', path='/positions')
+        assert result == {'data': []}
+        assert seren.call_publisher.call_count == 2
+        first_call = seren.call_publisher.call_args_list[0].kwargs
+        second_call = seren.call_publisher.call_args_list[1].kwargs
+        assert first_call['publisher'] == 'polymarket-trading'
+        assert second_call['publisher'] == 'polymarket-trading-serenai'
+
+    def test_desktop_auth_unauthorized_raises_helpful_error(self):
+        seren = _mock_seren()
+        seren.call_publisher.side_effect = Exception("Publisher call failed: 401 - unauthorized")
+        client = PolymarketClient(seren_client=seren)
+
+        with pytest.raises(Exception, match=r"desktop publisher authentication failed"):
+            client._call_trading(method='GET', path='/positions')


### PR DESCRIPTION
## Summary
- Migrate Kraken Money Mode Router persistence to local `seren-mcp` tool calls.
- Remove hard failure on missing `SEREN_API_KEY` for router flows when desktop MCP auth/session is available.
- Update Coinbase and Kraken Grid Trader clients + docs/env samples for desktop publisher-auth mode.
- Update Polymarket Bot auth-mode behavior with trading publisher fallback and add auth-mode coverage tests.

## Validation
- `python3 -m compileall coinbase/grid-trader/scripts kraken/grid-trader/scripts kraken/money-mode-router/scripts polymarket/bot/scripts`
- `pytest -q coinbase/grid-trader/scripts/test_seren_client.py polymarket/bot/scripts/test_polymarket_client_auth.py` (run in temporary venv)

## Notes
- Excluded local/untracked artifacts from commit: `.claude/`, `seren/customer-support-intake/tests/__pycache__/`, and `kraken/money-mode-router/scripts/serendb_bootstrap.py`.
