### PR TITLE
feat(wellsfargo): add cash-flow-statement skill

### DIFF
--- a/wellsfargo/cash-flow-statement/.env.example
+++ b/wellsfargo/cash-flow-statement/.env.example
@@ -1,0 +1,5 @@
+# Optional override: explicit SERENDB connection string.
+# If empty, scripts/run.py resolves this automatically from your logged-in
+# Seren CLI/MCP context via `seren env init`.
+# Example: postgresql://user:pass@host:5432/serendb
+WF_SERENDB_URL=

--- a/wellsfargo/cash-flow-statement/.gitignore
+++ b/wellsfargo/cash-flow-statement/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/cash-flow-statement/SKILL.md
+++ b/wellsfargo/cash-flow-statement/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cash-flow-statement
+description: "Generate operating, investing, and financing cash flow statements from Wells Fargo transaction data stored in SerenDB."
+---
+
+# Wells Fargo Cash Flow Statement
+
+## When To Use
+
+- Generate cash flow statements broken into Operating, Investing, and Financing activities.
+- Track net cash position changes over configurable periods.
+- Produce human-readable Markdown and machine-readable JSON reports.
+- Persist cash flow snapshots into SerenDB for downstream analysis.
+
+## Prerequisites
+
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables (`wf_transactions`, `wf_txn_categories`).
+- Writes only to dedicated `wf_cashflow_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+- All amounts sourced from already-masked account data.
+
+## Workflow Summary
+
+1. `resolve_serendb` connects to SerenDB using the same resolution chain as bank-statement-processing.
+2. `query_transactions` fetches categorized transactions for the requested date range.
+3. `classify_activities` maps transaction categories to Operating, Investing, or Financing activities using `config/activity_map.json`.
+4. `build_statement` aggregates activities into a cash flow statement.
+5. `render_report` produces Markdown and JSON output files.
+6. `persist_statement` upserts the cash flow snapshot into SerenDB.
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+cd wellsfargo/cash-flow-statement
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+cp config.example.json config.json
+```
+
+2. Generate a cash flow statement for the last 12 months:
+
+```bash
+python3 scripts/run.py --config config.json --months 12 --out artifacts/cash-flow-statement
+```
+
+3. Generate a statement for a specific date range:
+
+```bash
+python3 scripts/run.py --config config.json --start 2025-01-01 --end 2025-12-31 --out artifacts/cash-flow-statement
+```
+
+## Commands
+
+```bash
+# Last 12 months (default)
+python3 scripts/run.py --config config.json --months 12 --out artifacts/cash-flow-statement
+
+# Specific date range
+python3 scripts/run.py --config config.json --start 2025-06-01 --end 2025-12-31 --out artifacts/cash-flow-statement
+
+# Skip SerenDB persistence (local reports only)
+python3 scripts/run.py --config config.json --months 12 --skip-persist --out artifacts/cash-flow-statement
+```
+
+## Outputs
+
+- Markdown report: `artifacts/cash-flow-statement/reports/<run_id>.md`
+- JSON report: `artifacts/cash-flow-statement/reports/<run_id>.json`
+- Activity export: `artifacts/cash-flow-statement/exports/<run_id>.activities.jsonl`
+
+## SerenDB Tables
+
+- `wf_cashflow_runs` - cash flow statement generation runs
+- `wf_cashflow_activities` - individual activity line items per run
+- `wf_cashflow_snapshots` - summary totals per run
+
+## Reusable Views
+
+- `v_wf_cashflow_latest` - most recent cash flow snapshot
+- `v_wf_cashflow_by_month` - monthly cash flow breakdown by activity

--- a/wellsfargo/cash-flow-statement/config.example.json
+++ b/wellsfargo/cash-flow-statement/config.example.json
@@ -1,0 +1,18 @@
+{
+  "runtime": {
+    "artifacts_subdir": "cash-flow-statement"
+  },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
+  },
+  "activity_map_path": "config/activity_map.json"
+}

--- a/wellsfargo/cash-flow-statement/config/activity_map.json
+++ b/wellsfargo/cash-flow-statement/config/activity_map.json
@@ -1,0 +1,92 @@
+{
+  "_comment": "Maps wf_txn_categories.category values to cash flow activity sections.",
+  "operating": {
+    "payroll": {
+      "label": "Salary & Wages Received",
+      "direction": "inflow"
+    },
+    "interest_income": {
+      "label": "Interest Received",
+      "direction": "inflow"
+    },
+    "refunds": {
+      "label": "Refunds Received",
+      "direction": "inflow"
+    },
+    "housing": {
+      "label": "Rent / Mortgage Payments",
+      "direction": "outflow"
+    },
+    "utilities": {
+      "label": "Utility Payments",
+      "direction": "outflow"
+    },
+    "groceries": {
+      "label": "Grocery Purchases",
+      "direction": "outflow"
+    },
+    "dining": {
+      "label": "Dining & Restaurants",
+      "direction": "outflow"
+    },
+    "transportation": {
+      "label": "Transportation Costs",
+      "direction": "outflow"
+    },
+    "insurance": {
+      "label": "Insurance Premiums",
+      "direction": "outflow"
+    },
+    "healthcare": {
+      "label": "Healthcare Expenses",
+      "direction": "outflow"
+    },
+    "subscriptions": {
+      "label": "Subscriptions & Memberships",
+      "direction": "outflow"
+    },
+    "shopping": {
+      "label": "Shopping & Retail",
+      "direction": "outflow"
+    },
+    "fees": {
+      "label": "Bank Fees & Charges",
+      "direction": "outflow"
+    }
+  },
+  "investing": {
+    "investment_purchase": {
+      "label": "Investment Purchases",
+      "direction": "outflow"
+    },
+    "investment_sale": {
+      "label": "Investment Sales / Proceeds",
+      "direction": "inflow"
+    },
+    "dividend_income": {
+      "label": "Dividends Received",
+      "direction": "inflow"
+    }
+  },
+  "financing": {
+    "transfers_in": {
+      "label": "Transfers In (from other accounts)",
+      "direction": "inflow"
+    },
+    "transfers_out": {
+      "label": "Transfers Out (to other accounts)",
+      "direction": "outflow"
+    },
+    "loan_payment": {
+      "label": "Loan Payments",
+      "direction": "outflow"
+    },
+    "loan_proceeds": {
+      "label": "Loan Proceeds Received",
+      "direction": "inflow"
+    }
+  },
+  "uncategorized_default_activity": "operating",
+  "uncategorized_default_inflow_key": "other_operating_inflow",
+  "uncategorized_default_outflow_key": "other_operating_outflow"
+}

--- a/wellsfargo/cash-flow-statement/requirements.txt
+++ b/wellsfargo/cash-flow-statement/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/cash-flow-statement/scripts/cashflow_builder.py
+++ b/wellsfargo/cash-flow-statement/scripts/cashflow_builder.py
@@ -1,0 +1,172 @@
+"""Pure-logic cash flow statement builder (no DB dependencies)."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+def load_activity_map(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Activity map not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def classify_activity(
+    txn: dict[str, Any],
+    activity_map: dict[str, Any],
+) -> tuple[str, str, str]:
+    """Return (activity, line_item_key, direction) for a transaction.
+
+    activity: 'operating', 'investing', or 'financing'
+    direction: 'inflow' or 'outflow'
+    """
+    category = str(txn.get("category", "uncategorized")).lower().strip()
+    amount = float(txn.get("amount", 0))
+
+    for activity in ("operating", "investing", "financing"):
+        section = activity_map.get(activity, {})
+        if category in section:
+            spec = section[category]
+            direction = spec.get("direction", "inflow" if amount > 0 else "outflow")
+            return activity, category, direction
+
+    # Uncategorized fallback
+    default_activity = activity_map.get("uncategorized_default_activity", "operating")
+    if amount > 0:
+        default_key = activity_map.get("uncategorized_default_inflow_key", "other_operating_inflow")
+        return default_activity, default_key, "inflow"
+    default_key = activity_map.get("uncategorized_default_outflow_key", "other_operating_outflow")
+    return default_activity, default_key, "outflow"
+
+
+def build_cashflow_statement(
+    transactions: list[dict[str, Any]],
+    activity_map: dict[str, Any],
+) -> dict[str, Any]:
+    """Aggregate transactions into a cash flow statement structure."""
+    activities: dict[str, dict[str, dict[str, Any]]] = {
+        "operating": {},
+        "investing": {},
+        "financing": {},
+    }
+
+    # Pre-populate from map
+    for activity_name in ("operating", "investing", "financing"):
+        section = activity_map.get(activity_name, {})
+        for key, spec in section.items():
+            activities[activity_name][key] = {
+                "label": spec["label"],
+                "direction": spec.get("direction", "outflow"),
+                "amount": 0.0,
+                "txn_count": 0,
+            }
+
+    for txn in transactions:
+        activity, item_key, direction = classify_activity(txn, activity_map)
+        amount = abs(float(txn.get("amount", 0)))
+
+        bucket = activities[activity]
+        if item_key not in bucket:
+            bucket[item_key] = {
+                "label": item_key.replace("_", " ").title(),
+                "direction": direction,
+                "amount": 0.0,
+                "txn_count": 0,
+            }
+        bucket[item_key]["amount"] = round(bucket[item_key]["amount"] + amount, 2)
+        bucket[item_key]["txn_count"] += 1
+
+    # Remove zero-count items
+    for activity_name in ("operating", "investing", "financing"):
+        activities[activity_name] = {
+            k: v for k, v in activities[activity_name].items() if v["txn_count"] > 0
+        }
+
+    # Compute net per activity: inflows minus outflows
+    def _net(items: dict[str, dict[str, Any]]) -> float:
+        total = 0.0
+        for item in items.values():
+            if item["direction"] == "inflow":
+                total += item["amount"]
+            else:
+                total -= item["amount"]
+        return round(total, 2)
+
+    operating_net = _net(activities["operating"])
+    investing_net = _net(activities["investing"])
+    financing_net = _net(activities["financing"])
+    net_cash_change = round(operating_net + investing_net + financing_net, 2)
+
+    return {
+        "operating": activities["operating"],
+        "investing": activities["investing"],
+        "financing": activities["financing"],
+        "operating_net": operating_net,
+        "investing_net": investing_net,
+        "financing_net": financing_net,
+        "net_cash_change": net_cash_change,
+    }
+
+
+def render_markdown(
+    statement: dict[str, Any],
+    period_start: date,
+    period_end: date,
+    run_id: str,
+    txn_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Wells Fargo Cash Flow Statement")
+    lines.append("")
+    lines.append(f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}")
+    lines.append(f"**Run ID:** {run_id}")
+    lines.append(f"**Transactions analyzed:** {txn_count}")
+    lines.append("")
+
+    for activity, title in [
+        ("operating", "Operating Activities"),
+        ("investing", "Investing Activities"),
+        ("financing", "Financing Activities"),
+    ]:
+        items = statement.get(activity, {})
+        net_key = f"{activity}_net"
+        lines.append(f"## {title}")
+        lines.append("")
+        lines.append("| Line Item | Direction | Amount | Txns |")
+        lines.append("|-----------|-----------|-------:|-----:|")
+
+        inflows = {k: v for k, v in items.items() if v["direction"] == "inflow"}
+        outflows = {k: v for k, v in items.items() if v["direction"] == "outflow"}
+
+        for key, item in sorted(inflows.items(), key=lambda x: -x[1]["amount"]):
+            lines.append(f"| {item['label']} | Inflow | ${item['amount']:,.2f} | {item['txn_count']} |")
+        for key, item in sorted(outflows.items(), key=lambda x: -x[1]["amount"]):
+            lines.append(f"| {item['label']} | Outflow | (${item['amount']:,.2f}) | {item['txn_count']} |")
+
+        net_val = statement[net_key]
+        sign = "" if net_val >= 0 else "-"
+        display = f"${abs(net_val):,.2f}" if net_val >= 0 else f"(${abs(net_val):,.2f})"
+        lines.append(f"| **Net {title}** | | **{display}** | |")
+        lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| | Amount |")
+    lines.append("|--|-------:|")
+    for activity, label in [
+        ("operating_net", "Net Operating"),
+        ("investing_net", "Net Investing"),
+        ("financing_net", "Net Financing"),
+    ]:
+        val = statement[activity]
+        display = f"${val:,.2f}" if val >= 0 else f"(${abs(val):,.2f})"
+        lines.append(f"| {label} | {display} |")
+
+    ncc = statement["net_cash_change"]
+    display = f"${ncc:,.2f}" if ncc >= 0 else f"(${abs(ncc):,.2f})"
+    lines.append(f"| **Net Cash Change** | **{display}** |")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/wellsfargo/cash-flow-statement/scripts/run.py
+++ b/wellsfargo/cash-flow-statement/scripts/run.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Wells Fargo Cash Flow Statement Generator.
+
+Reads categorized transaction data from SerenDB (populated by bank-statement-processing)
+and generates a cash flow statement with Operating, Investing, and Financing activities.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from cashflow_builder import (
+    build_cashflow_statement,
+    load_activity_map,
+    render_markdown,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MONTHS = 12
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+def load_json(path: Path, default: Any = None) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+
+# ---------------------------------------------------------------------------
+# SerenDB resolution (mirrors bank-statement-processing logic)
+# ---------------------------------------------------------------------------
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload: Any = None
+    if result.stdout.strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+    return result.returncode, payload, result.stderr.strip()
+
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+
+def resolve_serendb_database_url(
+    config: dict[str, Any],
+    logger: RunLogger,
+) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+
+    from_env = os.getenv(env_key, "").strip()
+    if from_env:
+        return from_env, f"env:{env_key}"
+
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and auto-resolve is disabled."
+        )
+
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and `seren` CLI was not found in PATH."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wf-cashflow-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [
+            seren_bin,
+            "env",
+            "init",
+            "--env",
+            str(env_path),
+            "--key",
+            env_key,
+            "--yes",
+            "-o",
+            "json",
+        ]
+        if bool(serendb_cfg.get("pooled_connection", True)):
+            base_cmd.append("--pooled")
+
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        explicit_pid = str(serendb_cfg.get("project_id", "")).strip()
+        explicit_bid = str(serendb_cfg.get("branch_id", "")).strip()
+        if explicit_pid and explicit_bid:
+            candidates.append((explicit_pid, explicit_bid, "explicit"))
+            seen.add((explicit_pid, explicit_bid))
+
+        for row in rows:
+            pid = row.get("project_id", "").strip()
+            bid = row.get("branch_id", "").strip()
+            if not pid or not bid:
+                continue
+            key = (pid, bid)
+            if key in seen:
+                continue
+            rp = row.get("project_name", "").strip().lower()
+            rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project:
+                continue
+            if desired_database and rd != desired_database:
+                continue
+            seen.add(key)
+            label = f"catalog:{rp}/{row.get('branch_name', '')}/{rd}"
+            candidates.append((pid, bid, label))
+
+        if not candidates:
+            raise RuntimeError(
+                "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+                f"Could not infer a project/branch for {env_key}. "
+                "Set `serendb.project_id` + `serendb.branch_id`, or provide WF_SERENDB_URL."
+            )
+
+        attempt_errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved:
+                    os.environ[env_key] = resolved
+                    logger.emit(
+                        "serendb_url_resolved",
+                        "Resolved SerenDB URL from Seren CLI context",
+                        env_key=env_key,
+                        source=f"seren_cli_context:{source}",
+                    )
+                    return resolved, f"seren_cli_context:{source}"
+                attempt_errors.append(f"{source}: empty dotenv write")
+                continue
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            details = stderr or stdout or "unknown error"
+            attempt_errors.append(f"{source}: {details}")
+
+        preview = "; ".join(attempt_errors[:5])
+        raise RuntimeError(
+            "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+            f"Tried {len(candidates)} candidates for {env_key}. "
+            f"Errors: {preview}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+QUERY_CATEGORIZED_TRANSACTIONS = """
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+
+def fetch_transactions(
+    database_url: str,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                QUERY_CATEGORIZED_TRANSACTIONS,
+                {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()},
+            )
+            columns = [desc.name for desc in cur.description]
+            rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# SerenDB persistence
+# ---------------------------------------------------------------------------
+
+def _read_sql(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def persist_cashflow_statement(
+    database_url: str,
+    schema_path: Path,
+    run_record: dict[str, Any],
+    statement: dict[str, Any],
+) -> None:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_read_sql(schema_path))
+
+            cur.execute(
+                """
+                INSERT INTO wf_cashflow_runs (
+                  run_id, started_at, ended_at, status,
+                  period_start, period_end,
+                  operating_net, investing_net, financing_net, net_cash_change,
+                  txn_count, artifact_root
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  ended_at = EXCLUDED.ended_at,
+                  status = EXCLUDED.status,
+                  operating_net = EXCLUDED.operating_net,
+                  investing_net = EXCLUDED.investing_net,
+                  financing_net = EXCLUDED.financing_net,
+                  net_cash_change = EXCLUDED.net_cash_change,
+                  txn_count = EXCLUDED.txn_count
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["started_at"],
+                    run_record["ended_at"],
+                    run_record["status"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    statement["operating_net"],
+                    statement["investing_net"],
+                    statement["financing_net"],
+                    statement["net_cash_change"],
+                    run_record["txn_count"],
+                    run_record["artifact_root"],
+                ),
+            )
+
+            for activity in ("operating", "investing", "financing"):
+                items = statement.get(activity, {})
+                for key, item in items.items():
+                    cur.execute(
+                        """
+                        INSERT INTO wf_cashflow_activities (
+                          run_id, activity, line_item_key, label, direction, amount, txn_count
+                        ) VALUES (%s,%s,%s,%s,%s,%s,%s)
+                        ON CONFLICT (run_id, activity, line_item_key)
+                        DO UPDATE SET
+                          label = EXCLUDED.label,
+                          direction = EXCLUDED.direction,
+                          amount = EXCLUDED.amount,
+                          txn_count = EXCLUDED.txn_count
+                        """,
+                        (
+                            run_record["run_id"],
+                            activity,
+                            key,
+                            item["label"],
+                            item["direction"],
+                            item["amount"],
+                            item["txn_count"],
+                        ),
+                    )
+
+            snapshot_json = json.dumps(
+                {
+                    "operating": statement["operating"],
+                    "investing": statement["investing"],
+                    "financing": statement["financing"],
+                },
+                default=str,
+            )
+            cur.execute(
+                """
+                INSERT INTO wf_cashflow_snapshots (
+                  run_id, period_start, period_end,
+                  operating_net, investing_net, financing_net, net_cash_change,
+                  activities_json
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s::jsonb)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  operating_net = EXCLUDED.operating_net,
+                  investing_net = EXCLUDED.investing_net,
+                  financing_net = EXCLUDED.financing_net,
+                  net_cash_change = EXCLUDED.net_cash_change,
+                  activities_json = EXCLUDED.activities_json
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    statement["operating_net"],
+                    statement["investing_net"],
+                    statement["financing_net"],
+                    statement["net_cash_change"],
+                    snapshot_json,
+                ),
+            )
+
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Wells Fargo cash flow statement from SerenDB transaction data",
+    )
+    parser.add_argument("--config", default="config.json", help="Path to config JSON")
+    parser.add_argument(
+        "--months",
+        type=int,
+        default=DEFAULT_MONTHS,
+        help=f"Number of months to include (default {DEFAULT_MONTHS})",
+    )
+    parser.add_argument("--start", type=str, default="", help="Start date (YYYY-MM-DD), overrides --months")
+    parser.add_argument("--end", type=str, default="", help="End date (YYYY-MM-DD), defaults to today")
+    parser.add_argument("--out", type=str, default="artifacts/cash-flow-statement", help="Output directory")
+    parser.add_argument("--skip-persist", action="store_true", help="Skip SerenDB persistence")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    today = date.today()
+    if args.start:
+        period_start = date.fromisoformat(args.start)
+        period_end = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        period_start = today - relativedelta(months=args.months)
+        period_end = today
+
+    out_dir = Path(args.out)
+    report_dir = ensure_dir(out_dir / "reports")
+    export_dir = ensure_dir(out_dir / "exports")
+    log_dir = ensure_dir(out_dir / "logs")
+
+    run_id = f"cashflow-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{run_id}.jsonl")
+
+    logger.emit("start", "Cash flow statement generation started", run_id=run_id)
+    logger.emit(
+        "period",
+        f"Period: {period_start.isoformat()} to {period_end.isoformat()}",
+        start=period_start.isoformat(),
+        end=period_end.isoformat(),
+    )
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id,
+        "started_at": utc_now_iso(),
+        "ended_at": None,
+        "status": "running",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "txn_count": 0,
+        "artifact_root": str(out_dir.resolve()),
+    }
+
+    try:
+        db_url, db_source = resolve_serendb_database_url(config, logger)
+        logger.emit("serendb_connected", f"Connected via {db_source}")
+
+        logger.emit("query_transactions", "Fetching categorized transactions from SerenDB")
+        transactions = fetch_transactions(db_url, period_start, period_end)
+        logger.emit("query_transactions_done", f"Fetched {len(transactions)} transactions", count=len(transactions))
+
+        if not transactions:
+            logger.emit("warn", "No transactions found for the specified period.")
+            run_record["status"] = "empty"
+            run_record["ended_at"] = utc_now_iso()
+            print("No transactions found. Ensure bank-statement-processing has synced data to SerenDB.")
+            sys.exit(0)
+
+        run_record["txn_count"] = len(transactions)
+
+        map_path_str = config.get("activity_map_path", "config/activity_map.json")
+        map_path = Path(map_path_str)
+        if not map_path.is_absolute():
+            map_path = config_path.parent / map_path
+        activity_map = load_activity_map(map_path)
+        logger.emit("activity_map_loaded", f"Loaded activity map from {map_path}")
+
+        logger.emit("build_statement", "Building cash flow statement")
+        statement = build_cashflow_statement(transactions, activity_map)
+        logger.emit(
+            "build_statement_done",
+            "Cash flow statement built",
+            operating_net=statement["operating_net"],
+            investing_net=statement["investing_net"],
+            financing_net=statement["financing_net"],
+            net_cash_change=statement["net_cash_change"],
+        )
+
+        md_content = render_markdown(statement, period_start, period_end, run_id, len(transactions))
+        md_path = report_dir / f"{run_id}.md"
+        md_path.write_text(md_content, encoding="utf-8")
+
+        json_report = {
+            "run_id": run_id,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "txn_count": len(transactions),
+            "statement": statement,
+        }
+        json_path = report_dir / f"{run_id}.json"
+        dump_json(json_path, json_report)
+
+        export_path = export_dir / f"{run_id}.activities.jsonl"
+        for activity in ("operating", "investing", "financing"):
+            for key, item in statement.get(activity, {}).items():
+                append_jsonl(export_path, {
+                    "activity": activity,
+                    "line_item_key": key,
+                    "label": item["label"],
+                    "direction": item["direction"],
+                    "amount": item["amount"],
+                    "txn_count": item["txn_count"],
+                })
+
+        logger.emit("render_done", "Reports written", md=str(md_path), json=str(json_path))
+
+        if not args.skip_persist and bool(config.get("serendb", {}).get("enabled", True)):
+            schema_path_str = config.get("serendb", {}).get("schema_path", "sql/schema.sql")
+            schema_path = Path(schema_path_str)
+            if not schema_path.is_absolute():
+                schema_path = config_path.parent / schema_path
+            logger.emit("persist", "Persisting cash flow statement to SerenDB")
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            persist_cashflow_statement(db_url, schema_path, run_record, statement)
+            logger.emit("persist_done", "SerenDB persistence complete")
+        else:
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            logger.emit("persist_skipped", "SerenDB persistence skipped")
+
+        logger.emit("complete", "Cash flow statement generation complete")
+        print(f"\nCash Flow Statement generated successfully!")
+        print(f"  Markdown: {md_path}")
+        print(f"  JSON:     {json_path}")
+        print(f"  Period:   {period_start} to {period_end}")
+        print(f"  Transactions: {len(transactions)}")
+        print(f"  Net Cash Change: ${statement['net_cash_change']:,.2f}")
+
+    except Exception as exc:
+        run_record["status"] = "error"
+        run_record["ended_at"] = utc_now_iso()
+        logger.emit("error", str(exc), error_type=type(exc).__name__)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wellsfargo/cash-flow-statement/skill.spec.yaml
+++ b/wellsfargo/cash-flow-statement/skill.spec.yaml
@@ -1,0 +1,59 @@
+skill: cash-flow-statement
+description: Generate operating, investing, and financing cash flow statements from Wells Fargo transaction data stored in SerenDB.
+triggers:
+  - generate wells fargo cash flow statement
+  - create wellsfargo cash flow report
+  - build cash flow statement from wells fargo data
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 1
+    max: 24
+    default: 12
+  start:
+    type: string
+    description: Start date (YYYY-MM-DD). Overrides months if provided.
+  end:
+    type: string
+    description: End date (YYYY-MM-DD). Defaults to today if start is provided.
+  out:
+    type: string
+    default: artifacts/cash-flow-statement
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  checkpoints:
+    kind: sqlite
+    file: artifacts/cash-flow-statement/state/checkpoint.json
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: classify_activities
+      use: transform.map_activities
+    - id: build_statement
+      use: transform.aggregate_activities
+    - id: render_report
+      use: transform.render
+    - id: persist_statement
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: cash-flow-statement
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/cash-flow-statement/sql/queries.sql
+++ b/wellsfargo/cash-flow-statement/sql/queries.sql
@@ -1,0 +1,31 @@
+-- fetch_categorized_transactions: retrieve all categorized transactions for a date range
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;
+
+-- fetch_cashflow_summary: retrieve cash flow totals by activity for a date range
+SELECT
+  activity,
+  SUM(CASE WHEN direction = 'inflow' THEN amount ELSE 0 END) AS total_inflows,
+  SUM(CASE WHEN direction = 'outflow' THEN amount ELSE 0 END) AS total_outflows,
+  SUM(amount) AS net,
+  COUNT(*) AS txn_count
+FROM wf_cashflow_activities a
+JOIN wf_cashflow_runs r ON r.run_id = a.run_id
+WHERE r.status = 'success'
+  AND r.period_start >= %(start_date)s
+  AND r.period_end <= %(end_date)s
+GROUP BY activity
+ORDER BY activity;

--- a/wellsfargo/cash-flow-statement/sql/schema.sql
+++ b/wellsfargo/cash-flow-statement/sql/schema.sql
@@ -1,0 +1,71 @@
+CREATE TABLE IF NOT EXISTS wf_cashflow_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  operating_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  investing_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  financing_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_cash_change NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_cashflow_activities (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_cashflow_runs(run_id) ON DELETE CASCADE,
+  activity TEXT NOT NULL,
+  line_item_key TEXT NOT NULL,
+  label TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, activity, line_item_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_cashflow_activities_run ON wf_cashflow_activities(run_id);
+
+CREATE TABLE IF NOT EXISTS wf_cashflow_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_cashflow_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  operating_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  investing_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  financing_net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_cash_change NUMERIC(14,2) NOT NULL DEFAULT 0,
+  activities_json JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_cashflow_snapshots_period ON wf_cashflow_snapshots(period_start, period_end);
+
+CREATE OR REPLACE VIEW v_wf_cashflow_latest AS
+SELECT s.*
+FROM wf_cashflow_snapshots s
+JOIN wf_cashflow_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_cashflow_runs r2
+  WHERE r2.status = 'success'
+);
+
+CREATE OR REPLACE VIEW v_wf_cashflow_by_month AS
+SELECT
+  a.run_id,
+  a.activity,
+  a.line_item_key,
+  a.label,
+  a.direction,
+  a.amount,
+  a.txn_count,
+  r.period_start,
+  r.period_end
+FROM wf_cashflow_activities a
+JOIN wf_cashflow_runs r ON r.run_id = a.run_id
+WHERE r.status = 'success'
+ORDER BY r.period_start DESC, a.activity, a.line_item_key;

--- a/wellsfargo/cash-flow-statement/tests/test_smoke.py
+++ b/wellsfargo/cash-flow-statement/tests/test_smoke.py
@@ -1,0 +1,165 @@
+"""Smoke tests for the cash flow statement builder (no DB required)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Allow importing from scripts/
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from cashflow_builder import build_cashflow_statement, classify_activity, render_markdown  # noqa: E402
+from datetime import date  # noqa: E402
+
+
+ACTIVITY_MAP = json.loads(
+    (Path(__file__).resolve().parent.parent / "config" / "activity_map.json").read_text()
+)
+
+
+def _make_txn(amount: float, category: str = "uncategorized") -> dict:
+    return {
+        "row_hash": f"hash_{abs(hash((amount, category)))}",
+        "account_masked": "****1234",
+        "txn_date": "2025-06-15",
+        "description_raw": f"Test txn {category}",
+        "amount": amount,
+        "currency": "USD",
+        "category": category,
+        "category_source": "test",
+        "confidence": 1.0,
+    }
+
+
+class TestClassifyActivity:
+    def test_payroll_is_operating_inflow(self) -> None:
+        txn = _make_txn(5000.0, "payroll")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert key == "payroll"
+        assert direction == "inflow"
+
+    def test_housing_is_operating_outflow(self) -> None:
+        txn = _make_txn(-2000.0, "housing")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert key == "housing"
+        assert direction == "outflow"
+
+    def test_transfers_in_is_financing(self) -> None:
+        txn = _make_txn(500.0, "transfers_in")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "financing"
+        assert key == "transfers_in"
+        assert direction == "inflow"
+
+    def test_transfers_out_is_financing(self) -> None:
+        txn = _make_txn(-300.0, "transfers_out")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "financing"
+        assert key == "transfers_out"
+        assert direction == "outflow"
+
+    def test_uncategorized_positive_is_operating_inflow(self) -> None:
+        txn = _make_txn(100.0, "uncategorized")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert key == "other_operating_inflow"
+        assert direction == "inflow"
+
+    def test_uncategorized_negative_is_operating_outflow(self) -> None:
+        txn = _make_txn(-50.0, "uncategorized")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert key == "other_operating_outflow"
+        assert direction == "outflow"
+
+    def test_unknown_category_positive(self) -> None:
+        txn = _make_txn(200.0, "mystery_category")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert direction == "inflow"
+
+    def test_unknown_category_negative(self) -> None:
+        txn = _make_txn(-75.0, "mystery_category")
+        activity, key, direction = classify_activity(txn, ACTIVITY_MAP)
+        assert activity == "operating"
+        assert direction == "outflow"
+
+
+class TestBuildCashflowStatement:
+    def test_basic_statement(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "payroll"),
+            _make_txn(50.0, "interest_income"),
+            _make_txn(-2000.0, "housing"),
+            _make_txn(-300.0, "groceries"),
+            _make_txn(500.0, "transfers_in"),
+            _make_txn(-200.0, "transfers_out"),
+        ]
+        stmt = build_cashflow_statement(transactions, ACTIVITY_MAP)
+
+        # Operating: 5000 + 50 inflows - 2000 - 300 outflows = 2750
+        assert stmt["operating_net"] == 2750.0
+        # Financing: 500 inflow - 200 outflow = 300
+        assert stmt["financing_net"] == 300.0
+        assert stmt["investing_net"] == 0.0
+        assert stmt["net_cash_change"] == 3050.0
+
+    def test_empty_transactions(self) -> None:
+        stmt = build_cashflow_statement([], ACTIVITY_MAP)
+        assert stmt["operating_net"] == 0.0
+        assert stmt["investing_net"] == 0.0
+        assert stmt["financing_net"] == 0.0
+        assert stmt["net_cash_change"] == 0.0
+
+    def test_all_operating(self) -> None:
+        transactions = [
+            _make_txn(3000.0, "payroll"),
+            _make_txn(-1000.0, "groceries"),
+        ]
+        stmt = build_cashflow_statement(transactions, ACTIVITY_MAP)
+        assert stmt["operating_net"] == 2000.0
+        assert stmt["investing_net"] == 0.0
+        assert stmt["financing_net"] == 0.0
+        assert stmt["net_cash_change"] == 2000.0
+
+    def test_negative_net_cash(self) -> None:
+        transactions = [
+            _make_txn(1000.0, "payroll"),
+            _make_txn(-3000.0, "housing"),
+            _make_txn(-500.0, "transfers_out"),
+        ]
+        stmt = build_cashflow_statement(transactions, ACTIVITY_MAP)
+        assert stmt["operating_net"] == -2000.0
+        assert stmt["financing_net"] == -500.0
+        assert stmt["net_cash_change"] == -2500.0
+
+
+class TestRenderMarkdown:
+    def test_render_produces_valid_markdown(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "payroll"),
+            _make_txn(-1500.0, "housing"),
+            _make_txn(500.0, "transfers_in"),
+        ]
+        stmt = build_cashflow_statement(transactions, ACTIVITY_MAP)
+        md = render_markdown(
+            stmt,
+            period_start=date(2025, 1, 1),
+            period_end=date(2025, 12, 31),
+            run_id="test-run-001",
+            txn_count=3,
+        )
+
+        assert "# Wells Fargo Cash Flow Statement" in md
+        assert "2025-01-01" in md
+        assert "2025-12-31" in md
+        assert "test-run-001" in md
+        assert "Operating Activities" in md
+        assert "Investing Activities" in md
+        assert "Financing Activities" in md
+        assert "Net Cash Change" in md
+        assert "Salary & Wages Received" in md
+        assert "Rent / Mortgage Payments" in md


### PR DESCRIPTION
## Summary
- New `wellsfargo/cash-flow-statement` skill that generates cash flow statements from SerenDB transaction data
- Classifies transactions into Operating, Investing, and Financing activities using `config/activity_map.json`
- Produces Markdown and JSON reports, persists snapshots to SerenDB (`wf_cashflow_*` tables)
- Includes 13 smoke tests (all passing) covering activity classification, statement building, and markdown rendering

## Test plan
- [x] Run `pytest wellsfargo/cash-flow-statement/tests/test_smoke.py` — 13 tests pass
- [ ] Verify SKILL.md frontmatter matches agentskills.io spec
- [ ] Confirm SerenDB schema applies cleanly against a live instance

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com