### PR TITLE
feat(wellsfargo): add budget-tracker skill

### DIFF
--- a/wellsfargo/budget-tracker/.env.example
+++ b/wellsfargo/budget-tracker/.env.example
@@ -1,0 +1,5 @@
+# Optional override: explicit SERENDB connection string.
+# If empty, scripts/run.py resolves this automatically from your logged-in
+# Seren CLI/MCP context via `seren env init`.
+# Example: postgresql://user:pass@host:5432/serendb
+WF_SERENDB_URL=

--- a/wellsfargo/budget-tracker/.gitignore
+++ b/wellsfargo/budget-tracker/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/budget-tracker/SKILL.md
+++ b/wellsfargo/budget-tracker/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: budget-tracker
+description: "Track budget vs. actual spending by category from Wells Fargo transaction data stored in SerenDB."
+---
+
+# Wells Fargo Budget Tracker
+
+## When To Use
+
+- Compare actual spending against budget targets by category.
+- Track budget utilization and remaining allowances per period.
+- Identify categories where spending exceeds budget limits.
+- Persist budget snapshots into SerenDB for trend analysis.
+
+## Prerequisites
+
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+- Configure budget targets in `config/budget_targets.json`.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables (`wf_transactions`, `wf_txn_categories`).
+- Writes only to dedicated `wf_budget_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+
+## Workflow Summary
+
+1. `resolve_serendb` connects to SerenDB using the same resolution chain as bank-statement-processing.
+2. `query_transactions` fetches categorized transactions for the requested period.
+3. `aggregate_actuals` sums actual spending by category.
+4. `compare_budget` computes budget vs. actual variance per category.
+5. `render_report` produces Markdown and JSON output files.
+6. `persist_snapshot` upserts the budget snapshot into SerenDB.
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+cd wellsfargo/budget-tracker
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+cp config.example.json config.json
+```
+
+2. Customize budget targets in `config/budget_targets.json`.
+
+3. Run budget comparison for the current month:
+
+```bash
+python3 scripts/run.py --config config.json --months 1 --out artifacts/budget-tracker
+```
+
+## Commands
+
+```bash
+# Current month
+python3 scripts/run.py --config config.json --months 1 --out artifacts/budget-tracker
+
+# Last 12 months
+python3 scripts/run.py --config config.json --months 12 --out artifacts/budget-tracker
+
+# Specific date range
+python3 scripts/run.py --config config.json --start 2025-01-01 --end 2025-12-31 --out artifacts/budget-tracker
+
+# Skip SerenDB persistence
+python3 scripts/run.py --config config.json --months 1 --skip-persist --out artifacts/budget-tracker
+```
+
+## Outputs
+
+- Markdown report: `artifacts/budget-tracker/reports/<run_id>.md`
+- JSON report: `artifacts/budget-tracker/reports/<run_id>.json`
+- Category export: `artifacts/budget-tracker/exports/<run_id>.categories.jsonl`
+
+## SerenDB Tables
+
+- `wf_budget_runs` - budget tracking runs
+- `wf_budget_categories` - budget vs. actual per category per run
+- `wf_budget_snapshots` - summary snapshot per run
+
+## Reusable Views
+
+- `v_wf_budget_latest` - most recent budget snapshot
+- `v_wf_budget_over_limit` - categories currently over budget

--- a/wellsfargo/budget-tracker/config.example.json
+++ b/wellsfargo/budget-tracker/config.example.json
@@ -1,0 +1,18 @@
+{
+  "runtime": {
+    "artifacts_subdir": "budget-tracker"
+  },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
+  },
+  "budget_targets_path": "config/budget_targets.json"
+}

--- a/wellsfargo/budget-tracker/config/budget_targets.json
+++ b/wellsfargo/budget-tracker/config/budget_targets.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "Monthly budget targets by category. Amounts are per-month limits.",
+  "targets": {
+    "housing": {
+      "label": "Housing & Rent",
+      "monthly_limit": 2500.00
+    },
+    "utilities": {
+      "label": "Utilities",
+      "monthly_limit": 300.00
+    },
+    "groceries": {
+      "label": "Groceries",
+      "monthly_limit": 600.00
+    },
+    "dining": {
+      "label": "Dining & Restaurants",
+      "monthly_limit": 400.00
+    },
+    "transportation": {
+      "label": "Transportation",
+      "monthly_limit": 350.00
+    },
+    "insurance": {
+      "label": "Insurance",
+      "monthly_limit": 500.00
+    },
+    "healthcare": {
+      "label": "Healthcare",
+      "monthly_limit": 200.00
+    },
+    "subscriptions": {
+      "label": "Subscriptions & Memberships",
+      "monthly_limit": 150.00
+    },
+    "shopping": {
+      "label": "Shopping & Retail",
+      "monthly_limit": 300.00
+    },
+    "fees": {
+      "label": "Bank Fees & Charges",
+      "monthly_limit": 50.00
+    },
+    "other_expense": {
+      "label": "Other Expenses",
+      "monthly_limit": 500.00
+    }
+  },
+  "total_monthly_budget": 5850.00
+}

--- a/wellsfargo/budget-tracker/requirements.txt
+++ b/wellsfargo/budget-tracker/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/budget-tracker/scripts/budget_builder.py
+++ b/wellsfargo/budget-tracker/scripts/budget_builder.py
@@ -1,0 +1,150 @@
+"""Pure-logic budget vs. actual builder (no DB dependencies)."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+def load_budget_targets(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Budget targets not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def aggregate_actuals(
+    transactions: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Sum actual spending by category (expenses only, using absolute amounts)."""
+    actuals: dict[str, dict[str, Any]] = {}
+    for txn in transactions:
+        amount = float(txn.get("amount", 0))
+        if amount >= 0:
+            continue  # Skip income
+        category = str(txn.get("category", "uncategorized")).lower().strip()
+        if category not in actuals:
+            actuals[category] = {"amount": 0.0, "txn_count": 0}
+        actuals[category]["amount"] = round(actuals[category]["amount"] + abs(amount), 2)
+        actuals[category]["txn_count"] += 1
+    return actuals
+
+
+def compare_budget(
+    actuals: dict[str, dict[str, Any]],
+    budget_targets: dict[str, Any],
+    num_months: float = 1.0,
+) -> dict[str, Any]:
+    """Compare actual spending against budget targets.
+
+    Args:
+        actuals: category -> {amount, txn_count} from aggregate_actuals
+        budget_targets: loaded budget_targets.json
+        num_months: number of months in the period (for pro-rating monthly budgets)
+
+    Returns a dict with categories list, totals, and summary.
+    """
+    targets = budget_targets.get("targets", {})
+    categories: list[dict[str, Any]] = []
+
+    all_cats = set(targets.keys()) | set(actuals.keys())
+
+    for cat in sorted(all_cats):
+        target_spec = targets.get(cat, {})
+        label = target_spec.get("label", cat.replace("_", " ").title())
+        monthly_limit = float(target_spec.get("monthly_limit", 0))
+        budget_amount = round(monthly_limit * num_months, 2)
+
+        actual_data = actuals.get(cat, {"amount": 0.0, "txn_count": 0})
+        actual_amount = actual_data["amount"]
+        txn_count = actual_data["txn_count"]
+
+        variance = round(budget_amount - actual_amount, 2)
+        utilization = round((actual_amount / budget_amount * 100), 2) if budget_amount > 0 else (
+            100.0 if actual_amount > 0 else 0.0
+        )
+        is_over = actual_amount > budget_amount and budget_amount > 0
+
+        categories.append({
+            "category": cat,
+            "label": label,
+            "budget_amount": budget_amount,
+            "actual_amount": actual_amount,
+            "variance": variance,
+            "utilization_pct": utilization,
+            "txn_count": txn_count,
+            "is_over_budget": is_over,
+        })
+
+    total_budget = round(sum(c["budget_amount"] for c in categories), 2)
+    total_actual = round(sum(c["actual_amount"] for c in categories), 2)
+    total_variance = round(total_budget - total_actual, 2)
+    categories_over = sum(1 for c in categories if c["is_over_budget"])
+
+    return {
+        "categories": categories,
+        "total_budget": total_budget,
+        "total_actual": total_actual,
+        "total_variance": total_variance,
+        "categories_over": categories_over,
+    }
+
+
+def render_markdown(
+    comparison: dict[str, Any],
+    period_start: date,
+    period_end: date,
+    run_id: str,
+    txn_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Wells Fargo Budget Tracker")
+    lines.append("")
+    lines.append(f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}")
+    lines.append(f"**Run ID:** {run_id}")
+    lines.append(f"**Transactions analyzed:** {txn_count}")
+    lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Amount |")
+    lines.append("|--------|-------:|")
+    lines.append(f"| Total Budget | ${comparison['total_budget']:,.2f} |")
+    lines.append(f"| Total Actual | ${comparison['total_actual']:,.2f} |")
+
+    tv = comparison["total_variance"]
+    var_display = f"${tv:,.2f}" if tv >= 0 else f"(${abs(tv):,.2f})"
+    lines.append(f"| Variance | {var_display} |")
+    lines.append(f"| Categories Over Budget | {comparison['categories_over']} |")
+    lines.append("")
+
+    lines.append("## Budget vs. Actual by Category")
+    lines.append("")
+    lines.append("| Category | Budget | Actual | Variance | Utilization | Status |")
+    lines.append("|----------|-------:|-------:|---------:|------------:|--------|")
+
+    for cat in comparison["categories"]:
+        if cat["budget_amount"] == 0 and cat["actual_amount"] == 0:
+            continue
+        v = cat["variance"]
+        var_str = f"${v:,.2f}" if v >= 0 else f"(${abs(v):,.2f})"
+        status = "OVER" if cat["is_over_budget"] else "OK"
+        lines.append(
+            f"| {cat['label']} "
+            f"| ${cat['budget_amount']:,.2f} "
+            f"| ${cat['actual_amount']:,.2f} "
+            f"| {var_str} "
+            f"| {cat['utilization_pct']:.0f}% "
+            f"| {status} |"
+        )
+    lines.append("")
+
+    over_cats = [c for c in comparison["categories"] if c["is_over_budget"]]
+    if over_cats:
+        lines.append("## Over Budget Categories")
+        lines.append("")
+        for cat in sorted(over_cats, key=lambda c: c["variance"]):
+            lines.append(f"- **{cat['label']}**: ${cat['actual_amount']:,.2f} spent vs ${cat['budget_amount']:,.2f} budget ({cat['utilization_pct']:.0f}%)")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/wellsfargo/budget-tracker/scripts/run.py
+++ b/wellsfargo/budget-tracker/scripts/run.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Wells Fargo Budget Tracker.
+
+Reads categorized transaction data from SerenDB (populated by bank-statement-processing)
+and compares actual spending against budget targets by category.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from budget_builder import (
+    aggregate_actuals,
+    compare_budget,
+    load_budget_targets,
+    render_markdown,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MONTHS = 1
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+
+# ---------------------------------------------------------------------------
+# SerenDB resolution (mirrors bank-statement-processing logic)
+# ---------------------------------------------------------------------------
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload: Any = None
+    if result.stdout.strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+    return result.returncode, payload, result.stderr.strip()
+
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+
+def resolve_serendb_database_url(config: dict[str, Any], logger: RunLogger) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+
+    from_env = os.getenv(env_key, "").strip()
+    if from_env:
+        return from_env, f"env:{env_key}"
+
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(f"SerenDB is enabled but {env_key} is empty and auto-resolve is disabled.")
+
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(f"SerenDB is enabled but {env_key} is empty and `seren` CLI was not found in PATH.")
+
+    with tempfile.TemporaryDirectory(prefix="wf-budget-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [seren_bin, "env", "init", "--env", str(env_path), "--key", env_key, "--yes", "-o", "json"]
+        if bool(serendb_cfg.get("pooled_connection", True)):
+            base_cmd.append("--pooled")
+
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        explicit_pid = str(serendb_cfg.get("project_id", "")).strip()
+        explicit_bid = str(serendb_cfg.get("branch_id", "")).strip()
+        if explicit_pid and explicit_bid:
+            candidates.append((explicit_pid, explicit_bid, "explicit"))
+            seen.add((explicit_pid, explicit_bid))
+
+        for row in rows:
+            pid = row.get("project_id", "").strip()
+            bid = row.get("branch_id", "").strip()
+            if not pid or not bid or (pid, bid) in seen:
+                continue
+            rp = row.get("project_name", "").strip().lower()
+            rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project:
+                continue
+            if desired_database and rd != desired_database:
+                continue
+            seen.add((pid, bid))
+            candidates.append((pid, bid, f"catalog:{rp}/{row.get('branch_name', '')}/{rd}"))
+
+        if not candidates:
+            raise RuntimeError(f"Failed to resolve SerenDB URL for {env_key}.")
+
+        attempt_errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved:
+                    os.environ[env_key] = resolved
+                    logger.emit("serendb_url_resolved", "Resolved SerenDB URL", env_key=env_key, source=source)
+                    return resolved, f"seren_cli_context:{source}"
+                attempt_errors.append(f"{source}: empty dotenv write")
+                continue
+            attempt_errors.append(f"{source}: {(result.stderr or result.stdout or 'unknown error').strip()}")
+
+        raise RuntimeError(f"Failed to resolve SerenDB URL. Tried {len(candidates)} candidates. Errors: {'; '.join(attempt_errors[:5])}")
+
+
+QUERY_CATEGORIZED_TRANSACTIONS = """
+SELECT
+  t.row_hash, t.account_masked, t.txn_date, t.description_raw,
+  t.amount, t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+
+def fetch_transactions(database_url: str, start_date: date, end_date: date) -> list[dict[str, Any]]:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(QUERY_CATEGORIZED_TRANSACTIONS, {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()})
+            columns = [desc.name for desc in cur.description]
+            return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+def _read_sql(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def persist_budget_snapshot(database_url: str, schema_path: Path, run_record: dict[str, Any], comparison: dict[str, Any]) -> None:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_read_sql(schema_path))
+            cur.execute(
+                """INSERT INTO wf_budget_runs (run_id, started_at, ended_at, status, period_start, period_end, total_budget, total_actual, total_variance, categories_over, txn_count, artifact_root)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (run_id) DO UPDATE SET ended_at=EXCLUDED.ended_at, status=EXCLUDED.status, total_budget=EXCLUDED.total_budget, total_actual=EXCLUDED.total_actual, total_variance=EXCLUDED.total_variance, categories_over=EXCLUDED.categories_over, txn_count=EXCLUDED.txn_count""",
+                (run_record["run_id"], run_record["started_at"], run_record["ended_at"], run_record["status"], run_record["period_start"], run_record["period_end"], comparison["total_budget"], comparison["total_actual"], comparison["total_variance"], comparison["categories_over"], run_record["txn_count"], run_record["artifact_root"]),
+            )
+            for cat in comparison["categories"]:
+                cur.execute(
+                    """INSERT INTO wf_budget_categories (run_id, category, label, budget_amount, actual_amount, variance, utilization_pct, txn_count, is_over_budget)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT (run_id, category) DO UPDATE SET label=EXCLUDED.label, budget_amount=EXCLUDED.budget_amount, actual_amount=EXCLUDED.actual_amount, variance=EXCLUDED.variance, utilization_pct=EXCLUDED.utilization_pct, txn_count=EXCLUDED.txn_count, is_over_budget=EXCLUDED.is_over_budget""",
+                    (run_record["run_id"], cat["category"], cat["label"], cat["budget_amount"], cat["actual_amount"], cat["variance"], cat["utilization_pct"], cat["txn_count"], cat["is_over_budget"]),
+                )
+            cur.execute(
+                """INSERT INTO wf_budget_snapshots (run_id, period_start, period_end, total_budget, total_actual, total_variance, categories_json)
+                VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb)
+                ON CONFLICT (run_id) DO UPDATE SET total_budget=EXCLUDED.total_budget, total_actual=EXCLUDED.total_actual, total_variance=EXCLUDED.total_variance, categories_json=EXCLUDED.categories_json""",
+                (run_record["run_id"], run_record["period_start"], run_record["period_end"], comparison["total_budget"], comparison["total_actual"], comparison["total_variance"], json.dumps(comparison["categories"], default=str)),
+            )
+        conn.commit()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Track Wells Fargo budget vs. actual spending")
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument("--months", type=int, default=DEFAULT_MONTHS)
+    parser.add_argument("--start", type=str, default="")
+    parser.add_argument("--end", type=str, default="")
+    parser.add_argument("--out", type=str, default="artifacts/budget-tracker")
+    parser.add_argument("--skip-persist", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    today = date.today()
+    if args.start:
+        period_start = date.fromisoformat(args.start)
+        period_end = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        period_start = today - relativedelta(months=args.months)
+        period_end = today
+
+    num_months = max(1.0, (period_end - period_start).days / 30.44)
+    out_dir = Path(args.out)
+    report_dir = ensure_dir(out_dir / "reports")
+    export_dir = ensure_dir(out_dir / "exports")
+    log_dir = ensure_dir(out_dir / "logs")
+
+    run_id = f"budget-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{run_id}.jsonl")
+    logger.emit("start", "Budget tracking started", run_id=run_id)
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id, "started_at": utc_now_iso(), "ended_at": None,
+        "status": "running", "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(), "txn_count": 0,
+        "artifact_root": str(out_dir.resolve()),
+    }
+
+    try:
+        db_url, _ = resolve_serendb_database_url(config, logger)
+        transactions = fetch_transactions(db_url, period_start, period_end)
+        if not transactions:
+            run_record["status"] = "empty"
+            run_record["ended_at"] = utc_now_iso()
+            print("No transactions found.")
+            sys.exit(0)
+
+        run_record["txn_count"] = len(transactions)
+        targets_path = Path(config.get("budget_targets_path", "config/budget_targets.json"))
+        if not targets_path.is_absolute():
+            targets_path = config_path.parent / targets_path
+        budget_targets = load_budget_targets(targets_path)
+
+        actuals = aggregate_actuals(transactions)
+        comparison = compare_budget(actuals, budget_targets, num_months=num_months)
+
+        md_path = report_dir / f"{run_id}.md"
+        md_path.write_text(render_markdown(comparison, period_start, period_end, run_id, len(transactions)), encoding="utf-8")
+        dump_json(report_dir / f"{run_id}.json", {"run_id": run_id, "period_start": period_start.isoformat(), "period_end": period_end.isoformat(), "txn_count": len(transactions), "comparison": comparison})
+
+        export_path = export_dir / f"{run_id}.categories.jsonl"
+        for cat in comparison["categories"]:
+            append_jsonl(export_path, cat)
+
+        if not args.skip_persist and bool(config.get("serendb", {}).get("enabled", True)):
+            schema_path = Path(config.get("serendb", {}).get("schema_path", "sql/schema.sql"))
+            if not schema_path.is_absolute():
+                schema_path = config_path.parent / schema_path
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            persist_budget_snapshot(db_url, schema_path, run_record, comparison)
+        else:
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+
+        print(f"\nBudget Tracker completed!")
+        print(f"  Budget: ${comparison['total_budget']:,.2f}  Actual: ${comparison['total_actual']:,.2f}  Over: {comparison['categories_over']} categories")
+
+    except Exception as exc:
+        run_record["status"] = "error"
+        run_record["ended_at"] = utc_now_iso()
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wellsfargo/budget-tracker/skill.spec.yaml
+++ b/wellsfargo/budget-tracker/skill.spec.yaml
@@ -1,0 +1,59 @@
+skill: budget-tracker
+description: Track budget vs. actual spending by category from Wells Fargo transaction data stored in SerenDB.
+triggers:
+  - track wells fargo budget
+  - compare wellsfargo spending to budget
+  - budget vs actual from wells fargo data
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 1
+    max: 24
+    default: 1
+  start:
+    type: string
+    description: Start date (YYYY-MM-DD). Overrides months if provided.
+  end:
+    type: string
+    description: End date (YYYY-MM-DD). Defaults to today if start is provided.
+  out:
+    type: string
+    default: artifacts/budget-tracker
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  checkpoints:
+    kind: sqlite
+    file: artifacts/budget-tracker/state/checkpoint.json
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: aggregate_actuals
+      use: transform.aggregate_by_category
+    - id: compare_budget
+      use: transform.compare_budget
+    - id: render_report
+      use: transform.render
+    - id: persist_snapshot
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: budget-tracker
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/budget-tracker/sql/queries.sql
+++ b/wellsfargo/budget-tracker/sql/queries.sql
@@ -1,0 +1,30 @@
+-- fetch_categorized_transactions: retrieve all categorized transactions for a date range
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;
+
+-- fetch_budget_over_limit: categories exceeding their budget in the latest run
+SELECT
+  category,
+  label,
+  budget_amount,
+  actual_amount,
+  variance,
+  utilization_pct
+FROM wf_budget_categories c
+JOIN wf_budget_runs r ON r.run_id = c.run_id
+WHERE r.status = 'success'
+  AND c.is_over_budget = TRUE
+ORDER BY c.variance;

--- a/wellsfargo/budget-tracker/sql/schema.sql
+++ b/wellsfargo/budget-tracker/sql/schema.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS wf_budget_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_budget NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_actual NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_variance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  categories_over INTEGER NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_budget_categories (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_budget_runs(run_id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  label TEXT NOT NULL,
+  budget_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  actual_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  variance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  utilization_pct NUMERIC(7,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  is_over_budget BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_budget_categories_run ON wf_budget_categories(run_id);
+
+CREATE TABLE IF NOT EXISTS wf_budget_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_budget_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_budget NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_actual NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_variance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  categories_json JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_budget_snapshots_period ON wf_budget_snapshots(period_start, period_end);
+
+CREATE OR REPLACE VIEW v_wf_budget_latest AS
+SELECT s.*
+FROM wf_budget_snapshots s
+JOIN wf_budget_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_budget_runs r2
+  WHERE r2.status = 'success'
+);
+
+CREATE OR REPLACE VIEW v_wf_budget_over_limit AS
+SELECT c.*
+FROM wf_budget_categories c
+JOIN wf_budget_runs r ON r.run_id = c.run_id
+WHERE r.status = 'success'
+  AND c.is_over_budget = TRUE
+AND r.ended_at = (
+  SELECT MAX(r2.ended_at)
+  FROM wf_budget_runs r2
+  WHERE r2.status = 'success'
+)
+ORDER BY c.variance;

--- a/wellsfargo/budget-tracker/tests/test_smoke.py
+++ b/wellsfargo/budget-tracker/tests/test_smoke.py
@@ -1,0 +1,116 @@
+"""Smoke tests for the budget tracker builder (no DB required)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from datetime import date
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from budget_builder import aggregate_actuals, compare_budget, render_markdown  # noqa: E402
+
+BUDGET_TARGETS = json.loads(
+    (Path(__file__).resolve().parent.parent / "config" / "budget_targets.json").read_text()
+)
+
+
+def _make_txn(amount: float, category: str = "uncategorized") -> dict:
+    return {
+        "row_hash": f"hash_{abs(hash((amount, category)))}",
+        "account_masked": "****1234",
+        "txn_date": "2025-06-15",
+        "description_raw": f"Test txn {category}",
+        "amount": amount,
+        "currency": "USD",
+        "category": category,
+        "category_source": "test",
+        "confidence": 1.0,
+    }
+
+
+class TestAggregateActuals:
+    def test_sums_expenses_by_category(self) -> None:
+        txns = [
+            _make_txn(-200.0, "groceries"),
+            _make_txn(-150.0, "groceries"),
+            _make_txn(-80.0, "dining"),
+        ]
+        actuals = aggregate_actuals(txns)
+        assert actuals["groceries"]["amount"] == 350.0
+        assert actuals["groceries"]["txn_count"] == 2
+        assert actuals["dining"]["amount"] == 80.0
+
+    def test_ignores_income(self) -> None:
+        txns = [
+            _make_txn(5000.0, "payroll"),
+            _make_txn(-100.0, "groceries"),
+        ]
+        actuals = aggregate_actuals(txns)
+        assert "payroll" not in actuals
+        assert actuals["groceries"]["amount"] == 100.0
+
+    def test_empty_transactions(self) -> None:
+        actuals = aggregate_actuals([])
+        assert len(actuals) == 0
+
+
+class TestCompareBudget:
+    def test_under_budget(self) -> None:
+        actuals = {"groceries": {"amount": 300.0, "txn_count": 5}}
+        result = compare_budget(actuals, BUDGET_TARGETS, num_months=1.0)
+        grocery_cat = [c for c in result["categories"] if c["category"] == "groceries"]
+        assert len(grocery_cat) == 1
+        assert grocery_cat[0]["budget_amount"] == 600.0
+        assert grocery_cat[0]["actual_amount"] == 300.0
+        assert grocery_cat[0]["variance"] == 300.0
+        assert grocery_cat[0]["is_over_budget"] is False
+
+    def test_over_budget(self) -> None:
+        actuals = {"dining": {"amount": 500.0, "txn_count": 10}}
+        result = compare_budget(actuals, BUDGET_TARGETS, num_months=1.0)
+        dining_cat = [c for c in result["categories"] if c["category"] == "dining"]
+        assert len(dining_cat) == 1
+        assert dining_cat[0]["is_over_budget"] is True
+        assert dining_cat[0]["variance"] == -100.0
+        assert result["categories_over"] >= 1
+
+    def test_multi_month_pro_rates(self) -> None:
+        actuals = {"groceries": {"amount": 1000.0, "txn_count": 20}}
+        result = compare_budget(actuals, BUDGET_TARGETS, num_months=3.0)
+        grocery_cat = [c for c in result["categories"] if c["category"] == "groceries"]
+        assert grocery_cat[0]["budget_amount"] == 1800.0
+        assert grocery_cat[0]["is_over_budget"] is False
+
+    def test_empty_actuals(self) -> None:
+        result = compare_budget({}, BUDGET_TARGETS, num_months=1.0)
+        assert result["total_actual"] == 0.0
+        assert result["categories_over"] == 0
+
+    def test_uncategorized_spending_tracked(self) -> None:
+        actuals = {"mystery_cat": {"amount": 50.0, "txn_count": 1}}
+        result = compare_budget(actuals, BUDGET_TARGETS, num_months=1.0)
+        mystery = [c for c in result["categories"] if c["category"] == "mystery_cat"]
+        assert len(mystery) == 1
+        assert mystery[0]["actual_amount"] == 50.0
+
+
+class TestRenderMarkdown:
+    def test_render_produces_valid_markdown(self) -> None:
+        actuals = {"groceries": {"amount": 700.0, "txn_count": 15}, "dining": {"amount": 200.0, "txn_count": 8}}
+        comparison = compare_budget(actuals, BUDGET_TARGETS, num_months=1.0)
+        md = render_markdown(comparison, period_start=date(2025, 6, 1), period_end=date(2025, 6, 30), run_id="test-run-001", txn_count=23)
+        assert "# Wells Fargo Budget Tracker" in md
+        assert "test-run-001" in md
+        assert "Budget" in md
+        assert "Actual" in md
+        assert "Variance" in md
+        assert "Groceries" in md
+
+    def test_over_budget_section_appears(self) -> None:
+        actuals = {"groceries": {"amount": 800.0, "txn_count": 20}}
+        comparison = compare_budget(actuals, BUDGET_TARGETS, num_months=1.0)
+        md = render_markdown(comparison, period_start=date(2025, 6, 1), period_end=date(2025, 6, 30), run_id="test-run-002", txn_count=20)
+        assert "Over Budget Categories" in md
+        assert "OVER" in md


### PR DESCRIPTION
## Summary
- New `wellsfargo/budget-tracker` skill comparing actual spending against configurable budget targets
- Aggregates expenses by category, computes variance and utilization percentage
- Flags categories exceeding their budget limits with pro-rated multi-month support
- Persists snapshots to SerenDB (`wf_budget_*` tables) with over-budget view
- Includes 10 smoke tests (all passing)

## Test plan
- [x] Run `pytest wellsfargo/budget-tracker/tests/test_smoke.py` — 10 tests pass
- [ ] Verify SKILL.md frontmatter matches agentskills.io spec
- [ ] Confirm SerenDB schema applies cleanly against a live instance

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com