### PR TITLE
feat(wellsfargo): increase default statement retrieval from 3 to 12 months

### DIFF
--- a/wellsfargo/bank-statement-processing/SKILL.md
+++ b/wellsfargo/bank-statement-processing/SKILL.md
@@ -28,7 +28,7 @@ description: "Wells Fargo bank statement retrieval skill for Seren Desktop: runt
   - Firefox path preserves the historically stable flow.
   - Chrome path enables isolated recovery/fallback logic for Chrome-only issues.
 - The run enforces a single active process lock per artifact directory to prevent multiple browser windows from concurrent runs.
-- The run enforces a minimum of 3 months of statements.
+- The run defaults to 12 months of statements (minimum 3).
 
 ## Workflow Summary
 
@@ -70,7 +70,7 @@ seren auth
 2. Run end-to-end (read-only):
 
 ```bash
-python3 scripts/run.py --config config.json --mode read-only --months 3 --out artifacts/wellsfargo
+python3 scripts/run.py --config config.json --mode read-only --months 12 --out artifacts/wellsfargo
 ```
 
 3. Resume a prior interrupted run:
@@ -83,16 +83,16 @@ python3 scripts/run.py --config config.json --mode read-only --resume --out arti
 
 ```bash
 # End-to-end run
-python3 scripts/run.py --mode read-only --months 3 --out artifacts/wellsfargo
+python3 scripts/run.py --mode read-only --months 12 --out artifacts/wellsfargo
 
 # End-to-end run with explicit browser override (skips browser prompt)
-python3 scripts/run.py --mode read-only --auth-method manual --browser-app "Google Chrome" --browser-type chrome --months 3 --out artifacts/wellsfargo
+python3 scripts/run.py --mode read-only --auth-method manual --browser-app "Google Chrome" --browser-type chrome --months 12 --out artifacts/wellsfargo
 
 # End-to-end run pinned to Firefox stable path
-python3 scripts/run.py --mode read-only --auth-method manual --browser-app "Firefox" --browser-type moz-firefox --months 3 --out artifacts/wellsfargo
+python3 scripts/run.py --mode read-only --auth-method manual --browser-app "Firefox" --browser-type moz-firefox --months 12 --out artifacts/wellsfargo
 
 # End-to-end run with passkey auth (requires local user approval prompt)
-python3 scripts/run.py --mode read-only --auth-method passkey --months 3 --out artifacts/wellsfargo
+python3 scripts/run.py --mode read-only --auth-method passkey --months 12 --out artifacts/wellsfargo
 
 # Parse local PDFs only (skip browser)
 python3 scripts/run.py --mode read-only --skip-download --out artifacts/wellsfargo

--- a/wellsfargo/bank-statement-processing/scripts/run.py
+++ b/wellsfargo/bank-statement-processing/scripts/run.py
@@ -41,6 +41,7 @@ from wf_download import (
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 MIN_STATEMENT_MONTHS = 3
+DEFAULT_STATEMENT_MONTHS = 12
 RUN_LOCK_FILENAME = ".run.lock.json"
 
 BROWSER_TARGETS: list[tuple[str, str]] = [
@@ -81,8 +82,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--months",
         type=int,
-        default=MIN_STATEMENT_MONTHS,
-        help=f"Number of statement rows to download (minimum {MIN_STATEMENT_MONTHS})",
+        default=DEFAULT_STATEMENT_MONTHS,
+        help=f"Number of statement rows to download (default {DEFAULT_STATEMENT_MONTHS}, minimum {MIN_STATEMENT_MONTHS})",
     )
     parser.add_argument("--out", default="artifacts/wellsfargo", help="Artifact root directory")
     parser.add_argument("--resume", action="store_true", help="Resume from checkpoint")

--- a/wellsfargo/bank-statement-processing/skill.spec.yaml
+++ b/wellsfargo/bank-statement-processing/skill.spec.yaml
@@ -17,7 +17,7 @@ inputs:
     type: integer
     min: 3
     max: 24
-    default: 3
+    default: 12
   out:
     type: string
     default: artifacts/wellsfargo


### PR DESCRIPTION
## Summary
- Changes the default `--months` value from 3 to 12 for the Wells Fargo bank statement processing skill
- Updates `run.py` (new `DEFAULT_STATEMENT_MONTHS = 12` constant, `--months` default and help text), `skill.spec.yaml` (default: 12), and `SKILL.md` (docs and example commands)
- The minimum of 3 months is preserved; only the default changes

## Test plan
- [ ] Verify `python3 scripts/run.py --help` shows default of 12 and minimum of 3
- [ ] Verify `--months 3` still works (minimum enforced)
- [ ] Verify omitting `--months` defaults to 12

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com