### PR TITLE
feat(wellsfargo): add recurring-transactions skill

### DIFF
--- a/wellsfargo/recurring-transactions/.env.example
+++ b/wellsfargo/recurring-transactions/.env.example
@@ -1,0 +1,5 @@
+# Optional override: explicit SERENDB connection string.
+# If empty, scripts/run.py resolves this automatically from your logged-in
+# Seren CLI/MCP context via `seren env init`.
+# Example: postgresql://user:pass@host:5432/serendb
+WF_SERENDB_URL=

--- a/wellsfargo/recurring-transactions/.gitignore
+++ b/wellsfargo/recurring-transactions/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/recurring-transactions/SKILL.md
+++ b/wellsfargo/recurring-transactions/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: recurring-transactions
+description: "Detect and track recurring subscriptions, bills, and regular payments from Wells Fargo transaction data stored in SerenDB."
+---
+
+# Wells Fargo Recurring Transactions
+
+## When To Use
+
+- Detect recurring subscriptions, bills, and regular payments from transaction history.
+- Track recurring transaction frequency, amounts, and next expected dates.
+- Identify spending commitments and subscription creep.
+- Persist detected recurring patterns into SerenDB for downstream analysis.
+
+## Prerequisites
+
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+- At least 3 months of transaction data recommended for accurate detection.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables (`wf_transactions`, `wf_txn_categories`).
+- Writes only to dedicated `wf_recurring_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+- All amounts sourced from already-masked account data.
+
+## Workflow Summary
+
+1. `resolve_serendb` connects to SerenDB using the same resolution chain as bank-statement-processing.
+2. `query_transactions` fetches categorized transactions for the analysis window.
+3. `detect_recurring` groups transactions by normalized payee and amount to find repeating patterns.
+4. `score_patterns` assigns confidence scores based on frequency regularity and amount consistency.
+5. `render_report` produces Markdown and JSON output files.
+6. `persist_patterns` upserts detected recurring patterns into SerenDB.
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+cd wellsfargo/recurring-transactions
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+cp config.example.json config.json
+```
+
+2. Detect recurring transactions from the last 12 months:
+
+```bash
+python3 scripts/run.py --config config.json --months 12 --out artifacts/recurring-transactions
+```
+
+## Commands
+
+```bash
+# Last 12 months (default)
+python3 scripts/run.py --config config.json --months 12 --out artifacts/recurring-transactions
+
+# Specific date range
+python3 scripts/run.py --config config.json --start 2025-01-01 --end 2025-12-31 --out artifacts/recurring-transactions
+
+# Higher confidence threshold
+python3 scripts/run.py --config config.json --months 12 --min-confidence 0.8 --out artifacts/recurring-transactions
+
+# Skip SerenDB persistence (local reports only)
+python3 scripts/run.py --config config.json --months 12 --skip-persist --out artifacts/recurring-transactions
+```
+
+## Outputs
+
+- Markdown report: `artifacts/recurring-transactions/reports/<run_id>.md`
+- JSON report: `artifacts/recurring-transactions/reports/<run_id>.json`
+- Pattern export: `artifacts/recurring-transactions/exports/<run_id>.patterns.jsonl`
+
+## SerenDB Tables
+
+- `wf_recurring_runs` - recurring detection runs
+- `wf_recurring_patterns` - detected recurring transaction patterns
+- `wf_recurring_snapshots` - summary snapshot per run
+
+## Reusable Views
+
+- `v_wf_recurring_latest` - most recent recurring pattern snapshot
+- `v_wf_recurring_active` - currently active recurring transactions

--- a/wellsfargo/recurring-transactions/config.example.json
+++ b/wellsfargo/recurring-transactions/config.example.json
@@ -1,0 +1,22 @@
+{
+  "runtime": {
+    "artifacts_subdir": "recurring-transactions"
+  },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
+  },
+  "detection": {
+    "min_occurrences": 3,
+    "amount_tolerance_pct": 0.15,
+    "min_confidence": 0.5
+  }
+}

--- a/wellsfargo/recurring-transactions/config/frequency_rules.json
+++ b/wellsfargo/recurring-transactions/config/frequency_rules.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Rules for detecting transaction frequency from day-of-month intervals.",
+  "frequencies": {
+    "weekly": {
+      "label": "Weekly",
+      "interval_days_min": 5,
+      "interval_days_max": 9,
+      "expected_interval": 7
+    },
+    "biweekly": {
+      "label": "Bi-Weekly",
+      "interval_days_min": 12,
+      "interval_days_max": 16,
+      "expected_interval": 14
+    },
+    "monthly": {
+      "label": "Monthly",
+      "interval_days_min": 25,
+      "interval_days_max": 35,
+      "expected_interval": 30
+    },
+    "quarterly": {
+      "label": "Quarterly",
+      "interval_days_min": 80,
+      "interval_days_max": 100,
+      "expected_interval": 91
+    },
+    "annual": {
+      "label": "Annual",
+      "interval_days_min": 350,
+      "interval_days_max": 380,
+      "expected_interval": 365
+    }
+  }
+}

--- a/wellsfargo/recurring-transactions/requirements.txt
+++ b/wellsfargo/recurring-transactions/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/recurring-transactions/scripts/recurring_detector.py
+++ b/wellsfargo/recurring-transactions/scripts/recurring_detector.py
@@ -1,0 +1,272 @@
+"""Pure-logic recurring transaction detector (no DB dependencies)."""
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from collections import defaultdict
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def load_frequency_rules(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Frequency rules not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_payee(description: str) -> str:
+    """Normalize a transaction description to a canonical payee name."""
+    text = description.upper().strip()
+    # Remove common prefixes
+    for prefix in ("POS ", "ACH ", "DEBIT ", "CREDIT ", "ONLINE ", "RECURRING ", "AUTOPAY "):
+        if text.startswith(prefix):
+            text = text[len(prefix):]
+    # Remove trailing reference numbers (#123, REF:456, etc.)
+    text = re.sub(r"\s*[#]?\d{4,}$", "", text)
+    text = re.sub(r"\s*REF:\S+$", "", text)
+    # Remove date patterns
+    text = re.sub(r"\s*\d{1,2}/\d{1,2}(/\d{2,4})?", "", text)
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _detect_frequency(
+    dates: list[date],
+    frequency_rules: dict[str, Any],
+) -> tuple[str, float]:
+    """Determine the most likely frequency from a sorted list of dates.
+
+    Returns (frequency_name, regularity_score).
+    """
+    if len(dates) < 2:
+        return "unknown", 0.0
+
+    intervals = []
+    for i in range(1, len(dates)):
+        intervals.append((dates[i] - dates[i - 1]).days)
+
+    if not intervals:
+        return "unknown", 0.0
+
+    median_interval = statistics.median(intervals)
+    rules = frequency_rules.get("frequencies", {})
+
+    best_freq = "irregular"
+    best_score = 0.0
+
+    for freq_name, rule in rules.items():
+        lo = rule["interval_days_min"]
+        hi = rule["interval_days_max"]
+        expected = rule["expected_interval"]
+
+        if lo <= median_interval <= hi:
+            # Score based on how consistent intervals are relative to expected
+            deviations = [abs(iv - expected) / expected for iv in intervals]
+            avg_dev = statistics.mean(deviations)
+            score = max(0.0, 1.0 - avg_dev)
+            if score > best_score:
+                best_freq = freq_name
+                best_score = score
+
+    return best_freq, round(best_score, 4)
+
+
+def detect_recurring_patterns(
+    transactions: list[dict[str, Any]],
+    frequency_rules: dict[str, Any],
+    min_occurrences: int = 3,
+    amount_tolerance_pct: float = 0.15,
+    min_confidence: float = 0.5,
+) -> list[dict[str, Any]]:
+    """Detect recurring transaction patterns from a list of transactions.
+
+    Groups transactions by normalized payee and amount similarity,
+    then checks for frequency regularity.
+    """
+    # Group by normalized payee
+    payee_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for txn in transactions:
+        payee = normalize_payee(str(txn.get("description_raw", "")))
+        if payee:
+            payee_groups[payee].append(txn)
+
+    patterns: list[dict[str, Any]] = []
+
+    for payee, txns in payee_groups.items():
+        if len(txns) < min_occurrences:
+            continue
+
+        # Sub-group by similar amounts
+        amount_groups = _group_by_amount(txns, amount_tolerance_pct)
+
+        for amount_group in amount_groups:
+            if len(amount_group) < min_occurrences:
+                continue
+
+            amounts = [abs(float(t.get("amount", 0))) for t in amount_group]
+            dates = sorted(
+                [_parse_date(t.get("txn_date", "")) for t in amount_group if _parse_date(t.get("txn_date", ""))]
+            )
+
+            if len(dates) < min_occurrences:
+                continue
+
+            freq_name, regularity = _detect_frequency(dates, frequency_rules)
+            if freq_name in ("unknown", "irregular"):
+                continue
+
+            avg_amount = round(statistics.mean(amounts), 2)
+            median_amount = round(statistics.median(amounts), 2)
+
+            # Confidence = regularity * amount_consistency
+            amount_std = statistics.stdev(amounts) if len(amounts) > 1 else 0.0
+            amount_consistency = max(0.0, 1.0 - (amount_std / avg_amount)) if avg_amount > 0 else 0.0
+            confidence = round(regularity * amount_consistency, 4)
+
+            if confidence < min_confidence:
+                continue
+
+            category = str(amount_group[0].get("category", "uncategorized"))
+            last_seen = dates[-1]
+            expected_interval = frequency_rules.get("frequencies", {}).get(freq_name, {}).get("expected_interval", 30)
+            next_expected = last_seen + timedelta(days=expected_interval)
+
+            patterns.append({
+                "payee_normalized": payee,
+                "category": category,
+                "frequency": freq_name,
+                "avg_amount": avg_amount,
+                "median_amount": median_amount,
+                "occurrence_count": len(amount_group),
+                "confidence": confidence,
+                "first_seen": dates[0].isoformat(),
+                "last_seen": last_seen.isoformat(),
+                "next_expected": next_expected.isoformat(),
+                "is_active": (date.today() - last_seen).days < expected_interval * 2,
+            })
+
+    # Sort by average amount descending
+    patterns.sort(key=lambda p: -p["avg_amount"])
+    return patterns
+
+
+def _group_by_amount(
+    txns: list[dict[str, Any]],
+    tolerance_pct: float,
+) -> list[list[dict[str, Any]]]:
+    """Group transactions by similar absolute amounts."""
+    groups: list[list[dict[str, Any]]] = []
+    remaining = list(txns)
+
+    while remaining:
+        seed = remaining.pop(0)
+        seed_amount = abs(float(seed.get("amount", 0)))
+        group = [seed]
+        new_remaining = []
+
+        for txn in remaining:
+            txn_amount = abs(float(txn.get("amount", 0)))
+            if seed_amount == 0:
+                if txn_amount == 0:
+                    group.append(txn)
+                else:
+                    new_remaining.append(txn)
+            elif abs(txn_amount - seed_amount) / seed_amount <= tolerance_pct:
+                group.append(txn)
+            else:
+                new_remaining.append(txn)
+
+        remaining = new_remaining
+        groups.append(group)
+
+    return groups
+
+
+def _parse_date(val: Any) -> date | None:
+    if isinstance(val, date):
+        return val
+    if isinstance(val, str):
+        try:
+            return date.fromisoformat(val[:10])
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
+def compute_summary(patterns: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute summary statistics from detected patterns."""
+    monthly_rates = {
+        "weekly": 4.33,
+        "biweekly": 2.17,
+        "monthly": 1.0,
+        "quarterly": 1 / 3,
+        "annual": 1 / 12,
+    }
+
+    total_monthly = 0.0
+    active_count = 0
+    for p in patterns:
+        rate = monthly_rates.get(p["frequency"], 1.0)
+        total_monthly += p["avg_amount"] * rate
+        if p.get("is_active", False):
+            active_count += 1
+
+    return {
+        "patterns_found": len(patterns),
+        "active_patterns": active_count,
+        "total_monthly_committed": round(total_monthly, 2),
+        "total_annual_committed": round(total_monthly * 12, 2),
+    }
+
+
+def render_markdown(
+    patterns: list[dict[str, Any]],
+    summary: dict[str, Any],
+    period_start: date,
+    period_end: date,
+    run_id: str,
+    txn_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Wells Fargo Recurring Transactions")
+    lines.append("")
+    lines.append(f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}")
+    lines.append(f"**Run ID:** {run_id}")
+    lines.append(f"**Transactions analyzed:** {txn_count}")
+    lines.append(f"**Recurring patterns found:** {summary['patterns_found']}")
+    lines.append(f"**Active patterns:** {summary['active_patterns']}")
+    lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|------:|")
+    lines.append(f"| Est. Monthly Committed | ${summary['total_monthly_committed']:,.2f} |")
+    lines.append(f"| Est. Annual Committed | ${summary['total_annual_committed']:,.2f} |")
+    lines.append(f"| Patterns Detected | {summary['patterns_found']} |")
+    lines.append(f"| Active Patterns | {summary['active_patterns']} |")
+    lines.append("")
+
+    if patterns:
+        lines.append("## Detected Recurring Transactions")
+        lines.append("")
+        lines.append("| Payee | Frequency | Avg Amount | Occurrences | Confidence | Last Seen | Next Expected | Active |")
+        lines.append("|-------|-----------|----------:|------------:|----------:|-----------|---------------|--------|")
+        for p in patterns:
+            active_str = "Yes" if p.get("is_active") else "No"
+            lines.append(
+                f"| {p['payee_normalized']} "
+                f"| {p['frequency'].title()} "
+                f"| ${p['avg_amount']:,.2f} "
+                f"| {p['occurrence_count']} "
+                f"| {p['confidence']:.1%} "
+                f"| {p['last_seen']} "
+                f"| {p['next_expected']} "
+                f"| {active_str} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/wellsfargo/recurring-transactions/scripts/run.py
+++ b/wellsfargo/recurring-transactions/scripts/run.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Wells Fargo Recurring Transaction Detector.
+
+Reads categorized transaction data from SerenDB (populated by bank-statement-processing)
+and detects recurring subscriptions, bills, and regular payments.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from recurring_detector import (
+    compute_summary,
+    detect_recurring_patterns,
+    load_frequency_rules,
+    render_markdown,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MONTHS = 12
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+
+# ---------------------------------------------------------------------------
+# SerenDB resolution (mirrors bank-statement-processing logic)
+# ---------------------------------------------------------------------------
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload: Any = None
+    if result.stdout.strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+    return result.returncode, payload, result.stderr.strip()
+
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+
+def resolve_serendb_database_url(
+    config: dict[str, Any],
+    logger: RunLogger,
+) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+
+    from_env = os.getenv(env_key, "").strip()
+    if from_env:
+        return from_env, f"env:{env_key}"
+
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and auto-resolve is disabled."
+        )
+
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and `seren` CLI was not found in PATH."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wf-recurring-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [
+            seren_bin, "env", "init",
+            "--env", str(env_path),
+            "--key", env_key,
+            "--yes", "-o", "json",
+        ]
+        if bool(serendb_cfg.get("pooled_connection", True)):
+            base_cmd.append("--pooled")
+
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        explicit_pid = str(serendb_cfg.get("project_id", "")).strip()
+        explicit_bid = str(serendb_cfg.get("branch_id", "")).strip()
+        if explicit_pid and explicit_bid:
+            candidates.append((explicit_pid, explicit_bid, "explicit"))
+            seen.add((explicit_pid, explicit_bid))
+
+        for row in rows:
+            pid = row.get("project_id", "").strip()
+            bid = row.get("branch_id", "").strip()
+            if not pid or not bid:
+                continue
+            key = (pid, bid)
+            if key in seen:
+                continue
+            rp = row.get("project_name", "").strip().lower()
+            rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project:
+                continue
+            if desired_database and rd != desired_database:
+                continue
+            seen.add(key)
+            label = f"catalog:{rp}/{row.get('branch_name', '')}/{rd}"
+            candidates.append((pid, bid, label))
+
+        if not candidates:
+            raise RuntimeError(
+                "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+                f"Could not infer a project/branch for {env_key}. "
+                "Set `serendb.project_id` + `serendb.branch_id`, or provide WF_SERENDB_URL."
+            )
+
+        attempt_errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved:
+                    os.environ[env_key] = resolved
+                    logger.emit(
+                        "serendb_url_resolved",
+                        "Resolved SerenDB URL from Seren CLI context",
+                        env_key=env_key,
+                        source=f"seren_cli_context:{source}",
+                    )
+                    return resolved, f"seren_cli_context:{source}"
+                attempt_errors.append(f"{source}: empty dotenv write")
+                continue
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            details = stderr or stdout or "unknown error"
+            attempt_errors.append(f"{source}: {details}")
+
+        preview = "; ".join(attempt_errors[:5])
+        raise RuntimeError(
+            "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+            f"Tried {len(candidates)} candidates for {env_key}. "
+            f"Errors: {preview}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+QUERY_CATEGORIZED_TRANSACTIONS = """
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+
+def fetch_transactions(
+    database_url: str,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                QUERY_CATEGORIZED_TRANSACTIONS,
+                {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()},
+            )
+            columns = [desc.name for desc in cur.description]
+            rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# SerenDB persistence
+# ---------------------------------------------------------------------------
+
+def _read_sql(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def persist_recurring_patterns(
+    database_url: str,
+    schema_path: Path,
+    run_record: dict[str, Any],
+    patterns: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> None:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_read_sql(schema_path))
+
+            cur.execute(
+                """
+                INSERT INTO wf_recurring_runs (
+                  run_id, started_at, ended_at, status,
+                  period_start, period_end,
+                  patterns_found, total_monthly_committed,
+                  txn_count, artifact_root
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  ended_at = EXCLUDED.ended_at,
+                  status = EXCLUDED.status,
+                  patterns_found = EXCLUDED.patterns_found,
+                  total_monthly_committed = EXCLUDED.total_monthly_committed,
+                  txn_count = EXCLUDED.txn_count
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["started_at"],
+                    run_record["ended_at"],
+                    run_record["status"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    summary["patterns_found"],
+                    summary["total_monthly_committed"],
+                    run_record["txn_count"],
+                    run_record["artifact_root"],
+                ),
+            )
+
+            for p in patterns:
+                cur.execute(
+                    """
+                    INSERT INTO wf_recurring_patterns (
+                      run_id, payee_normalized, category, frequency,
+                      avg_amount, median_amount, occurrence_count,
+                      confidence, first_seen, last_seen, next_expected, is_active
+                    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT (run_id, payee_normalized, frequency)
+                    DO UPDATE SET
+                      category = EXCLUDED.category,
+                      avg_amount = EXCLUDED.avg_amount,
+                      median_amount = EXCLUDED.median_amount,
+                      occurrence_count = EXCLUDED.occurrence_count,
+                      confidence = EXCLUDED.confidence,
+                      first_seen = EXCLUDED.first_seen,
+                      last_seen = EXCLUDED.last_seen,
+                      next_expected = EXCLUDED.next_expected,
+                      is_active = EXCLUDED.is_active
+                    """,
+                    (
+                        run_record["run_id"],
+                        p["payee_normalized"],
+                        p["category"],
+                        p["frequency"],
+                        p["avg_amount"],
+                        p["median_amount"],
+                        p["occurrence_count"],
+                        p["confidence"],
+                        p["first_seen"],
+                        p["last_seen"],
+                        p["next_expected"],
+                        p["is_active"],
+                    ),
+                )
+
+            snapshot_json = json.dumps(patterns, default=str)
+            cur.execute(
+                """
+                INSERT INTO wf_recurring_snapshots (
+                  run_id, period_start, period_end,
+                  patterns_found, total_monthly_committed,
+                  patterns_json
+                ) VALUES (%s,%s,%s,%s,%s,%s::jsonb)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  patterns_found = EXCLUDED.patterns_found,
+                  total_monthly_committed = EXCLUDED.total_monthly_committed,
+                  patterns_json = EXCLUDED.patterns_json
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    summary["patterns_found"],
+                    summary["total_monthly_committed"],
+                    snapshot_json,
+                ),
+            )
+
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect recurring transactions from Wells Fargo SerenDB data",
+    )
+    parser.add_argument("--config", default="config.json", help="Path to config JSON")
+    parser.add_argument("--months", type=int, default=DEFAULT_MONTHS, help=f"Months to analyze (default {DEFAULT_MONTHS})")
+    parser.add_argument("--start", type=str, default="", help="Start date (YYYY-MM-DD), overrides --months")
+    parser.add_argument("--end", type=str, default="", help="End date (YYYY-MM-DD), defaults to today")
+    parser.add_argument("--min-confidence", type=float, default=0.5, help="Minimum confidence threshold (default 0.5)")
+    parser.add_argument("--out", type=str, default="artifacts/recurring-transactions", help="Output directory")
+    parser.add_argument("--skip-persist", action="store_true", help="Skip SerenDB persistence")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    today = date.today()
+    if args.start:
+        period_start = date.fromisoformat(args.start)
+        period_end = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        period_start = today - relativedelta(months=args.months)
+        period_end = today
+
+    out_dir = Path(args.out)
+    report_dir = ensure_dir(out_dir / "reports")
+    export_dir = ensure_dir(out_dir / "exports")
+    log_dir = ensure_dir(out_dir / "logs")
+
+    run_id = f"recurring-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{run_id}.jsonl")
+
+    logger.emit("start", "Recurring transaction detection started", run_id=run_id)
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id,
+        "started_at": utc_now_iso(),
+        "ended_at": None,
+        "status": "running",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "txn_count": 0,
+        "artifact_root": str(out_dir.resolve()),
+    }
+
+    try:
+        db_url, db_source = resolve_serendb_database_url(config, logger)
+        logger.emit("serendb_connected", f"Connected via {db_source}")
+
+        logger.emit("query_transactions", "Fetching categorized transactions from SerenDB")
+        transactions = fetch_transactions(db_url, period_start, period_end)
+        logger.emit("query_transactions_done", f"Fetched {len(transactions)} transactions", count=len(transactions))
+
+        if not transactions:
+            logger.emit("warn", "No transactions found for the specified period.")
+            run_record["status"] = "empty"
+            run_record["ended_at"] = utc_now_iso()
+            print("No transactions found. Ensure bank-statement-processing has synced data to SerenDB.")
+            sys.exit(0)
+
+        run_record["txn_count"] = len(transactions)
+
+        rules_path_str = config.get("frequency_rules_path", "config/frequency_rules.json")
+        rules_path = Path(rules_path_str)
+        if not rules_path.is_absolute():
+            rules_path = config_path.parent / rules_path
+        # Use default rules if no custom file
+        if not rules_path.exists():
+            rules_path = SCRIPT_DIR.parent / "config" / "frequency_rules.json"
+        frequency_rules = load_frequency_rules(rules_path)
+
+        detection_cfg = config.get("detection", {})
+        min_occ = int(detection_cfg.get("min_occurrences", 3))
+        amt_tol = float(detection_cfg.get("amount_tolerance_pct", 0.15))
+        min_conf = args.min_confidence
+
+        logger.emit("detect", "Detecting recurring patterns")
+        patterns = detect_recurring_patterns(
+            transactions, frequency_rules,
+            min_occurrences=min_occ,
+            amount_tolerance_pct=amt_tol,
+            min_confidence=min_conf,
+        )
+        summary = compute_summary(patterns)
+        logger.emit("detect_done", f"Found {len(patterns)} recurring patterns", **summary)
+
+        md_content = render_markdown(patterns, summary, period_start, period_end, run_id, len(transactions))
+        md_path = report_dir / f"{run_id}.md"
+        md_path.write_text(md_content, encoding="utf-8")
+
+        json_report = {
+            "run_id": run_id,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "txn_count": len(transactions),
+            "summary": summary,
+            "patterns": patterns,
+        }
+        json_path = report_dir / f"{run_id}.json"
+        dump_json(json_path, json_report)
+
+        export_path = export_dir / f"{run_id}.patterns.jsonl"
+        for p in patterns:
+            append_jsonl(export_path, p)
+
+        logger.emit("render_done", "Reports written", md=str(md_path), json=str(json_path))
+
+        if not args.skip_persist and bool(config.get("serendb", {}).get("enabled", True)):
+            schema_path_str = config.get("serendb", {}).get("schema_path", "sql/schema.sql")
+            schema_path = Path(schema_path_str)
+            if not schema_path.is_absolute():
+                schema_path = config_path.parent / schema_path
+            logger.emit("persist", "Persisting recurring patterns to SerenDB")
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            persist_recurring_patterns(db_url, schema_path, run_record, patterns, summary)
+            logger.emit("persist_done", "SerenDB persistence complete")
+        else:
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            logger.emit("persist_skipped", "SerenDB persistence skipped")
+
+        logger.emit("complete", "Recurring transaction detection complete")
+        print(f"\nRecurring Transactions detected successfully!")
+        print(f"  Markdown: {md_path}")
+        print(f"  JSON:     {json_path}")
+        print(f"  Patterns found: {summary['patterns_found']}")
+        print(f"  Est. monthly committed: ${summary['total_monthly_committed']:,.2f}")
+
+    except Exception as exc:
+        run_record["status"] = "error"
+        run_record["ended_at"] = utc_now_iso()
+        logger.emit("error", str(exc), error_type=type(exc).__name__)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wellsfargo/recurring-transactions/skill.spec.yaml
+++ b/wellsfargo/recurring-transactions/skill.spec.yaml
@@ -1,0 +1,64 @@
+skill: recurring-transactions
+description: Detect and track recurring subscriptions, bills, and regular payments from Wells Fargo transaction data stored in SerenDB.
+triggers:
+  - detect wells fargo recurring transactions
+  - find wellsfargo subscriptions and bills
+  - track recurring payments from wells fargo data
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 3
+    max: 24
+    default: 12
+  start:
+    type: string
+    description: Start date (YYYY-MM-DD). Overrides months if provided.
+  end:
+    type: string
+    description: End date (YYYY-MM-DD). Defaults to today if start is provided.
+  min_confidence:
+    type: number
+    min: 0.0
+    max: 1.0
+    default: 0.5
+  out:
+    type: string
+    default: artifacts/recurring-transactions
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  checkpoints:
+    kind: sqlite
+    file: artifacts/recurring-transactions/state/checkpoint.json
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: detect_recurring
+      use: transform.detect_patterns
+    - id: score_patterns
+      use: transform.score_patterns
+    - id: render_report
+      use: transform.render
+    - id: persist_patterns
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: recurring-transactions
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/recurring-transactions/sql/queries.sql
+++ b/wellsfargo/recurring-transactions/sql/queries.sql
@@ -1,0 +1,32 @@
+-- fetch_categorized_transactions: retrieve all categorized transactions for a date range
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;
+
+-- fetch_active_recurring: retrieve all currently active recurring patterns
+SELECT
+  payee_normalized,
+  category,
+  frequency,
+  avg_amount,
+  occurrence_count,
+  confidence,
+  last_seen,
+  next_expected
+FROM wf_recurring_patterns p
+JOIN wf_recurring_runs r ON r.run_id = p.run_id
+WHERE r.status = 'success'
+  AND p.is_active = TRUE
+ORDER BY p.avg_amount DESC;

--- a/wellsfargo/recurring-transactions/sql/schema.sql
+++ b/wellsfargo/recurring-transactions/sql/schema.sql
@@ -1,0 +1,70 @@
+CREATE TABLE IF NOT EXISTS wf_recurring_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  patterns_found INTEGER NOT NULL DEFAULT 0,
+  total_monthly_committed NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_recurring_patterns (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_recurring_runs(run_id) ON DELETE CASCADE,
+  payee_normalized TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'uncategorized',
+  frequency TEXT NOT NULL,
+  avg_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  median_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  occurrence_count INTEGER NOT NULL DEFAULT 0,
+  confidence NUMERIC(5,4) NOT NULL DEFAULT 0,
+  first_seen DATE NOT NULL,
+  last_seen DATE NOT NULL,
+  next_expected DATE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, payee_normalized, frequency)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_recurring_patterns_run ON wf_recurring_patterns(run_id);
+CREATE INDEX IF NOT EXISTS idx_wf_recurring_patterns_payee ON wf_recurring_patterns(payee_normalized);
+
+CREATE TABLE IF NOT EXISTS wf_recurring_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_recurring_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  patterns_found INTEGER NOT NULL DEFAULT 0,
+  total_monthly_committed NUMERIC(14,2) NOT NULL DEFAULT 0,
+  patterns_json JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_recurring_snapshots_period ON wf_recurring_snapshots(period_start, period_end);
+
+CREATE OR REPLACE VIEW v_wf_recurring_latest AS
+SELECT s.*
+FROM wf_recurring_snapshots s
+JOIN wf_recurring_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_recurring_runs r2
+  WHERE r2.status = 'success'
+);
+
+CREATE OR REPLACE VIEW v_wf_recurring_active AS
+SELECT p.*
+FROM wf_recurring_patterns p
+JOIN wf_recurring_runs r ON r.run_id = p.run_id
+WHERE r.status = 'success'
+  AND p.is_active = TRUE
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_recurring_runs r2
+  WHERE r2.status = 'success'
+)
+ORDER BY p.avg_amount DESC;

--- a/wellsfargo/recurring-transactions/tests/test_smoke.py
+++ b/wellsfargo/recurring-transactions/tests/test_smoke.py
@@ -1,0 +1,199 @@
+"""Smoke tests for the recurring transaction detector (no DB required)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from datetime import date, timedelta
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from recurring_detector import (  # noqa: E402
+    compute_summary,
+    detect_recurring_patterns,
+    normalize_payee,
+    render_markdown,
+)
+
+FREQUENCY_RULES = json.loads(
+    (Path(__file__).resolve().parent.parent / "config" / "frequency_rules.json").read_text()
+)
+
+
+def _make_monthly_txns(payee: str, amount: float, category: str, count: int = 6) -> list[dict]:
+    """Generate monthly recurring transactions."""
+    base = date(2025, 1, 15)
+    txns = []
+    for i in range(count):
+        d = date(2025, 1 + i if 1 + i <= 12 else (1 + i) - 12, 15)
+        txns.append({
+            "row_hash": f"hash_{payee}_{i}",
+            "account_masked": "****1234",
+            "txn_date": d.isoformat(),
+            "description_raw": f"POS {payee} #{1000 + i}",
+            "amount": amount,
+            "currency": "USD",
+            "category": category,
+            "category_source": "test",
+            "confidence": 1.0,
+        })
+    return txns
+
+
+def _make_weekly_txns(payee: str, amount: float, category: str, count: int = 12) -> list[dict]:
+    """Generate weekly recurring transactions."""
+    base = date(2025, 1, 6)
+    txns = []
+    for i in range(count):
+        d = base + timedelta(weeks=i)
+        txns.append({
+            "row_hash": f"hash_{payee}_{i}",
+            "account_masked": "****1234",
+            "txn_date": d.isoformat(),
+            "description_raw": f"RECURRING {payee}",
+            "amount": amount,
+            "currency": "USD",
+            "category": category,
+            "category_source": "test",
+            "confidence": 1.0,
+        })
+    return txns
+
+
+class TestNormalizePayee:
+    def test_removes_pos_prefix(self) -> None:
+        assert normalize_payee("POS NETFLIX") == "NETFLIX"
+
+    def test_removes_trailing_numbers(self) -> None:
+        assert normalize_payee("NETFLIX 123456") == "NETFLIX"
+
+    def test_removes_ach_prefix(self) -> None:
+        assert normalize_payee("ACH SPOTIFY USA") == "SPOTIFY USA"
+
+    def test_collapses_whitespace(self) -> None:
+        assert normalize_payee("  AMAZON   PRIME  ") == "AMAZON PRIME"
+
+    def test_removes_ref(self) -> None:
+        assert normalize_payee("COMCAST REF:ABC123") == "COMCAST"
+
+
+class TestDetectRecurringPatterns:
+    def test_detects_monthly_subscription(self) -> None:
+        txns = _make_monthly_txns("NETFLIX", -15.99, "subscriptions", count=6)
+        patterns = detect_recurring_patterns(txns, FREQUENCY_RULES, min_occurrences=3, min_confidence=0.3)
+        assert len(patterns) >= 1
+        netflix = [p for p in patterns if "NETFLIX" in p["payee_normalized"]]
+        assert len(netflix) == 1
+        assert netflix[0]["frequency"] == "monthly"
+        assert netflix[0]["avg_amount"] == 15.99
+
+    def test_detects_weekly_pattern(self) -> None:
+        txns = _make_weekly_txns("PLANET FITNESS", -10.0, "healthcare", count=12)
+        patterns = detect_recurring_patterns(txns, FREQUENCY_RULES, min_occurrences=3, min_confidence=0.3)
+        assert len(patterns) >= 1
+        gym = [p for p in patterns if "PLANET FITNESS" in p["payee_normalized"]]
+        assert len(gym) == 1
+        assert gym[0]["frequency"] == "weekly"
+
+    def test_no_patterns_from_random_txns(self) -> None:
+        txns = [
+            {
+                "row_hash": f"hash_random_{i}",
+                "account_masked": "****1234",
+                "txn_date": date(2025, 1, 1 + i).isoformat(),
+                "description_raw": f"RANDOM MERCHANT {i}",
+                "amount": -float(i * 17 + 3),
+                "currency": "USD",
+                "category": "shopping",
+                "category_source": "test",
+                "confidence": 1.0,
+            }
+            for i in range(10)
+        ]
+        patterns = detect_recurring_patterns(txns, FREQUENCY_RULES, min_occurrences=3, min_confidence=0.5)
+        assert len(patterns) == 0
+
+    def test_respects_min_occurrences(self) -> None:
+        txns = _make_monthly_txns("HULU", -7.99, "subscriptions", count=2)
+        patterns = detect_recurring_patterns(txns, FREQUENCY_RULES, min_occurrences=3, min_confidence=0.3)
+        assert len(patterns) == 0
+
+    def test_respects_min_confidence(self) -> None:
+        # Create transactions with very variable amounts (low confidence)
+        txns = []
+        for i in range(6):
+            d = date(2025, 1 + i, 15)
+            txns.append({
+                "row_hash": f"hash_var_{i}",
+                "account_masked": "****1234",
+                "txn_date": d.isoformat(),
+                "description_raw": "VARIABLE MERCHANT",
+                "amount": -(10.0 + i * 50),  # 10, 60, 110, 160, 210, 260
+                "currency": "USD",
+                "category": "shopping",
+                "category_source": "test",
+                "confidence": 1.0,
+            })
+        patterns = detect_recurring_patterns(txns, FREQUENCY_RULES, min_occurrences=3, min_confidence=0.9)
+        assert len(patterns) == 0
+
+
+class TestComputeSummary:
+    def test_summary_with_patterns(self) -> None:
+        patterns = [
+            {
+                "payee_normalized": "NETFLIX",
+                "frequency": "monthly",
+                "avg_amount": 15.99,
+                "is_active": True,
+            },
+            {
+                "payee_normalized": "GYM",
+                "frequency": "monthly",
+                "avg_amount": 49.99,
+                "is_active": True,
+            },
+        ]
+        summary = compute_summary(patterns)
+        assert summary["patterns_found"] == 2
+        assert summary["active_patterns"] == 2
+        assert summary["total_monthly_committed"] == 65.98
+        assert summary["total_annual_committed"] == 791.76
+
+    def test_summary_empty(self) -> None:
+        summary = compute_summary([])
+        assert summary["patterns_found"] == 0
+        assert summary["total_monthly_committed"] == 0.0
+
+
+class TestRenderMarkdown:
+    def test_render_produces_valid_markdown(self) -> None:
+        patterns = [
+            {
+                "payee_normalized": "NETFLIX",
+                "category": "subscriptions",
+                "frequency": "monthly",
+                "avg_amount": 15.99,
+                "median_amount": 15.99,
+                "occurrence_count": 6,
+                "confidence": 0.95,
+                "first_seen": "2025-01-15",
+                "last_seen": "2025-06-15",
+                "next_expected": "2025-07-15",
+                "is_active": True,
+            },
+        ]
+        summary = compute_summary(patterns)
+        md = render_markdown(
+            patterns, summary,
+            period_start=date(2025, 1, 1),
+            period_end=date(2025, 12, 31),
+            run_id="test-run-001",
+            txn_count=100,
+        )
+        assert "# Wells Fargo Recurring Transactions" in md
+        assert "NETFLIX" in md
+        assert "Monthly" in md
+        assert "test-run-001" in md
+        assert "Est. Monthly Committed" in md


### PR DESCRIPTION
## Summary
- New `wellsfargo/recurring-transactions` skill that detects recurring subscriptions, bills, and regular payments
- Groups transactions by normalized payee and amount similarity, detects frequency patterns (weekly/biweekly/monthly/quarterly/annual)
- Assigns confidence scores based on regularity and amount consistency
- Persists detected patterns to SerenDB (`wf_recurring_*` tables), estimates monthly/annual committed spend
- Includes 13 smoke tests (all passing)

## Test plan
- [x] Run `pytest wellsfargo/recurring-transactions/tests/test_smoke.py` — 13 tests pass
- [ ] Verify SKILL.md frontmatter matches agentskills.io spec
- [ ] Confirm SerenDB schema applies cleanly against a live instance

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com