### PR TITLE
feat: support desktop runtime API_KEY auth for polymarket bot

### DIFF
--- a/polymarket/bot/QUICKSTART.md
+++ b/polymarket/bot/QUICKSTART.md
@@ -6,7 +6,9 @@ Get the Polymarket Trading Bot running in 5 minutes.
 
 - Python 3.9+
 - $550+ total budget (see [SKILL.md Phase 4](SKILL.md#phase-4-fund-your-wallets) for why)
-- Seren API key from [app.serendb.com/settings/api-keys](https://app.serendb.com/settings/api-keys)
+- Seren gateway auth via:
+  - `SEREN_API_KEY` (standalone), or
+  - runtime `API_KEY` when launched by Seren Desktop
 
 ## One-Command Setup (Recommended)
 
@@ -16,7 +18,7 @@ Get the Polymarket Trading Bot running in 5 minutes.
 
 This script will:
 - ✅ Install Python dependencies
-- ✅ Create `.env` with your SEREN_API_KEY
+- ✅ Create `.env` with desktop-auth defaults
 - ✅ Create `config.json` with safe defaults
 - ✅ Run syntax validation tests
 - ✅ Run dry-run tests
@@ -66,7 +68,7 @@ Review the settings - defaults are safe for testing.
 # Syntax validation (no credentials needed)
 python3 scripts/test_syntax.py
 
-# Dry-run test (needs SEREN_API_KEY)
+# Dry-run test (needs SEREN_API_KEY or runtime API_KEY)
 python3 scripts/test_dry_run.py
 ```
 
@@ -120,7 +122,7 @@ tail -f logs/trading_*.log
 pip3 install -r requirements.txt
 ```
 
-### "SEREN_API_KEY not found"
+### "SEREN_API_KEY/API_KEY not found"
 
 Check your `.env` file:
 
@@ -128,7 +130,7 @@ Check your `.env` file:
 cat .env | grep SEREN_API_KEY
 ```
 
-Make sure it's set and the file is in the same directory as the bot scripts.
+For desktop-launched runs, `API_KEY` may be injected automatically.
 
 ### "Polymarket desktop publisher authentication failed"
 

--- a/polymarket/bot/README.md
+++ b/polymarket/bot/README.md
@@ -29,8 +29,8 @@ cp .env.example .env
 ```
 
 Edit `.env` and add:
-- **SEREN_API_KEY**: Get from [app.serendb.com/settings/api-keys](https://app.serendb.com/settings/api-keys)
-- **SEREN_DESKTOP_PUBLISHER_AUTH=true** (recommended): desktop sidecar/keychain auth flow
+- **SEREN_API_KEY** (or runtime `API_KEY` when launched by Seren Desktop): Get from [app.serendb.com/settings/api-keys](https://app.serendb.com/settings/api-keys)
+- **SEREN_DESKTOP_PUBLISHER_AUTH=true** (recommended): use desktop sidecar/keychain publisher auth
 
 Desktop sidecar/keychain flow (recommended):
 - Configure Polymarket publisher credentials in Seren Desktop Settings → Publisher MCPs

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -221,10 +221,10 @@ Create `.env` file from template:
 cp .env.example .env
 ```
 
-Edit `.env`:
+Edit `.env` and add:
 
 ```bash
-# Seren API key - get from https://app.serendb.com/settings/api-keys
+# Seren API key (standalone mode) - get from https://app.serendb.com/settings/api-keys
 SEREN_API_KEY=your_seren_api_key_here
 
 # Desktop sidecar/keychain mode (recommended)
@@ -867,7 +867,7 @@ def calculate_position_size(fair_value, market_price, bankroll, max_kelly=0.06):
 
 **Seren Publishers Used:**
 - `polymarket-data` - Real-time market data (prices, liquidity, volumes)
-- `polymarket-trading` / `polymarket-trading-serenai` - Order placement with server-side signing
+- `polymarket-trading` (preferred) / `polymarket-trading-serenai` (fallback) - Order placement with server-side signing
 - `perplexity` - AI-powered market research
 - `seren-models` - LLM inference (Claude, GPT, Gemini, etc.)
 - `seren-cron` - Autonomous job scheduling
@@ -908,9 +908,10 @@ Per scan cycle:
 
 ## Troubleshooting
 
-### "SEREN_API_KEY is required"
+### "SEREN_API_KEY/API_KEY is required"
 - Create `.env` file from `.env.example`
-- Add your Seren API key
+- Add `SEREN_API_KEY` for standalone runs
+- For desktop-launched runs, ensure runtime `API_KEY` is injected
 
 ### "Polymarket credentials required"
 - Recommended: enable desktop keychain mode in `.env` with `SEREN_DESKTOP_PUBLISHER_AUTH=true`

--- a/polymarket/bot/scripts/seren_client.py
+++ b/polymarket/bot/scripts/seren_client.py
@@ -22,11 +22,14 @@ class SerenClient:
         Initialize Seren client
 
         Args:
-            api_key: Seren API key (defaults to SEREN_API_KEY env var)
+            api_key: Seren API key (defaults to SEREN_API_KEY or API_KEY env var)
         """
-        self.api_key = api_key or os.getenv('SEREN_API_KEY')
+        self.api_key = api_key or os.getenv('SEREN_API_KEY') or os.getenv('API_KEY')
         if not self.api_key:
-            raise ValueError("SEREN_API_KEY is required")
+            raise ValueError(
+                "Seren API key is required. Set SEREN_API_KEY (standalone) "
+                "or API_KEY (Seren Desktop runtime)."
+            )
 
         self.gateway_url = os.getenv('SEREN_GATEWAY_URL', "https://api.serendb.com")
         self.session = requests.Session()

--- a/polymarket/bot/scripts/setup_cron.py
+++ b/polymarket/bot/scripts/setup_cron.py
@@ -48,7 +48,10 @@ def main():
         print()
     except Exception as e:
         print(f"Error initializing Seren client: {e}")
-        print("\nMake sure SEREN_API_KEY is set in your .env file or environment.")
+        print(
+            "\nMake sure SEREN_API_KEY (standalone) or API_KEY "
+            "(Seren Desktop runtime) is available."
+        )
         sys.exit(1)
 
     # Create cron job

--- a/polymarket/bot/scripts/setup_serendb.py
+++ b/polymarket/bot/scripts/setup_serendb.py
@@ -64,14 +64,16 @@ def main():
     print()
 
     # Check for API key
-    if not os.getenv('SEREN_API_KEY'):
-        print("❌ Error: SEREN_API_KEY environment variable not set")
+    if not (os.getenv('SEREN_API_KEY') or os.getenv('API_KEY')):
+        print("❌ Error: Seren API key not found")
         print()
-        print("Set your API key:")
+        print("Set your API key (standalone mode):")
         print("  export SEREN_API_KEY='your-api-key'")
         print()
         print("Or add it to .env file:")
         print("  SEREN_API_KEY=your-api-key")
+        print()
+        print("When launched by Seren Desktop, API_KEY may be injected automatically.")
         print()
         sys.exit(1)
 

--- a/polymarket/bot/scripts/setup_test.sh
+++ b/polymarket/bot/scripts/setup_test.sh
@@ -38,27 +38,34 @@ if [ -f .env ]; then
     echo "   To reconfigure, delete .env and run this script again"
 else
     echo ""
-    echo "Enter your SEREN_API_KEY (required for testing):"
+    echo "Enter your SEREN_API_KEY (optional if API_KEY is injected by Seren Desktop):"
     echo "(Get it from https://app.serendb.com/settings/api-keys)"
     read -r SEREN_API_KEY
 
-    if [ -z "$SEREN_API_KEY" ]; then
-        echo "❌ SEREN_API_KEY is required"
+    if [ -z "$SEREN_API_KEY" ] && [ -z "${API_KEY:-}" ]; then
+        echo "❌ Missing gateway key. Provide SEREN_API_KEY or run with API_KEY injected."
         exit 1
     fi
 
+    if [ -n "$SEREN_API_KEY" ]; then
+        SEREN_KEY_LINE="SEREN_API_KEY=$SEREN_API_KEY"
+    else
+        SEREN_KEY_LINE="# SEREN_API_KEY is not set here (using runtime API_KEY instead)"
+    fi
+
     cat > .env << EOF2
-# Seren API credentials (REQUIRED)
-SEREN_API_KEY=$SEREN_API_KEY
+# Seren API credentials (required via SEREN_API_KEY or runtime API_KEY)
+$SEREN_KEY_LINE
 
 # Desktop sidecar/keychain mode (recommended)
+# Configure Polymarket publisher credentials in Seren Desktop Settings > Publisher MCPs.
 SEREN_DESKTOP_PUBLISHER_AUTH=true
 
 # Optional legacy fallback (set SEREN_DESKTOP_PUBLISHER_AUTH=false)
-# POLY_API_KEY=mock_key_for_testing
-# POLY_PASSPHRASE=mock_passphrase_for_testing
-# POLY_SECRET=mock_secret_for_testing
-# POLY_ADDRESS=0xMockAddressForTesting
+# POLY_API_KEY=your_polymarket_api_key
+# POLY_PASSPHRASE=your_polymarket_passphrase
+# POLY_SECRET=your_polymarket_secret
+# POLY_ADDRESS=your_wallet_address
 EOF2
 
     echo "✅ .env created"

--- a/polymarket/bot/scripts/test_dry_run.py
+++ b/polymarket/bot/scripts/test_dry_run.py
@@ -37,23 +37,19 @@ print()
 
 # Test 2: Check environment
 print("Test 2: Checking environment...")
-required_vars = ['SEREN_API_KEY']
-legacy_optional_vars = ['POLY_API_KEY', 'POLY_PASSPHRASE', 'POLY_ADDRESS']
+optional_vars = ['POLY_API_KEY', 'POLY_PASSPHRASE', 'POLY_ADDRESS']
 
-missing_required = []
-missing_legacy_optional = []
+missing_optional = []
+seren_api_key = os.getenv('SEREN_API_KEY') or os.getenv('API_KEY')
 
-for var in required_vars:
+for var in optional_vars:
     if not os.getenv(var):
-        missing_required.append(var)
+        missing_optional.append(var)
 
-for var in legacy_optional_vars:
-    if not os.getenv(var):
-        missing_legacy_optional.append(var)
-
-if missing_required:
-    print(f"❌ Missing required: {', '.join(missing_required)}")
-    print("   Set SEREN_API_KEY in .env file or environment")
+if not seren_api_key:
+    print("❌ Missing required key: SEREN_API_KEY or API_KEY")
+    print("   Set SEREN_API_KEY in .env for standalone runs")
+    print("   or launch via Seren Desktop with API_KEY injected")
     sys.exit(1)
 
 desktop_auth = os.getenv('SEREN_DESKTOP_PUBLISHER_AUTH', 'true').strip().lower() in (
@@ -61,12 +57,12 @@ desktop_auth = os.getenv('SEREN_DESKTOP_PUBLISHER_AUTH', 'true').strip().lower()
 )
 if desktop_auth:
     print("✅ Desktop publisher-auth mode enabled (SEREN_DESKTOP_PUBLISHER_AUTH=true)")
-elif missing_legacy_optional:
-    print(f"⚠️  Missing optional legacy POLY_* vars: {', '.join(missing_legacy_optional)}")
+elif missing_optional:
+    print(f"⚠️  Missing optional legacy POLY_* vars: {', '.join(missing_optional)}")
 else:
     print("✅ Legacy Polymarket credentials found")
 
-print("✅ SEREN_API_KEY found")
+print("✅ Seren gateway key found (SEREN_API_KEY/API_KEY)")
 print()
 
 # Test 3: Initialize Seren client


### PR DESCRIPTION
## Summary
- allow `polymarket/bot` gateway client to authenticate with `SEREN_API_KEY` (standalone) or `API_KEY` (Seren Desktop runtime)
- remove hard `SEREN_API_KEY`-only setup gate in setup and dry-run scripts
- update setup/docs to default to desktop sidecar/keychain publisher auth with legacy `POLY_*` fallback
- add unit tests for api key resolution precedence in `SerenClient`

## Testing
- `./.test-venv/bin/pytest -q polymarket/bot/scripts/test_seren_client.py polymarket/bot/scripts/test_pipeline.py`
- `python3 polymarket/bot/scripts/test_syntax.py`
