### PR TITLE
feat(wellsfargo): add income-statement skill

### DIFF
--- a/wellsfargo/income-statement/.env.example
+++ b/wellsfargo/income-statement/.env.example
@@ -1,0 +1,5 @@
+# Optional override: explicit SERENDB connection string.
+# If empty, scripts/run.py resolves this automatically from your logged-in
+# Seren CLI/MCP context via `seren env init`.
+# Example: postgresql://user:pass@host:5432/serendb
+WF_SERENDB_URL=

--- a/wellsfargo/income-statement/.gitignore
+++ b/wellsfargo/income-statement/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/income-statement/SKILL.md
+++ b/wellsfargo/income-statement/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: income-statement
+description: "Generate categorized income statements from Wells Fargo transaction data stored in SerenDB by the bank-statement-processing skill."
+---
+
+# Wells Fargo Income Statement
+
+## When To Use
+
+- Generate monthly or multi-month income statements from Wells Fargo transaction data.
+- Categorize transactions into income and expense line items.
+- Produce human-readable Markdown and machine-readable JSON reports.
+- Persist income statement snapshots into SerenDB for downstream analysis.
+
+## Prerequisites
+
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables (`wf_transactions`, `wf_txn_categories`, `wf_monthly_summary`).
+- Writes only to dedicated `wf_income_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+- All amounts sourced from already-masked account data.
+
+## Workflow Summary
+
+1. `resolve_serendb` connects to SerenDB using the same resolution chain as bank-statement-processing.
+2. `query_transactions` fetches categorized transactions for the requested date range.
+3. `classify_line_items` maps transaction categories to income statement line items using `config/line_item_map.json`.
+4. `build_statement` aggregates line items into Income, Expenses, and Net Income sections.
+5. `render_report` produces Markdown and JSON output files.
+6. `persist_statement` upserts the income statement snapshot into SerenDB.
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+cd wellsfargo/income-statement
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+cp config.example.json config.json
+```
+
+2. Generate an income statement for the last 12 months:
+
+```bash
+python3 scripts/run.py --config config.json --months 12 --out artifacts/income-statement
+```
+
+3. Generate a statement for a specific date range:
+
+```bash
+python3 scripts/run.py --config config.json --start 2025-01-01 --end 2025-12-31 --out artifacts/income-statement
+```
+
+## Commands
+
+```bash
+# Last 12 months (default)
+python3 scripts/run.py --config config.json --months 12 --out artifacts/income-statement
+
+# Specific date range
+python3 scripts/run.py --config config.json --start 2025-06-01 --end 2025-12-31 --out artifacts/income-statement
+
+# Single month
+python3 scripts/run.py --config config.json --start 2025-11-01 --end 2025-11-30 --out artifacts/income-statement
+
+# Skip SerenDB persistence (local reports only)
+python3 scripts/run.py --config config.json --months 12 --skip-persist --out artifacts/income-statement
+```
+
+## Outputs
+
+- Markdown report: `artifacts/income-statement/reports/<run_id>.md`
+- JSON report: `artifacts/income-statement/reports/<run_id>.json`
+- Line-item export: `artifacts/income-statement/exports/<run_id>.line_items.jsonl`
+
+## SerenDB Tables
+
+- `wf_income_runs` - income statement generation runs
+- `wf_income_line_items` - individual line items per run
+- `wf_income_snapshots` - summary totals per run
+
+## Reusable Views
+
+- `v_wf_income_latest` - most recent income statement snapshot
+- `v_wf_income_by_month` - monthly income/expense breakdown

--- a/wellsfargo/income-statement/config.example.json
+++ b/wellsfargo/income-statement/config.example.json
@@ -1,0 +1,18 @@
+{
+  "runtime": {
+    "artifacts_subdir": "income-statement"
+  },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
+  },
+  "line_item_map_path": "config/line_item_map.json"
+}

--- a/wellsfargo/income-statement/config/line_item_map.json
+++ b/wellsfargo/income-statement/config/line_item_map.json
@@ -1,0 +1,77 @@
+{
+  "_comment": "Maps wf_txn_categories.category values to income statement sections and line items.",
+  "income": {
+    "payroll": {
+      "label": "Salary & Wages",
+      "keywords": ["payroll", "direct deposit", "salary", "wages"]
+    },
+    "interest_income": {
+      "label": "Interest Income",
+      "keywords": ["interest earned", "interest payment", "savings interest"]
+    },
+    "transfers_in": {
+      "label": "Transfers In",
+      "keywords": ["transfer from", "zelle received", "venmo credit", "cashapp"]
+    },
+    "refunds": {
+      "label": "Refunds & Reimbursements",
+      "keywords": ["refund", "reimbursement", "credit adjustment"]
+    },
+    "other_income": {
+      "label": "Other Income",
+      "keywords": []
+    }
+  },
+  "expenses": {
+    "housing": {
+      "label": "Housing & Rent",
+      "keywords": ["rent", "mortgage", "hoa", "property"]
+    },
+    "utilities": {
+      "label": "Utilities",
+      "keywords": ["electric", "gas", "water", "sewer", "trash", "internet", "phone", "cable"]
+    },
+    "groceries": {
+      "label": "Groceries",
+      "keywords": ["grocery", "supermarket", "whole foods", "trader joe", "safeway", "kroger"]
+    },
+    "dining": {
+      "label": "Dining & Restaurants",
+      "keywords": ["restaurant", "dining", "doordash", "uber eats", "grubhub"]
+    },
+    "transportation": {
+      "label": "Transportation",
+      "keywords": ["gas station", "fuel", "uber", "lyft", "parking", "toll", "transit"]
+    },
+    "insurance": {
+      "label": "Insurance",
+      "keywords": ["insurance", "premium", "geico", "allstate", "state farm"]
+    },
+    "healthcare": {
+      "label": "Healthcare",
+      "keywords": ["medical", "doctor", "pharmacy", "hospital", "dental", "vision"]
+    },
+    "subscriptions": {
+      "label": "Subscriptions & Memberships",
+      "keywords": ["netflix", "spotify", "hulu", "gym", "membership", "subscription"]
+    },
+    "shopping": {
+      "label": "Shopping & Retail",
+      "keywords": ["amazon", "target", "walmart", "retail"]
+    },
+    "transfers_out": {
+      "label": "Transfers Out",
+      "keywords": ["transfer to", "zelle sent", "venmo debit", "wire transfer"]
+    },
+    "fees": {
+      "label": "Bank Fees & Charges",
+      "keywords": ["fee", "service charge", "overdraft", "atm fee"]
+    },
+    "other_expense": {
+      "label": "Other Expenses",
+      "keywords": []
+    }
+  },
+  "uncategorized_default_section": "expenses",
+  "uncategorized_default_line_item": "other_expense"
+}

--- a/wellsfargo/income-statement/requirements.txt
+++ b/wellsfargo/income-statement/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/income-statement/scripts/run.py
+++ b/wellsfargo/income-statement/scripts/run.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Wells Fargo Income Statement Generator.
+
+Reads categorized transaction data from SerenDB (populated by bank-statement-processing)
+and generates a categorized income statement with Income, Expenses, and Net Income sections.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from statement_builder import (
+    build_income_statement,
+    classify_transaction,
+    load_line_item_map,
+    render_markdown,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MONTHS = 12
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+def load_json(path: Path, default: Any = None) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+
+# ---------------------------------------------------------------------------
+# SerenDB resolution (mirrors bank-statement-processing logic)
+# ---------------------------------------------------------------------------
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload: Any = None
+    if result.stdout.strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+    return result.returncode, payload, result.stderr.strip()
+
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+
+def resolve_serendb_database_url(
+    config: dict[str, Any],
+    logger: RunLogger,
+) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+
+    from_env = os.getenv(env_key, "").strip()
+    if from_env:
+        return from_env, f"env:{env_key}"
+
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and auto-resolve is disabled."
+        )
+
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and `seren` CLI was not found in PATH."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wf-income-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [
+            seren_bin,
+            "env",
+            "init",
+            "--env",
+            str(env_path),
+            "--key",
+            env_key,
+            "--yes",
+            "-o",
+            "json",
+        ]
+        if bool(serendb_cfg.get("pooled_connection", True)):
+            base_cmd.append("--pooled")
+
+        # Build candidates from database catalog
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        # Explicit project_id + branch_id
+        explicit_pid = str(serendb_cfg.get("project_id", "")).strip()
+        explicit_bid = str(serendb_cfg.get("branch_id", "")).strip()
+        if explicit_pid and explicit_bid:
+            candidates.append((explicit_pid, explicit_bid, "explicit"))
+            seen.add((explicit_pid, explicit_bid))
+
+        # Rank from catalog
+        for row in rows:
+            pid = row.get("project_id", "").strip()
+            bid = row.get("branch_id", "").strip()
+            if not pid or not bid:
+                continue
+            key = (pid, bid)
+            if key in seen:
+                continue
+            rp = row.get("project_name", "").strip().lower()
+            rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project:
+                continue
+            if desired_database and rd != desired_database:
+                continue
+            seen.add(key)
+            label = f"catalog:{rp}/{row.get('branch_name', '')}/{rd}"
+            candidates.append((pid, bid, label))
+
+        if not candidates:
+            raise RuntimeError(
+                "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+                f"Could not infer a project/branch for {env_key}. "
+                "Set `serendb.project_id` + `serendb.branch_id`, or provide WF_SERENDB_URL."
+            )
+
+        attempt_errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved:
+                    os.environ[env_key] = resolved
+                    logger.emit(
+                        "serendb_url_resolved",
+                        "Resolved SerenDB URL from Seren CLI context",
+                        env_key=env_key,
+                        source=f"seren_cli_context:{source}",
+                    )
+                    return resolved, f"seren_cli_context:{source}"
+                attempt_errors.append(f"{source}: empty dotenv write")
+                continue
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            details = stderr or stdout or "unknown error"
+            attempt_errors.append(f"{source}: {details}")
+
+        preview = "; ".join(attempt_errors[:5])
+        raise RuntimeError(
+            "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+            f"Tried {len(candidates)} candidates for {env_key}. "
+            f"Errors: {preview}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+QUERY_CATEGORIZED_TRANSACTIONS = """
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+
+def fetch_transactions(
+    database_url: str,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                QUERY_CATEGORIZED_TRANSACTIONS,
+                {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()},
+            )
+            columns = [desc.name for desc in cur.description]
+            rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+    return rows
+
+
+
+
+# ---------------------------------------------------------------------------
+# SerenDB persistence
+# ---------------------------------------------------------------------------
+
+def _read_sql(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def persist_income_statement(
+    database_url: str,
+    schema_path: Path,
+    run_record: dict[str, Any],
+    statement: dict[str, Any],
+) -> None:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_read_sql(schema_path))
+
+            cur.execute(
+                """
+                INSERT INTO wf_income_runs (
+                  run_id, started_at, ended_at, status,
+                  period_start, period_end,
+                  total_income, total_expenses, net_income,
+                  txn_count, artifact_root
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  ended_at = EXCLUDED.ended_at,
+                  status = EXCLUDED.status,
+                  total_income = EXCLUDED.total_income,
+                  total_expenses = EXCLUDED.total_expenses,
+                  net_income = EXCLUDED.net_income,
+                  txn_count = EXCLUDED.txn_count
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["started_at"],
+                    run_record["ended_at"],
+                    run_record["status"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    statement["total_income"],
+                    statement["total_expenses"],
+                    statement["net_income"],
+                    run_record["txn_count"],
+                    run_record["artifact_root"],
+                ),
+            )
+
+            # Insert line items
+            for section in ("income", "expenses"):
+                items = statement.get(section, {})
+                for key, item in items.items():
+                    cur.execute(
+                        """
+                        INSERT INTO wf_income_line_items (
+                          run_id, section, line_item_key, label, amount, txn_count
+                        ) VALUES (%s,%s,%s,%s,%s,%s)
+                        ON CONFLICT (run_id, section, line_item_key)
+                        DO UPDATE SET
+                          label = EXCLUDED.label,
+                          amount = EXCLUDED.amount,
+                          txn_count = EXCLUDED.txn_count
+                        """,
+                        (
+                            run_record["run_id"],
+                            section,
+                            key,
+                            item["label"],
+                            item["amount"],
+                            item["txn_count"],
+                        ),
+                    )
+
+            # Insert snapshot
+            snapshot_json = json.dumps(
+                {"income": statement["income"], "expenses": statement["expenses"]},
+                default=str,
+            )
+            cur.execute(
+                """
+                INSERT INTO wf_income_snapshots (
+                  run_id, period_start, period_end,
+                  total_income, total_expenses, net_income,
+                  line_items_json
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  total_income = EXCLUDED.total_income,
+                  total_expenses = EXCLUDED.total_expenses,
+                  net_income = EXCLUDED.net_income,
+                  line_items_json = EXCLUDED.line_items_json
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    statement["total_income"],
+                    statement["total_expenses"],
+                    statement["net_income"],
+                    snapshot_json,
+                ),
+            )
+
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Wells Fargo income statement from SerenDB transaction data",
+    )
+    parser.add_argument("--config", default="config.json", help="Path to config JSON")
+    parser.add_argument(
+        "--months",
+        type=int,
+        default=DEFAULT_MONTHS,
+        help=f"Number of months to include (default {DEFAULT_MONTHS})",
+    )
+    parser.add_argument("--start", type=str, default="", help="Start date (YYYY-MM-DD), overrides --months")
+    parser.add_argument("--end", type=str, default="", help="End date (YYYY-MM-DD), defaults to today")
+    parser.add_argument("--out", type=str, default="artifacts/income-statement", help="Output directory")
+    parser.add_argument("--skip-persist", action="store_true", help="Skip SerenDB persistence")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Load config
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    # Determine date range
+    today = date.today()
+    if args.start:
+        period_start = date.fromisoformat(args.start)
+        period_end = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        period_start = today - relativedelta(months=args.months)
+        period_end = today
+
+    # Set up output directories
+    out_dir = Path(args.out)
+    report_dir = ensure_dir(out_dir / "reports")
+    export_dir = ensure_dir(out_dir / "exports")
+    log_dir = ensure_dir(out_dir / "logs")
+
+    run_id = f"income-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{run_id}.jsonl")
+
+    logger.emit("start", "Income statement generation started", run_id=run_id)
+    logger.emit(
+        "period",
+        f"Period: {period_start.isoformat()} to {period_end.isoformat()}",
+        start=period_start.isoformat(),
+        end=period_end.isoformat(),
+    )
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id,
+        "started_at": utc_now_iso(),
+        "ended_at": None,
+        "status": "running",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "txn_count": 0,
+        "artifact_root": str(out_dir.resolve()),
+    }
+
+    try:
+        # Resolve SerenDB URL
+        db_url, db_source = resolve_serendb_database_url(config, logger)
+        logger.emit("serendb_connected", f"Connected via {db_source}")
+
+        # Fetch transactions
+        logger.emit("query_transactions", "Fetching categorized transactions from SerenDB")
+        transactions = fetch_transactions(db_url, period_start, period_end)
+        logger.emit("query_transactions_done", f"Fetched {len(transactions)} transactions", count=len(transactions))
+
+        if not transactions:
+            logger.emit("warn", "No transactions found for the specified period. Is bank-statement-processing data synced?")
+            run_record["status"] = "empty"
+            run_record["ended_at"] = utc_now_iso()
+            run_record["txn_count"] = 0
+            print("No transactions found. Ensure bank-statement-processing has synced data to SerenDB.")
+            sys.exit(0)
+
+        run_record["txn_count"] = len(transactions)
+
+        # Load line item map
+        map_path_str = config.get("line_item_map_path", "config/line_item_map.json")
+        map_path = Path(map_path_str)
+        if not map_path.is_absolute():
+            map_path = config_path.parent / map_path
+        line_item_map = load_line_item_map(map_path)
+        logger.emit("line_item_map_loaded", f"Loaded line item map from {map_path}")
+
+        # Build income statement
+        logger.emit("build_statement", "Building income statement")
+        statement = build_income_statement(transactions, line_item_map)
+        logger.emit(
+            "build_statement_done",
+            "Income statement built",
+            total_income=statement["total_income"],
+            total_expenses=statement["total_expenses"],
+            net_income=statement["net_income"],
+        )
+
+        # Render reports
+        md_content = render_markdown(statement, period_start, period_end, run_id, len(transactions))
+        md_path = report_dir / f"{run_id}.md"
+        md_path.write_text(md_content, encoding="utf-8")
+
+        json_report = {
+            "run_id": run_id,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "txn_count": len(transactions),
+            "statement": statement,
+        }
+        json_path = report_dir / f"{run_id}.json"
+        dump_json(json_path, json_report)
+
+        # Export line items
+        export_path = export_dir / f"{run_id}.line_items.jsonl"
+        for section in ("income", "expenses"):
+            for key, item in statement.get(section, {}).items():
+                append_jsonl(export_path, {
+                    "section": section,
+                    "line_item_key": key,
+                    "label": item["label"],
+                    "amount": item["amount"],
+                    "txn_count": item["txn_count"],
+                })
+
+        logger.emit("render_done", "Reports written", md=str(md_path), json=str(json_path))
+
+        # Persist to SerenDB
+        if not args.skip_persist and bool(config.get("serendb", {}).get("enabled", True)):
+            schema_path_str = config.get("serendb", {}).get("schema_path", "sql/schema.sql")
+            schema_path = Path(schema_path_str)
+            if not schema_path.is_absolute():
+                schema_path = config_path.parent / schema_path
+            logger.emit("persist", "Persisting income statement to SerenDB")
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            persist_income_statement(db_url, schema_path, run_record, statement)
+            logger.emit("persist_done", "SerenDB persistence complete")
+        else:
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            logger.emit("persist_skipped", "SerenDB persistence skipped")
+
+        logger.emit("complete", "Income statement generation complete")
+        print(f"\nIncome Statement generated successfully!")
+        print(f"  Markdown: {md_path}")
+        print(f"  JSON:     {json_path}")
+        print(f"  Period:   {period_start} to {period_end}")
+        print(f"  Transactions: {len(transactions)}")
+        print(f"  Net Income: ${statement['net_income']:,.2f}")
+
+    except Exception as exc:
+        run_record["status"] = "error"
+        run_record["ended_at"] = utc_now_iso()
+        logger.emit("error", str(exc), error_type=type(exc).__name__)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wellsfargo/income-statement/scripts/statement_builder.py
+++ b/wellsfargo/income-statement/scripts/statement_builder.py
@@ -1,0 +1,130 @@
+"""Pure-logic income statement builder (no DB dependencies)."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+def load_line_item_map(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Line item map not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def classify_transaction(
+    txn: dict[str, Any],
+    line_item_map: dict[str, Any],
+) -> tuple[str, str]:
+    """Return (section, line_item_key) for a transaction."""
+    category = str(txn.get("category", "uncategorized")).lower().strip()
+    amount = float(txn.get("amount", 0))
+
+    for key in line_item_map.get("income", {}):
+        if category == key:
+            return "income", key
+
+    for key in line_item_map.get("expenses", {}):
+        if category == key:
+            return "expenses", key
+
+    if category == "uncategorized":
+        if amount > 0:
+            return "income", "other_income"
+        default_section = line_item_map.get("uncategorized_default_section", "expenses")
+        default_item = line_item_map.get("uncategorized_default_line_item", "other_expense")
+        return default_section, default_item
+
+    if amount > 0:
+        return "income", "other_income"
+    return "expenses", "other_expense"
+
+
+def build_income_statement(
+    transactions: list[dict[str, Any]],
+    line_item_map: dict[str, Any],
+) -> dict[str, Any]:
+    """Aggregate transactions into an income statement structure."""
+    income_items: dict[str, dict[str, Any]] = {}
+    expense_items: dict[str, dict[str, Any]] = {}
+
+    for key, spec in line_item_map.get("income", {}).items():
+        income_items[key] = {"label": spec["label"], "amount": 0.0, "txn_count": 0}
+    for key, spec in line_item_map.get("expenses", {}).items():
+        expense_items[key] = {"label": spec["label"], "amount": 0.0, "txn_count": 0}
+
+    for txn in transactions:
+        section, item_key = classify_transaction(txn, line_item_map)
+        amount = float(txn.get("amount", 0))
+
+        if section == "income":
+            if item_key not in income_items:
+                income_items[item_key] = {"label": item_key.replace("_", " ").title(), "amount": 0.0, "txn_count": 0}
+            income_items[item_key]["amount"] = round(income_items[item_key]["amount"] + amount, 2)
+            income_items[item_key]["txn_count"] += 1
+        else:
+            if item_key not in expense_items:
+                expense_items[item_key] = {"label": item_key.replace("_", " ").title(), "amount": 0.0, "txn_count": 0}
+            expense_items[item_key]["amount"] = round(expense_items[item_key]["amount"] + abs(amount), 2)
+            expense_items[item_key]["txn_count"] += 1
+
+    income_items = {k: v for k, v in income_items.items() if v["txn_count"] > 0}
+    expense_items = {k: v for k, v in expense_items.items() if v["txn_count"] > 0}
+
+    total_income = round(sum(v["amount"] for v in income_items.values()), 2)
+    total_expenses = round(sum(v["amount"] for v in expense_items.values()), 2)
+    net_income = round(total_income - total_expenses, 2)
+
+    return {
+        "income": income_items,
+        "expenses": expense_items,
+        "total_income": total_income,
+        "total_expenses": total_expenses,
+        "net_income": net_income,
+    }
+
+
+def render_markdown(
+    statement: dict[str, Any],
+    period_start: date,
+    period_end: date,
+    run_id: str,
+    txn_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Wells Fargo Income Statement")
+    lines.append("")
+    lines.append(f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}")
+    lines.append(f"**Run ID:** {run_id}")
+    lines.append(f"**Transactions analyzed:** {txn_count}")
+    lines.append("")
+
+    lines.append("## Income")
+    lines.append("")
+    lines.append("| Line Item | Amount | Txns |")
+    lines.append("|-----------|-------:|-----:|")
+    for key, item in sorted(statement["income"].items(), key=lambda x: -x[1]["amount"]):
+        lines.append(f"| {item['label']} | ${item['amount']:,.2f} | {item['txn_count']} |")
+    lines.append(f"| **Total Income** | **${statement['total_income']:,.2f}** | |")
+    lines.append("")
+
+    lines.append("## Expenses")
+    lines.append("")
+    lines.append("| Line Item | Amount | Txns |")
+    lines.append("|-----------|-------:|-----:|")
+    for key, item in sorted(statement["expenses"].items(), key=lambda x: -x[1]["amount"]):
+        lines.append(f"| {item['label']} | ${item['amount']:,.2f} | {item['txn_count']} |")
+    lines.append(f"| **Total Expenses** | **${statement['total_expenses']:,.2f}** | |")
+    lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| | Amount |")
+    lines.append("|--|-------:|")
+    lines.append(f"| Total Income | ${statement['total_income']:,.2f} |")
+    lines.append(f"| Total Expenses | (${statement['total_expenses']:,.2f}) |")
+    lines.append(f"| **Net Income** | **${statement['net_income']:,.2f}** |")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/wellsfargo/income-statement/skill.spec.yaml
+++ b/wellsfargo/income-statement/skill.spec.yaml
@@ -1,0 +1,59 @@
+skill: income-statement
+description: Generate categorized income statements from Wells Fargo transaction data stored in SerenDB by the bank-statement-processing skill.
+triggers:
+  - generate wells fargo income statement
+  - create wellsfargo income report
+  - build income statement from wells fargo data
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 1
+    max: 24
+    default: 12
+  start:
+    type: string
+    description: Start date (YYYY-MM-DD). Overrides months if provided.
+  end:
+    type: string
+    description: End date (YYYY-MM-DD). Defaults to today if start is provided.
+  out:
+    type: string
+    default: artifacts/income-statement
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  checkpoints:
+    kind: sqlite
+    file: artifacts/income-statement/state/checkpoint.json
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: classify_line_items
+      use: transform.map_categories
+    - id: build_statement
+      use: transform.aggregate_line_items
+    - id: render_report
+      use: transform.render
+    - id: persist_statement
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: income-statement
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/income-statement/sql/queries.sql
+++ b/wellsfargo/income-statement/sql/queries.sql
@@ -1,0 +1,28 @@
+-- fetch_categorized_transactions: retrieve all categorized transactions for a date range
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;
+
+-- fetch_monthly_summary: retrieve monthly aggregates for a date range
+SELECT
+  account_masked,
+  month_start,
+  debit_total,
+  credit_total,
+  txn_count
+FROM wf_monthly_summary
+WHERE month_start >= %(start_date)s
+  AND month_start <= %(end_date)s
+ORDER BY month_start;

--- a/wellsfargo/income-statement/sql/schema.sql
+++ b/wellsfargo/income-statement/sql/schema.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS wf_income_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_income NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_expenses NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_income NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_income_line_items (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_income_runs(run_id) ON DELETE CASCADE,
+  section TEXT NOT NULL,
+  line_item_key TEXT NOT NULL,
+  label TEXT NOT NULL,
+  amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, section, line_item_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_income_line_items_run ON wf_income_line_items(run_id);
+
+CREATE TABLE IF NOT EXISTS wf_income_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_income_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_income NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_expenses NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_income NUMERIC(14,2) NOT NULL DEFAULT 0,
+  line_items_json JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_income_snapshots_period ON wf_income_snapshots(period_start, period_end);
+
+CREATE OR REPLACE VIEW v_wf_income_latest AS
+SELECT s.*
+FROM wf_income_snapshots s
+JOIN wf_income_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_income_runs r2
+  WHERE r2.status = 'success'
+);
+
+CREATE OR REPLACE VIEW v_wf_income_by_month AS
+SELECT
+  li.run_id,
+  li.section,
+  li.line_item_key,
+  li.label,
+  li.amount,
+  li.txn_count,
+  r.period_start,
+  r.period_end
+FROM wf_income_line_items li
+JOIN wf_income_runs r ON r.run_id = li.run_id
+WHERE r.status = 'success'
+ORDER BY r.period_start DESC, li.section, li.line_item_key;

--- a/wellsfargo/income-statement/tests/test_smoke.py
+++ b/wellsfargo/income-statement/tests/test_smoke.py
@@ -1,0 +1,143 @@
+"""Smoke tests for the income statement builder (no DB required)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from scripts/
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from statement_builder import build_income_statement, classify_transaction, render_markdown  # noqa: E402
+from datetime import date  # noqa: E402
+
+
+LINE_ITEM_MAP = json.loads(
+    (Path(__file__).resolve().parent.parent / "config" / "line_item_map.json").read_text()
+)
+
+
+def _make_txn(amount: float, category: str = "uncategorized") -> dict:
+    return {
+        "row_hash": f"hash_{abs(hash((amount, category)))}",
+        "account_masked": "****1234",
+        "txn_date": "2025-06-15",
+        "description_raw": f"Test txn {category}",
+        "amount": amount,
+        "currency": "USD",
+        "category": category,
+        "category_source": "test",
+        "confidence": 1.0,
+    }
+
+
+class TestClassifyTransaction:
+    def test_payroll_is_income(self) -> None:
+        txn = _make_txn(5000.0, "payroll")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "income"
+        assert key == "payroll"
+
+    def test_housing_is_expense(self) -> None:
+        txn = _make_txn(-2000.0, "housing")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "expenses"
+        assert key == "housing"
+
+    def test_uncategorized_positive_goes_to_income(self) -> None:
+        txn = _make_txn(100.0, "uncategorized")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "income"
+        assert key == "other_income"
+
+    def test_uncategorized_negative_goes_to_expenses(self) -> None:
+        txn = _make_txn(-50.0, "uncategorized")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "expenses"
+        assert key == "other_expense"
+
+    def test_unknown_category_positive(self) -> None:
+        txn = _make_txn(200.0, "mystery_category")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "income"
+        assert key == "other_income"
+
+    def test_unknown_category_negative(self) -> None:
+        txn = _make_txn(-75.0, "mystery_category")
+        section, key = classify_transaction(txn, LINE_ITEM_MAP)
+        assert section == "expenses"
+        assert key == "other_expense"
+
+
+class TestBuildIncomeStatement:
+    def test_basic_statement(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "payroll"),
+            _make_txn(50.0, "interest_income"),
+            _make_txn(-2000.0, "housing"),
+            _make_txn(-300.0, "groceries"),
+            _make_txn(-100.0, "dining"),
+        ]
+        stmt = build_income_statement(transactions, LINE_ITEM_MAP)
+
+        assert stmt["total_income"] == 5050.0
+        assert stmt["total_expenses"] == 2400.0
+        assert stmt["net_income"] == 2650.0
+        assert "payroll" in stmt["income"]
+        assert "interest_income" in stmt["income"]
+        assert "housing" in stmt["expenses"]
+        assert "groceries" in stmt["expenses"]
+        assert "dining" in stmt["expenses"]
+
+    def test_empty_transactions(self) -> None:
+        stmt = build_income_statement([], LINE_ITEM_MAP)
+        assert stmt["total_income"] == 0.0
+        assert stmt["total_expenses"] == 0.0
+        assert stmt["net_income"] == 0.0
+        assert len(stmt["income"]) == 0
+        assert len(stmt["expenses"]) == 0
+
+    def test_all_income(self) -> None:
+        transactions = [
+            _make_txn(3000.0, "payroll"),
+            _make_txn(100.0, "interest_income"),
+        ]
+        stmt = build_income_statement(transactions, LINE_ITEM_MAP)
+        assert stmt["total_income"] == 3100.0
+        assert stmt["total_expenses"] == 0.0
+        assert stmt["net_income"] == 3100.0
+
+    def test_negative_net_income(self) -> None:
+        transactions = [
+            _make_txn(1000.0, "payroll"),
+            _make_txn(-3000.0, "housing"),
+        ]
+        stmt = build_income_statement(transactions, LINE_ITEM_MAP)
+        assert stmt["net_income"] == -2000.0
+
+
+class TestRenderMarkdown:
+    def test_render_produces_valid_markdown(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "payroll"),
+            _make_txn(-1500.0, "housing"),
+        ]
+        stmt = build_income_statement(transactions, LINE_ITEM_MAP)
+        md = render_markdown(
+            stmt,
+            period_start=date(2025, 1, 1),
+            period_end=date(2025, 12, 31),
+            run_id="test-run-001",
+            txn_count=2,
+        )
+
+        assert "# Wells Fargo Income Statement" in md
+        assert "2025-01-01" in md
+        assert "2025-12-31" in md
+        assert "test-run-001" in md
+        assert "Salary & Wages" in md
+        assert "Housing & Rent" in md
+        assert "Total Income" in md
+        assert "Total Expenses" in md
+        assert "Net Income" in md


### PR DESCRIPTION
## Summary

- Adds a new `wellsfargo/income-statement` skill that generates categorized income statements from SerenDB transaction data populated by the `bank-statement-processing` skill.
- Reads from upstream `wf_transactions` and `wf_txn_categories` tables, classifies transactions into Income (payroll, interest, transfers in, refunds) and Expense (housing, utilities, groceries, dining, transportation, etc.) line items via a configurable `line_item_map.json`.
- Produces Markdown and JSON reports with Income, Expenses, and Net Income sections, plus JSONL line-item exports.
- Persists income statement snapshots to SerenDB (`wf_income_runs`, `wf_income_line_items`, `wf_income_snapshots`) with views `v_wf_income_latest` and `v_wf_income_by_month`.
- Reuses the same SerenDB URL resolution chain as bank-statement-processing (env var → Seren CLI auto-resolve).
- 11 smoke tests passing (classification, aggregation, rendering).

## Files added

```
wellsfargo/income-statement/
├── .env.example
├── .gitignore
├── SKILL.md
├── config.example.json
├── config/line_item_map.json
├── requirements.txt
├── scripts/run.py
├── scripts/statement_builder.py
├── skill.spec.yaml
├── sql/queries.sql
├── sql/schema.sql
└── tests/test_smoke.py
```

## Test plan

- [x] All 11 smoke tests pass (`pytest tests/test_smoke.py -v`)
- [ ] End-to-end run against a SerenDB with bank-statement-processing data
- [ ] Verify Markdown report renders correctly
- [ ] Verify SerenDB persistence creates expected tables and views

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com