### PR TITLE
feat(wellsfargo): add vendor-analysis skill

### DIFF
--- a/wellsfargo/vendor-analysis/.env.example
+++ b/wellsfargo/vendor-analysis/.env.example
@@ -1,0 +1,2 @@
+# Optional override
+WF_SERENDB_URL=

--- a/wellsfargo/vendor-analysis/.gitignore
+++ b/wellsfargo/vendor-analysis/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/vendor-analysis/SKILL.md
+++ b/wellsfargo/vendor-analysis/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: vendor-analysis
+description: "Analyze spending by vendor/merchant from Wells Fargo transaction data stored in SerenDB."
+---
+
+# Wells Fargo Vendor Analysis
+
+## When To Use
+
+- Analyze spending patterns by vendor/merchant/payee.
+- Rank vendors by total spend, frequency, and average transaction size.
+- Identify top merchants and spending concentration.
+- Persist vendor analytics into SerenDB for downstream analysis.
+
+## Prerequisites
+
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables (`wf_transactions`, `wf_txn_categories`).
+- Writes only to dedicated `wf_vendor_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+
+## Quick Start
+
+```bash
+cd wellsfargo/vendor-analysis
+python3 -m pip install -r requirements.txt
+cp .env.example .env && cp config.example.json config.json
+python3 scripts/run.py --config config.json --months 12 --out artifacts/vendor-analysis
+```
+
+## Commands
+
+```bash
+python3 scripts/run.py --config config.json --months 12 --out artifacts/vendor-analysis
+python3 scripts/run.py --config config.json --months 12 --top 20 --out artifacts/vendor-analysis
+python3 scripts/run.py --config config.json --months 12 --skip-persist --out artifacts/vendor-analysis
+```
+
+## Outputs
+
+- Markdown report: `artifacts/vendor-analysis/reports/<run_id>.md`
+- JSON report: `artifacts/vendor-analysis/reports/<run_id>.json`
+- Vendor export: `artifacts/vendor-analysis/exports/<run_id>.vendors.jsonl`
+
+## SerenDB Tables
+
+- `wf_vendor_runs` - vendor analysis runs
+- `wf_vendor_merchants` - per-vendor spending data per run
+- `wf_vendor_snapshots` - summary snapshot per run
+
+## Reusable Views
+
+- `v_wf_vendor_latest` - most recent vendor snapshot
+- `v_wf_vendor_top_merchants` - top merchants by spend from latest run

--- a/wellsfargo/vendor-analysis/config.example.json
+++ b/wellsfargo/vendor-analysis/config.example.json
@@ -1,0 +1,15 @@
+{
+  "runtime": { "artifacts_subdir": "vendor-analysis" },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
+  }
+}

--- a/wellsfargo/vendor-analysis/requirements.txt
+++ b/wellsfargo/vendor-analysis/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/vendor-analysis/scripts/run.py
+++ b/wellsfargo/vendor-analysis/scripts/run.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Wells Fargo Vendor Analysis."""
+from __future__ import annotations
+
+import argparse, json, os, shutil, subprocess, sys, tempfile, uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from vendor_builder import aggregate_vendors, render_markdown
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload = None
+    if result.stdout.strip():
+        try: payload = json.loads(result.stdout)
+        except json.JSONDecodeError: pass
+    return result.returncode, payload, result.stderr.strip()
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list): return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list): return payload[key]
+    return []
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists(): return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+def resolve_serendb_database_url(config: dict[str, Any], logger: RunLogger) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+    from_env = os.getenv(env_key, "").strip()
+    if from_env: return from_env, f"env:{env_key}"
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(f"{env_key} is empty and auto-resolve is disabled.")
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(f"{env_key} is empty and `seren` CLI not found.")
+    with tempfile.TemporaryDirectory(prefix="wf-vendor-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [seren_bin, "env", "init", "--env", str(env_path), "--key", env_key, "--yes", "-o", "json"]
+        if bool(serendb_cfg.get("pooled_connection", True)): base_cmd.append("--pooled")
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        pid_e = str(serendb_cfg.get("project_id", "")).strip()
+        bid_e = str(serendb_cfg.get("branch_id", "")).strip()
+        if pid_e and bid_e: candidates.append((pid_e, bid_e, "explicit")); seen.add((pid_e, bid_e))
+        for row in rows:
+            pid = row.get("project_id", "").strip(); bid = row.get("branch_id", "").strip()
+            if not pid or not bid or (pid, bid) in seen: continue
+            rp = row.get("project_name", "").strip().lower(); rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project: continue
+            if desired_database and rd != desired_database: continue
+            seen.add((pid, bid)); candidates.append((pid, bid, f"catalog:{rp}/{row.get('branch_name','')}/{rd}"))
+        if not candidates: raise RuntimeError(f"No candidates for {env_key}.")
+        errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved: os.environ[env_key] = resolved; return resolved, f"seren_cli_context:{source}"
+                errors.append(f"{source}: empty"); continue
+            errors.append(f"{source}: {(result.stderr or result.stdout or '?').strip()}")
+        raise RuntimeError(f"Failed. Errors: {'; '.join(errors[:5])}")
+
+QUERY = """
+SELECT t.row_hash, t.account_masked, t.txn_date, t.description_raw,
+  t.amount, t.currency, COALESCE(c.category,'uncategorized') AS category,
+  COALESCE(c.category_source,'none') AS category_source, c.confidence
+FROM wf_transactions t LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+def fetch_transactions(url: str, s: date, e: date) -> list[dict[str, Any]]:
+    with psycopg.connect(url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(QUERY, {"start_date": s.isoformat(), "end_date": e.isoformat()})
+            cols = [d.name for d in cur.description]
+            return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+def persist_vendor_analysis(url: str, schema_path: Path, rec: dict, analysis: dict) -> None:
+    with psycopg.connect(url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(schema_path.read_text(encoding="utf-8"))
+            cur.execute("INSERT INTO wf_vendor_runs (run_id,started_at,ended_at,status,period_start,period_end,unique_vendors,total_spend,txn_count,artifact_root) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT (run_id) DO UPDATE SET ended_at=EXCLUDED.ended_at,status=EXCLUDED.status,unique_vendors=EXCLUDED.unique_vendors,total_spend=EXCLUDED.total_spend,txn_count=EXCLUDED.txn_count",
+                (rec["run_id"],rec["started_at"],rec["ended_at"],rec["status"],rec["period_start"],rec["period_end"],analysis["unique_vendors"],analysis["total_spend"],rec["txn_count"],rec["artifact_root"]))
+            for v in analysis["vendors"]:
+                cur.execute("INSERT INTO wf_vendor_merchants (run_id,vendor_normalized,category,total_spend,txn_count,avg_amount,first_seen,last_seen,spend_rank) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT (run_id,vendor_normalized) DO UPDATE SET category=EXCLUDED.category,total_spend=EXCLUDED.total_spend,txn_count=EXCLUDED.txn_count,avg_amount=EXCLUDED.avg_amount,spend_rank=EXCLUDED.spend_rank",
+                    (rec["run_id"],v["vendor_normalized"],v["category"],v["total_spend"],v["txn_count"],v["avg_amount"],v["first_seen"],v["last_seen"],v["spend_rank"]))
+            cur.execute("INSERT INTO wf_vendor_snapshots (run_id,period_start,period_end,unique_vendors,total_spend,top_vendors_json) VALUES (%s,%s,%s,%s,%s,%s::jsonb) ON CONFLICT (run_id) DO UPDATE SET unique_vendors=EXCLUDED.unique_vendors,total_spend=EXCLUDED.total_spend,top_vendors_json=EXCLUDED.top_vendors_json",
+                (rec["run_id"],rec["period_start"],rec["period_end"],analysis["unique_vendors"],analysis["total_spend"],json.dumps(analysis["vendors"],default=str)))
+        conn.commit()
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Analyze Wells Fargo vendor spending")
+    p.add_argument("--config", default="config.json"); p.add_argument("--months", type=int, default=12)
+    p.add_argument("--start", default=""); p.add_argument("--end", default="")
+    p.add_argument("--top", type=int, default=50); p.add_argument("--out", default="artifacts/vendor-analysis")
+    p.add_argument("--skip-persist", action="store_true")
+    args = p.parse_args()
+    cp = Path(args.config)
+    if not cp.exists(): print(f"Config not found: {cp}", file=sys.stderr); sys.exit(1)
+    config = json.loads(cp.read_text(encoding="utf-8"))
+    today = date.today()
+    if args.start:
+        ps = date.fromisoformat(args.start); pe = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        ps = today - relativedelta(months=args.months); pe = today
+    out = Path(args.out); log_dir = ensure_dir(out / "logs")
+    rid = f"vendor-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{rid}.jsonl")
+    rec = {"run_id": rid, "started_at": utc_now_iso(), "ended_at": None, "status": "running", "period_start": ps.isoformat(), "period_end": pe.isoformat(), "txn_count": 0, "artifact_root": str(out.resolve())}
+    try:
+        url, _ = resolve_serendb_database_url(config, logger)
+        txns = fetch_transactions(url, ps, pe)
+        if not txns: rec["status"]="empty"; rec["ended_at"]=utc_now_iso(); print("No transactions."); sys.exit(0)
+        rec["txn_count"] = len(txns)
+        analysis = aggregate_vendors(txns, top_n=args.top)
+        rd = ensure_dir(out / "reports")
+        rd_path = rd / f"{rid}.md"
+        rd_path.write_text(render_markdown(analysis, ps, pe, rid, len(txns)), encoding="utf-8")
+        dump_json(rd / f"{rid}.json", {"run_id": rid, "period_start": ps.isoformat(), "period_end": pe.isoformat(), "txn_count": len(txns), "analysis": analysis})
+        ed = ensure_dir(out / "exports")
+        for v in analysis["vendors"]: append_jsonl(ed / f"{rid}.vendors.jsonl", v)
+        if not args.skip_persist and config.get("serendb",{}).get("enabled",True):
+            sp = Path(config.get("serendb",{}).get("schema_path","sql/schema.sql"))
+            if not sp.is_absolute(): sp = cp.parent / sp
+            rec["status"]="success"; rec["ended_at"]=utc_now_iso()
+            persist_vendor_analysis(url, sp, rec, analysis)
+        else: rec["status"]="success"; rec["ended_at"]=utc_now_iso()
+        print(f"\nVendor Analysis done! {analysis['unique_vendors']} vendors, ${analysis['total_spend']:,.2f} total")
+    except Exception as e:
+        rec["status"]="error"; rec["ended_at"]=utc_now_iso(); print(f"ERROR: {e}", file=sys.stderr); sys.exit(1)
+
+if __name__ == "__main__": main()

--- a/wellsfargo/vendor-analysis/scripts/vendor_builder.py
+++ b/wellsfargo/vendor-analysis/scripts/vendor_builder.py
@@ -1,0 +1,99 @@
+"""Pure-logic vendor analysis builder (no DB dependencies)."""
+from __future__ import annotations
+
+import re
+import statistics
+from collections import defaultdict
+from datetime import date
+from typing import Any
+
+
+def normalize_vendor(description: str) -> str:
+    text = description.upper().strip()
+    for prefix in ("POS ", "ACH ", "DEBIT ", "CREDIT ", "ONLINE ", "RECURRING ", "AUTOPAY "):
+        if text.startswith(prefix):
+            text = text[len(prefix):]
+    text = re.sub(r"\s*[#]?\d{4,}$", "", text)
+    text = re.sub(r"\s*REF:\S+$", "", text)
+    text = re.sub(r"\s*\d{1,2}/\d{1,2}(/\d{2,4})?", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _parse_date(val: Any) -> date | None:
+    if isinstance(val, date):
+        return val
+    if isinstance(val, str):
+        try:
+            return date.fromisoformat(val[:10])
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
+def aggregate_vendors(transactions: list[dict[str, Any]], top_n: int = 50) -> dict[str, Any]:
+    vendor_data: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"amounts": [], "dates": [], "categories": [], "txn_count": 0}
+    )
+    for txn in transactions:
+        amount = float(txn.get("amount", 0))
+        if amount >= 0:
+            continue
+        vendor = normalize_vendor(str(txn.get("description_raw", "")))
+        if not vendor:
+            continue
+        vendor_data[vendor]["amounts"].append(abs(amount))
+        d = _parse_date(txn.get("txn_date"))
+        if d:
+            vendor_data[vendor]["dates"].append(d)
+        vendor_data[vendor]["categories"].append(str(txn.get("category", "uncategorized")))
+        vendor_data[vendor]["txn_count"] += 1
+
+    vendors: list[dict[str, Any]] = []
+    for name, data in vendor_data.items():
+        amounts = data["amounts"]
+        dates = sorted(data["dates"])
+        total_spend = round(sum(amounts), 2)
+        avg_amount = round(statistics.mean(amounts), 2) if amounts else 0.0
+        cat_counts: dict[str, int] = {}
+        for c in data["categories"]:
+            cat_counts[c] = cat_counts.get(c, 0) + 1
+        primary_category = max(cat_counts, key=cat_counts.get) if cat_counts else "uncategorized"
+        vendors.append({
+            "vendor_normalized": name, "category": primary_category,
+            "total_spend": total_spend, "txn_count": data["txn_count"],
+            "avg_amount": avg_amount,
+            "first_seen": dates[0].isoformat() if dates else "",
+            "last_seen": dates[-1].isoformat() if dates else "",
+        })
+
+    vendors.sort(key=lambda v: -v["total_spend"])
+    for i, v in enumerate(vendors):
+        v["spend_rank"] = i + 1
+
+    total_spend = round(sum(v["total_spend"] for v in vendors), 2)
+    return {"vendors": vendors[:top_n], "unique_vendors": len(vendors), "total_spend": total_spend, "top_n": top_n}
+
+
+def render_markdown(analysis: dict[str, Any], period_start: date, period_end: date, run_id: str, txn_count: int) -> str:
+    lines = [
+        "# Wells Fargo Vendor Analysis", "",
+        f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}",
+        f"**Run ID:** {run_id}",
+        f"**Transactions analyzed:** {txn_count}", "",
+        "## Summary", "",
+        "| Metric | Value |", "|--------|------:|",
+        f"| Unique Vendors | {analysis['unique_vendors']} |",
+        f"| Total Spend | ${analysis['total_spend']:,.2f} |", "",
+    ]
+    vendors = analysis.get("vendors", [])
+    if vendors:
+        lines.extend([
+            f"## Top {len(vendors)} Vendors by Spend", "",
+            "| Rank | Vendor | Category | Total Spend | Txns | Avg Amount |",
+            "|-----:|--------|----------|----------:|-----:|---------:|",
+        ])
+        for v in vendors:
+            lines.append(f"| {v['spend_rank']} | {v['vendor_normalized']} | {v['category']} | ${v['total_spend']:,.2f} | {v['txn_count']} | ${v['avg_amount']:,.2f} |")
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/wellsfargo/vendor-analysis/skill.spec.yaml
+++ b/wellsfargo/vendor-analysis/skill.spec.yaml
@@ -1,0 +1,55 @@
+skill: vendor-analysis
+description: Analyze spending by vendor/merchant from Wells Fargo transaction data stored in SerenDB.
+triggers:
+  - analyze wells fargo vendor spending
+  - wellsfargo merchant analysis
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 1
+    max: 24
+    default: 12
+  start:
+    type: string
+  end:
+    type: string
+  top:
+    type: integer
+    default: 50
+  out:
+    type: string
+    default: artifacts/vendor-analysis
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: normalize_vendors
+      use: transform.normalize_payees
+    - id: aggregate_vendors
+      use: transform.aggregate_vendors
+    - id: render_report
+      use: transform.render
+    - id: persist_vendors
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: vendor-analysis
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/vendor-analysis/sql/queries.sql
+++ b/wellsfargo/vendor-analysis/sql/queries.sql
@@ -1,0 +1,9 @@
+-- fetch_categorized_transactions
+SELECT t.row_hash, t.account_masked, t.txn_date, t.description_raw,
+  t.amount, t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source, c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;

--- a/wellsfargo/vendor-analysis/sql/schema.sql
+++ b/wellsfargo/vendor-analysis/sql/schema.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS wf_vendor_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  unique_vendors INTEGER NOT NULL DEFAULT 0,
+  total_spend NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_vendor_merchants (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_vendor_runs(run_id) ON DELETE CASCADE,
+  vendor_normalized TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'uncategorized',
+  total_spend NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  avg_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+  first_seen DATE NOT NULL,
+  last_seen DATE NOT NULL,
+  spend_rank INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, vendor_normalized)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_vendor_merchants_run ON wf_vendor_merchants(run_id);
+
+CREATE TABLE IF NOT EXISTS wf_vendor_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_vendor_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  unique_vendors INTEGER NOT NULL DEFAULT 0,
+  total_spend NUMERIC(14,2) NOT NULL DEFAULT 0,
+  top_vendors_json JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE VIEW v_wf_vendor_latest AS
+SELECT s.* FROM wf_vendor_snapshots s
+JOIN wf_vendor_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (SELECT MAX(r2.ended_at) FROM wf_vendor_runs r2 WHERE r2.status = 'success');
+
+CREATE OR REPLACE VIEW v_wf_vendor_top_merchants AS
+SELECT m.* FROM wf_vendor_merchants m
+JOIN wf_vendor_runs r ON r.run_id = m.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (SELECT MAX(r2.ended_at) FROM wf_vendor_runs r2 WHERE r2.status = 'success')
+ORDER BY m.total_spend DESC;

--- a/wellsfargo/vendor-analysis/tests/test_smoke.py
+++ b/wellsfargo/vendor-analysis/tests/test_smoke.py
@@ -1,0 +1,90 @@
+"""Smoke tests for the vendor analysis builder (no DB required)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import date
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from vendor_builder import aggregate_vendors, normalize_vendor, render_markdown
+
+
+def _make_txn(amount: float, description: str, category: str = "shopping", txn_date: str = "2025-06-15") -> dict:
+    return {
+        "row_hash": f"hash_{abs(hash((amount, description)))}",
+        "account_masked": "****1234",
+        "txn_date": txn_date,
+        "description_raw": description,
+        "amount": amount,
+        "currency": "USD",
+        "category": category,
+        "category_source": "test",
+        "confidence": 1.0,
+    }
+
+
+class TestNormalizeVendor:
+    def test_removes_pos_prefix(self) -> None:
+        assert normalize_vendor("POS AMAZON") == "AMAZON"
+
+    def test_removes_trailing_numbers(self) -> None:
+        assert normalize_vendor("NETFLIX 123456") == "NETFLIX"
+
+    def test_collapses_whitespace(self) -> None:
+        assert normalize_vendor("  TARGET   STORE  ") == "TARGET STORE"
+
+
+class TestAggregateVendors:
+    def test_groups_by_vendor(self) -> None:
+        txns = [
+            _make_txn(-50.0, "POS AMAZON 12345", "shopping", "2025-01-15"),
+            _make_txn(-30.0, "POS AMAZON 67890", "shopping", "2025-02-15"),
+            _make_txn(-100.0, "NETFLIX 11111", "subscriptions", "2025-03-15"),
+        ]
+        result = aggregate_vendors(txns)
+        assert result["unique_vendors"] == 2
+        amazon = [v for v in result["vendors"] if v["vendor_normalized"] == "AMAZON"]
+        assert len(amazon) == 1
+        assert amazon[0]["total_spend"] == 80.0
+        assert amazon[0]["txn_count"] == 2
+
+    def test_ignores_income(self) -> None:
+        txns = [
+            _make_txn(5000.0, "ACH PAYROLL", "payroll"),
+            _make_txn(-50.0, "POS STARBUCKS", "dining"),
+        ]
+        result = aggregate_vendors(txns)
+        assert result["unique_vendors"] == 1
+
+    def test_empty_transactions(self) -> None:
+        result = aggregate_vendors([])
+        assert result["unique_vendors"] == 0
+        assert result["total_spend"] == 0.0
+
+    def test_ranks_by_spend(self) -> None:
+        txns = [
+            _make_txn(-500.0, "RENT LLC", "housing"),
+            _make_txn(-50.0, "COFFEE SHOP", "dining"),
+            _make_txn(-200.0, "GROCERY MART", "groceries"),
+        ]
+        result = aggregate_vendors(txns)
+        assert result["vendors"][0]["spend_rank"] == 1
+        assert result["vendors"][0]["vendor_normalized"] == "RENT LLC"
+
+    def test_top_n_limits(self) -> None:
+        txns = [_make_txn(-10.0, f"VENDOR {i}", "shopping") for i in range(10)]
+        result = aggregate_vendors(txns, top_n=3)
+        assert len(result["vendors"]) == 3
+        assert result["unique_vendors"] == 10
+
+
+class TestRenderMarkdown:
+    def test_render_produces_valid_markdown(self) -> None:
+        txns = [_make_txn(-500.0, "RENT LLC", "housing"), _make_txn(-50.0, "POS STARBUCKS", "dining")]
+        analysis = aggregate_vendors(txns)
+        md = render_markdown(analysis, date(2025, 1, 1), date(2025, 12, 31), "test-run-001", 2)
+        assert "# Wells Fargo Vendor Analysis" in md
+        assert "RENT LLC" in md
+        assert "Total Spend" in md


### PR DESCRIPTION
## Summary
- New `wellsfargo/vendor-analysis` skill analyzing spending by vendor/merchant
- Normalizes payee names, ranks vendors by total spend, computes averages and frequency
- Configurable top-N vendor limiting (default 50)
- Persists vendor analytics to SerenDB (`wf_vendor_*` tables) with top merchants view
- Includes 9 smoke tests (all passing)

## Test plan
- [x] Run `pytest wellsfargo/vendor-analysis/tests/test_smoke.py` — 9 tests pass
- [ ] Verify SKILL.md frontmatter matches agentskills.io spec
- [ ] Confirm SerenDB schema applies cleanly against a live instance

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com