### PR TITLE
feat(wellsfargo): add net-worth-tracker skill

### DIFF
--- a/wellsfargo/net-worth-tracker/.env.example
+++ b/wellsfargo/net-worth-tracker/.env.example
@@ -1,3 +1,2 @@
-# Generated SkillForge environment template for net-worth-tracker
-# No required secrets for this skill.
-
+# Optional override
+WF_SERENDB_URL=

--- a/wellsfargo/net-worth-tracker/.gitignore
+++ b/wellsfargo/net-worth-tracker/.gitignore
@@ -1,0 +1,6 @@
+config.json
+.env
+artifacts/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/wellsfargo/net-worth-tracker/SKILL.md
+++ b/wellsfargo/net-worth-tracker/SKILL.md
@@ -1,22 +1,59 @@
 ---
 name: net-worth-tracker
-description: "Track account balances from Wells Fargo statement data with optional manual asset and liability entries to produce a simplified balance sheet and net worth trajectory over time."
+description: "Track net worth trends over time from Wells Fargo transaction data stored in SerenDB."
 ---
 
-# Net Worth Tracker
+# Wells Fargo Net Worth Tracker
 
-## When to Use
+## When To Use
 
-- track my net worth over time
-- generate balance sheet from wells fargo data
-- show net worth trajectory
+- Track net worth trends from cumulative transaction balances over time.
+- Compute monthly inflow/outflow totals and running balance.
+- Visualize net worth trajectory across configurable periods.
+- Persist net worth snapshots into SerenDB for trend analysis.
 
-## Workflow Summary
+## Prerequisites
 
-1. `resolve_serendb` uses `connector.serendb.connect`
-2. `query_balances` uses `connector.serendb.query`
-3. `load_manual_entries` uses `transform.load_manual_entries`
-4. `compute_balance_sheet` uses `transform.compute_balance_sheet`
-5. `compute_net_worth_trajectory` uses `transform.compute_net_worth_trajectory`
-6. `render_report` uses `transform.render`
-7. `persist_networth_data` uses `connector.serendb.upsert`
+- The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
+- SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+
+## Safety Profile
+
+- Read-only against SerenDB source tables.
+- Writes only to dedicated `wf_networth_*` tables (never modifies upstream data).
+- No browser automation required.
+- No credentials stored or transmitted.
+
+## Quick Start
+
+```bash
+cd wellsfargo/net-worth-tracker
+python3 -m pip install -r requirements.txt
+cp .env.example .env && cp config.example.json config.json
+python3 scripts/run.py --config config.json --months 12 --out artifacts/net-worth-tracker
+```
+
+## Commands
+
+```bash
+python3 scripts/run.py --config config.json --months 12 --out artifacts/net-worth-tracker
+python3 scripts/run.py --config config.json --start 2025-01-01 --end 2025-12-31 --out artifacts/net-worth-tracker
+python3 scripts/run.py --config config.json --months 12 --skip-persist --out artifacts/net-worth-tracker
+```
+
+## Outputs
+
+- Markdown report: `artifacts/net-worth-tracker/reports/<run_id>.md`
+- JSON report: `artifacts/net-worth-tracker/reports/<run_id>.json`
+- Monthly export: `artifacts/net-worth-tracker/exports/<run_id>.monthly.jsonl`
+
+## SerenDB Tables
+
+- `wf_networth_runs` - net worth tracking runs
+- `wf_networth_monthly` - monthly inflow/outflow/balance per run
+- `wf_networth_snapshots` - summary snapshot per run
+
+## Reusable Views
+
+- `v_wf_networth_latest` - most recent net worth snapshot
+- `v_wf_networth_trend` - monthly net worth trend from latest run

--- a/wellsfargo/net-worth-tracker/config.example.json
+++ b/wellsfargo/net-worth-tracker/config.example.json
@@ -1,15 +1,16 @@
 {
-  "connectors": [
-    "serendb"
-  ],
-  "dry_run": false,
-  "inputs": {
-    "end": "",
-    "manual_entries_file": "config/manual_entries.json",
-    "months": 12,
-    "out": "artifacts/net-worth-tracker",
-    "skip_persist": false,
-    "start": ""
+  "runtime": { "artifacts_subdir": "net-worth-tracker" },
+  "serendb": {
+    "enabled": true,
+    "database_url_env": "WF_SERENDB_URL",
+    "auto_resolve_via_seren_cli": true,
+    "pooled_connection": true,
+    "project_id": "",
+    "branch_id": "",
+    "schema_path": "sql/schema.sql",
+    "project_name": "",
+    "branch_name": "",
+    "database_name": "serendb"
   },
-  "skill": "net-worth-tracker"
+  "starting_balance": 0.0
 }

--- a/wellsfargo/net-worth-tracker/requirements.txt
+++ b/wellsfargo/net-worth-tracker/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2.0
+python-dateutil>=2.9.0

--- a/wellsfargo/net-worth-tracker/scripts/networth_builder.py
+++ b/wellsfargo/net-worth-tracker/scripts/networth_builder.py
@@ -1,0 +1,142 @@
+"""Pure-logic net worth builder (no DB dependencies)."""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from typing import Any
+
+
+def compute_monthly_totals(transactions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group transactions by month and compute inflows, outflows, net, and txn_count.
+
+    Returns a sorted list of dicts:
+        {month_start, inflows, outflows, net, txn_count}
+    """
+    buckets: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"inflows": 0.0, "outflows": 0.0, "txn_count": 0}
+    )
+
+    for txn in transactions:
+        txn_date = txn.get("txn_date")
+        if isinstance(txn_date, str):
+            txn_date = date.fromisoformat(txn_date)
+        month_key = txn_date.replace(day=1).isoformat()
+        amount = float(txn.get("amount", 0))
+        if amount >= 0:
+            buckets[month_key]["inflows"] = round(buckets[month_key]["inflows"] + amount, 2)
+        else:
+            buckets[month_key]["outflows"] = round(buckets[month_key]["outflows"] + amount, 2)
+        buckets[month_key]["txn_count"] += 1
+
+    result: list[dict[str, Any]] = []
+    for month_key in sorted(buckets):
+        b = buckets[month_key]
+        net = round(b["inflows"] + b["outflows"], 2)
+        result.append(
+            {
+                "month_start": month_key,
+                "inflows": b["inflows"],
+                "outflows": b["outflows"],
+                "net": net,
+                "txn_count": b["txn_count"],
+            }
+        )
+    return result
+
+
+def compute_running_balance(
+    monthly_totals: list[dict[str, Any]],
+    starting_balance: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Add a running_balance field to each month dict (cumulative from starting_balance)."""
+    balance = starting_balance
+    for month in monthly_totals:
+        balance = round(balance + month["net"], 2)
+        month["running_balance"] = balance
+    return monthly_totals
+
+
+def build_networth_summary(
+    transactions: list[dict[str, Any]],
+    starting_balance: float = 0.0,
+) -> dict[str, Any]:
+    """Build a complete net worth summary from transactions.
+
+    Returns a dict with:
+        monthly: list of monthly dicts (with running_balance)
+        total_inflows, total_outflows, net_change, ending_balance, starting_balance
+    """
+    monthly = compute_monthly_totals(transactions)
+    monthly = compute_running_balance(monthly, starting_balance)
+
+    total_inflows = round(sum(m["inflows"] for m in monthly), 2)
+    total_outflows = round(sum(m["outflows"] for m in monthly), 2)
+    net_change = round(total_inflows + total_outflows, 2)
+    ending_balance = monthly[-1]["running_balance"] if monthly else starting_balance
+
+    return {
+        "monthly": monthly,
+        "total_inflows": total_inflows,
+        "total_outflows": total_outflows,
+        "net_change": net_change,
+        "starting_balance": starting_balance,
+        "ending_balance": ending_balance,
+    }
+
+
+def render_markdown(
+    summary: dict[str, Any],
+    period_start: date,
+    period_end: date,
+    run_id: str,
+    txn_count: int,
+) -> str:
+    """Render a net worth report as Markdown."""
+    lines: list[str] = []
+    lines.append("# Wells Fargo Net Worth Report")
+    lines.append("")
+    lines.append(f"**Period:** {period_start.isoformat()} to {period_end.isoformat()}")
+    lines.append(f"**Run ID:** {run_id}")
+    lines.append(f"**Transactions analyzed:** {txn_count}")
+    lines.append(f"**Starting Balance:** ${summary['starting_balance']:,.2f}")
+    lines.append("")
+
+    lines.append("## Monthly Breakdown")
+    lines.append("")
+    lines.append("| Month | Inflows | Outflows | Net | Running Balance | Txns |")
+    lines.append("|-------|--------:|---------:|----:|----------------:|-----:|")
+    for m in summary["monthly"]:
+        lines.append(
+            f"| {m['month_start']} "
+            f"| ${m['inflows']:,.2f} "
+            f"| ${m['outflows']:,.2f} "
+            f"| ${m['net']:,.2f} "
+            f"| ${m['running_balance']:,.2f} "
+            f"| {m['txn_count']} |"
+        )
+    lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| | Amount |")
+    lines.append("|--|-------:|")
+    lines.append(f"| Starting Balance | ${summary['starting_balance']:,.2f} |")
+    lines.append(f"| Total Inflows | ${summary['total_inflows']:,.2f} |")
+    lines.append(f"| Total Outflows | ${summary['total_outflows']:,.2f} |")
+    lines.append(f"| Net Change | ${summary['net_change']:,.2f} |")
+    lines.append(f"| **Ending Balance** | **${summary['ending_balance']:,.2f}** |")
+    lines.append("")
+
+    lines.append("## Net Worth Trend")
+    lines.append("")
+    if summary["monthly"]:
+        max_balance = max(m["running_balance"] for m in summary["monthly"])
+        min_balance = min(m["running_balance"] for m in summary["monthly"])
+        lines.append(f"- **Peak:** ${max_balance:,.2f}")
+        lines.append(f"- **Trough:** ${min_balance:,.2f}")
+        lines.append(f"- **Final:** ${summary['ending_balance']:,.2f}")
+    else:
+        lines.append("No data for the selected period.")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/wellsfargo/net-worth-tracker/scripts/run.py
+++ b/wellsfargo/net-worth-tracker/scripts/run.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Wells Fargo Net Worth Tracker.
+
+Reads categorized transaction data from SerenDB (populated by bank-statement-processing)
+and computes monthly inflow/outflow totals, running balance, and net worth trajectory.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from networth_builder import (
+    build_networth_summary,
+    render_markdown,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MONTHS = 12
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dump_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+def load_json(path: Path, default: Any = None) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+class RunLogger:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def emit(self, step: str, message: str, **data: Any) -> None:
+        payload = {"ts": utc_now_iso(), "step": step, "message": message, "data": data}
+        append_jsonl(self.log_path, payload)
+        suffix = f" | {json.dumps(data, sort_keys=True, default=str)}" if data else ""
+        print(f"[{payload['ts']}] {step}: {message}{suffix}")
+
+
+# ---------------------------------------------------------------------------
+# SerenDB resolution (mirrors bank-statement-processing logic)
+# ---------------------------------------------------------------------------
+
+def _run_seren_json(seren_bin: str, args: list[str]) -> tuple[int, Any, str]:
+    cmd = [seren_bin, *args, "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload: Any = None
+    if result.stdout.strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+    return result.returncode, payload, result.stderr.strip()
+
+
+def _extract_database_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("databases", "data", "items", "results"):
+            if isinstance(payload.get(key), list):
+                return payload[key]
+    return []
+
+
+def _parse_dotenv_value(env_path: Path, key: str) -> str:
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line[len(f"{key}="):].strip().strip("\"'")
+    return ""
+
+
+def resolve_serendb_database_url(
+    config: dict[str, Any],
+    logger: RunLogger,
+) -> tuple[str, str]:
+    serendb_cfg = config.get("serendb", {})
+    env_key = str(serendb_cfg.get("database_url_env", "WF_SERENDB_URL")).strip() or "WF_SERENDB_URL"
+
+    from_env = os.getenv(env_key, "").strip()
+    if from_env:
+        return from_env, f"env:{env_key}"
+
+    if not bool(serendb_cfg.get("auto_resolve_via_seren_cli", True)):
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and auto-resolve is disabled."
+        )
+
+    seren_bin = shutil.which("seren")
+    if not seren_bin:
+        raise RuntimeError(
+            f"SerenDB is enabled but {env_key} is empty and `seren` CLI was not found in PATH."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="wf-networth-env-") as temp_dir:
+        env_path = Path(temp_dir) / ".env"
+        base_cmd = [
+            seren_bin,
+            "env",
+            "init",
+            "--env",
+            str(env_path),
+            "--key",
+            env_key,
+            "--yes",
+            "-o",
+            "json",
+        ]
+        if bool(serendb_cfg.get("pooled_connection", True)):
+            base_cmd.append("--pooled")
+
+        # Build candidates from database catalog
+        rc, payload, _ = _run_seren_json(seren_bin, ["list-all-databases"])
+        rows = _extract_database_rows(payload) if rc == 0 else []
+
+        desired_project = str(serendb_cfg.get("project_name", "")).strip().lower()
+        desired_database = str(serendb_cfg.get("database_name", "serendb")).strip().lower()
+
+        candidates: list[tuple[str, str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        # Explicit project_id + branch_id
+        explicit_pid = str(serendb_cfg.get("project_id", "")).strip()
+        explicit_bid = str(serendb_cfg.get("branch_id", "")).strip()
+        if explicit_pid and explicit_bid:
+            candidates.append((explicit_pid, explicit_bid, "explicit"))
+            seen.add((explicit_pid, explicit_bid))
+
+        # Rank from catalog
+        for row in rows:
+            pid = row.get("project_id", "").strip()
+            bid = row.get("branch_id", "").strip()
+            if not pid or not bid:
+                continue
+            key = (pid, bid)
+            if key in seen:
+                continue
+            rp = row.get("project_name", "").strip().lower()
+            rd = row.get("database_name", "").strip().lower()
+            if desired_project and rp != desired_project:
+                continue
+            if desired_database and rd != desired_database:
+                continue
+            seen.add(key)
+            label = f"catalog:{rp}/{row.get('branch_name', '')}/{rd}"
+            candidates.append((pid, bid, label))
+
+        if not candidates:
+            raise RuntimeError(
+                "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+                f"Could not infer a project/branch for {env_key}. "
+                "Set `serendb.project_id` + `serendb.branch_id`, or provide WF_SERENDB_URL."
+            )
+
+        attempt_errors: list[str] = []
+        for project_id, branch_id, source in candidates:
+            cmd = [*base_cmd, "--project-id", project_id, "--branch-id", branch_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if result.returncode == 0:
+                resolved = _parse_dotenv_value(env_path, env_key).strip()
+                if resolved:
+                    os.environ[env_key] = resolved
+                    logger.emit(
+                        "serendb_url_resolved",
+                        "Resolved SerenDB URL from Seren CLI context",
+                        env_key=env_key,
+                        source=f"seren_cli_context:{source}",
+                    )
+                    return resolved, f"seren_cli_context:{source}"
+                attempt_errors.append(f"{source}: empty dotenv write")
+                continue
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            details = stderr or stdout or "unknown error"
+            attempt_errors.append(f"{source}: {details}")
+
+        preview = "; ".join(attempt_errors[:5])
+        raise RuntimeError(
+            "Failed to resolve SerenDB URL via logged-in Seren CLI context. "
+            f"Tried {len(candidates)} candidates for {env_key}. "
+            f"Errors: {preview}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+QUERY_CATEGORIZED_TRANSACTIONS = """
+SELECT
+  t.row_hash,
+  t.account_masked,
+  t.txn_date,
+  t.description_raw,
+  t.amount,
+  t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source,
+  c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s
+  AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash
+"""
+
+
+def fetch_transactions(
+    database_url: str,
+    start_date: date,
+    end_date: date,
+) -> list[dict[str, Any]]:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                QUERY_CATEGORIZED_TRANSACTIONS,
+                {"start_date": start_date.isoformat(), "end_date": end_date.isoformat()},
+            )
+            columns = [desc.name for desc in cur.description]
+            rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# SerenDB persistence
+# ---------------------------------------------------------------------------
+
+def _read_sql(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def persist_networth(
+    database_url: str,
+    schema_path: Path,
+    run_record: dict[str, Any],
+    summary: dict[str, Any],
+) -> None:
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_read_sql(schema_path))
+
+            cur.execute(
+                """
+                INSERT INTO wf_networth_runs (
+                  run_id, started_at, ended_at, status,
+                  period_start, period_end,
+                  starting_balance, ending_balance,
+                  total_inflows, total_outflows, net_change,
+                  months_count, txn_count, artifact_root
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  ended_at = EXCLUDED.ended_at,
+                  status = EXCLUDED.status,
+                  ending_balance = EXCLUDED.ending_balance,
+                  total_inflows = EXCLUDED.total_inflows,
+                  total_outflows = EXCLUDED.total_outflows,
+                  net_change = EXCLUDED.net_change,
+                  months_count = EXCLUDED.months_count,
+                  txn_count = EXCLUDED.txn_count
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["started_at"],
+                    run_record["ended_at"],
+                    run_record["status"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    summary["starting_balance"],
+                    summary["ending_balance"],
+                    summary["total_inflows"],
+                    summary["total_outflows"],
+                    summary["net_change"],
+                    len(summary["monthly"]),
+                    run_record["txn_count"],
+                    run_record["artifact_root"],
+                ),
+            )
+
+            # Insert monthly rows
+            for m in summary["monthly"]:
+                cur.execute(
+                    """
+                    INSERT INTO wf_networth_monthly (
+                      run_id, month_start, inflows, outflows, net,
+                      running_balance, txn_count
+                    ) VALUES (%s,%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT (run_id, month_start)
+                    DO UPDATE SET
+                      inflows = EXCLUDED.inflows,
+                      outflows = EXCLUDED.outflows,
+                      net = EXCLUDED.net,
+                      running_balance = EXCLUDED.running_balance,
+                      txn_count = EXCLUDED.txn_count
+                    """,
+                    (
+                        run_record["run_id"],
+                        m["month_start"],
+                        m["inflows"],
+                        m["outflows"],
+                        m["net"],
+                        m["running_balance"],
+                        m["txn_count"],
+                    ),
+                )
+
+            # Insert snapshot
+            monthly_json = json.dumps(summary["monthly"], default=str)
+            cur.execute(
+                """
+                INSERT INTO wf_networth_snapshots (
+                  run_id, period_start, period_end,
+                  starting_balance, ending_balance, net_change,
+                  monthly_json
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb)
+                ON CONFLICT (run_id)
+                DO UPDATE SET
+                  starting_balance = EXCLUDED.starting_balance,
+                  ending_balance = EXCLUDED.ending_balance,
+                  net_change = EXCLUDED.net_change,
+                  monthly_json = EXCLUDED.monthly_json
+                """,
+                (
+                    run_record["run_id"],
+                    run_record["period_start"],
+                    run_record["period_end"],
+                    summary["starting_balance"],
+                    summary["ending_balance"],
+                    summary["net_change"],
+                    monthly_json,
+                ),
+            )
+
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Track net worth trends from Wells Fargo transaction data in SerenDB",
+    )
+    parser.add_argument("--config", default="config.json", help="Path to config JSON")
+    parser.add_argument(
+        "--months",
+        type=int,
+        default=DEFAULT_MONTHS,
+        help=f"Number of months to include (default {DEFAULT_MONTHS})",
+    )
+    parser.add_argument("--start", type=str, default="", help="Start date (YYYY-MM-DD), overrides --months")
+    parser.add_argument("--end", type=str, default="", help="End date (YYYY-MM-DD), defaults to today")
+    parser.add_argument(
+        "--starting-balance",
+        type=float,
+        default=None,
+        help="Known starting balance at period start (overrides config)",
+    )
+    parser.add_argument("--out", type=str, default="artifacts/net-worth-tracker", help="Output directory")
+    parser.add_argument("--skip-persist", action="store_true", help="Skip SerenDB persistence")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Load config
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    # Determine date range
+    today = date.today()
+    if args.start:
+        period_start = date.fromisoformat(args.start)
+        period_end = date.fromisoformat(args.end) if args.end else today
+    else:
+        from dateutil.relativedelta import relativedelta
+        period_start = today - relativedelta(months=args.months)
+        period_end = today
+
+    # Determine starting balance
+    starting_balance = (
+        args.starting_balance
+        if args.starting_balance is not None
+        else float(config.get("starting_balance", 0.0))
+    )
+
+    # Set up output directories
+    out_dir = Path(args.out)
+    report_dir = ensure_dir(out_dir / "reports")
+    export_dir = ensure_dir(out_dir / "exports")
+    log_dir = ensure_dir(out_dir / "logs")
+
+    run_id = f"networth-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    logger = RunLogger(log_dir / f"{run_id}.jsonl")
+
+    logger.emit("start", "Net worth tracking started", run_id=run_id)
+    logger.emit(
+        "period",
+        f"Period: {period_start.isoformat()} to {period_end.isoformat()}",
+        start=period_start.isoformat(),
+        end=period_end.isoformat(),
+        starting_balance=starting_balance,
+    )
+
+    run_record: dict[str, Any] = {
+        "run_id": run_id,
+        "started_at": utc_now_iso(),
+        "ended_at": None,
+        "status": "running",
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "txn_count": 0,
+        "artifact_root": str(out_dir.resolve()),
+    }
+
+    try:
+        # Resolve SerenDB URL
+        db_url, db_source = resolve_serendb_database_url(config, logger)
+        logger.emit("serendb_connected", f"Connected via {db_source}")
+
+        # Fetch transactions
+        logger.emit("query_transactions", "Fetching categorized transactions from SerenDB")
+        transactions = fetch_transactions(db_url, period_start, period_end)
+        logger.emit("query_transactions_done", f"Fetched {len(transactions)} transactions", count=len(transactions))
+
+        if not transactions:
+            logger.emit("warn", "No transactions found for the specified period. Is bank-statement-processing data synced?")
+            run_record["status"] = "empty"
+            run_record["ended_at"] = utc_now_iso()
+            run_record["txn_count"] = 0
+            print("No transactions found. Ensure bank-statement-processing has synced data to SerenDB.")
+            sys.exit(0)
+
+        run_record["txn_count"] = len(transactions)
+
+        # Build net worth summary
+        logger.emit("build_networth", "Computing net worth summary")
+        summary = build_networth_summary(transactions, starting_balance)
+        logger.emit(
+            "build_networth_done",
+            "Net worth summary computed",
+            total_inflows=summary["total_inflows"],
+            total_outflows=summary["total_outflows"],
+            net_change=summary["net_change"],
+            ending_balance=summary["ending_balance"],
+        )
+
+        # Render reports
+        md_content = render_markdown(summary, period_start, period_end, run_id, len(transactions))
+        md_path = report_dir / f"{run_id}.md"
+        md_path.write_text(md_content, encoding="utf-8")
+
+        json_report = {
+            "run_id": run_id,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "txn_count": len(transactions),
+            "starting_balance": starting_balance,
+            "summary": summary,
+        }
+        json_path = report_dir / f"{run_id}.json"
+        dump_json(json_path, json_report)
+
+        # Export monthly data
+        export_path = export_dir / f"{run_id}.monthly.jsonl"
+        for m in summary["monthly"]:
+            append_jsonl(export_path, m)
+
+        logger.emit("render_done", "Reports written", md=str(md_path), json=str(json_path))
+
+        # Persist to SerenDB
+        if not args.skip_persist and bool(config.get("serendb", {}).get("enabled", True)):
+            schema_path_str = config.get("serendb", {}).get("schema_path", "sql/schema.sql")
+            schema_path = Path(schema_path_str)
+            if not schema_path.is_absolute():
+                schema_path = config_path.parent / schema_path
+            logger.emit("persist", "Persisting net worth data to SerenDB")
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            persist_networth(db_url, schema_path, run_record, summary)
+            logger.emit("persist_done", "SerenDB persistence complete")
+        else:
+            run_record["status"] = "success"
+            run_record["ended_at"] = utc_now_iso()
+            logger.emit("persist_skipped", "SerenDB persistence skipped")
+
+        logger.emit("complete", "Net worth tracking complete")
+        print(f"\nNet Worth Report generated successfully!")
+        print(f"  Markdown: {md_path}")
+        print(f"  JSON:     {json_path}")
+        print(f"  Period:   {period_start} to {period_end}")
+        print(f"  Transactions: {len(transactions)}")
+        print(f"  Starting Balance: ${starting_balance:,.2f}")
+        print(f"  Ending Balance:   ${summary['ending_balance']:,.2f}")
+        print(f"  Net Change:       ${summary['net_change']:,.2f}")
+
+    except Exception as exc:
+        run_record["status"] = "error"
+        run_record["ended_at"] = utc_now_iso()
+        logger.emit("error", str(exc), error_type=type(exc).__name__)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wellsfargo/net-worth-tracker/skill.spec.yaml
+++ b/wellsfargo/net-worth-tracker/skill.spec.yaml
@@ -1,0 +1,56 @@
+skill: net-worth-tracker
+description: Track net worth trends over time from Wells Fargo transaction data stored in SerenDB.
+triggers:
+  - track wells fargo net worth
+  - wellsfargo balance history
+runtime:
+  language: python
+  entrypoint: scripts/run.py
+inputs:
+  months:
+    type: integer
+    min: 1
+    max: 60
+    default: 12
+  start:
+    type: string
+  end:
+    type: string
+  starting_balance:
+    type: number
+    default: 0.0
+    description: Known starting balance at period start.
+  out:
+    type: string
+    default: artifacts/net-worth-tracker
+  skip_persist:
+    type: boolean
+    default: false
+connectors:
+  serendb:
+    kind: seren_publisher
+    publisher: serendb
+policies:
+  dry_run_default: false
+  idempotency_required: true
+workflow:
+  steps:
+    - id: resolve_serendb
+      use: connector.serendb.connect
+    - id: query_transactions
+      use: connector.serendb.query
+    - id: compute_monthly
+      use: transform.aggregate_monthly
+    - id: compute_running_balance
+      use: transform.running_balance
+    - id: render_report
+      use: transform.render
+    - id: persist_snapshot
+      use: connector.serendb.upsert
+publish:
+  org: seren-skills
+  slug: net-worth-tracker
+metadata:
+  category: finance
+  depends_on:
+    - bank-statement-processing

--- a/wellsfargo/net-worth-tracker/sql/queries.sql
+++ b/wellsfargo/net-worth-tracker/sql/queries.sql
@@ -1,0 +1,9 @@
+-- fetch_categorized_transactions
+SELECT t.row_hash, t.account_masked, t.txn_date, t.description_raw,
+  t.amount, t.currency,
+  COALESCE(c.category, 'uncategorized') AS category,
+  COALESCE(c.category_source, 'none') AS category_source, c.confidence
+FROM wf_transactions t
+LEFT JOIN wf_txn_categories c ON c.row_hash = t.row_hash
+WHERE t.txn_date >= %(start_date)s AND t.txn_date <= %(end_date)s
+ORDER BY t.txn_date, t.row_hash;

--- a/wellsfargo/net-worth-tracker/sql/schema.sql
+++ b/wellsfargo/net-worth-tracker/sql/schema.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS wf_networth_runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  starting_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  ending_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_inflows NUMERIC(14,2) NOT NULL DEFAULT 0,
+  total_outflows NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_change NUMERIC(14,2) NOT NULL DEFAULT 0,
+  months_count INTEGER NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  artifact_root TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS wf_networth_monthly (
+  id SERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES wf_networth_runs(run_id) ON DELETE CASCADE,
+  month_start DATE NOT NULL,
+  inflows NUMERIC(14,2) NOT NULL DEFAULT 0,
+  outflows NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net NUMERIC(14,2) NOT NULL DEFAULT 0,
+  running_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  txn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (run_id, month_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wf_networth_monthly_run ON wf_networth_monthly(run_id);
+
+CREATE TABLE IF NOT EXISTS wf_networth_snapshots (
+  run_id TEXT PRIMARY KEY REFERENCES wf_networth_runs(run_id) ON DELETE CASCADE,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  starting_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  ending_balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  net_change NUMERIC(14,2) NOT NULL DEFAULT 0,
+  monthly_json JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE VIEW v_wf_networth_latest AS
+SELECT s.* FROM wf_networth_snapshots s
+JOIN wf_networth_runs r ON r.run_id = s.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (SELECT MAX(r2.ended_at) FROM wf_networth_runs r2 WHERE r2.status = 'success');
+
+CREATE OR REPLACE VIEW v_wf_networth_trend AS
+SELECT m.* FROM wf_networth_monthly m
+JOIN wf_networth_runs r ON r.run_id = m.run_id
+WHERE r.status = 'success'
+AND r.ended_at = (SELECT MAX(r2.ended_at) FROM wf_networth_runs r2 WHERE r2.status = 'success')
+ORDER BY m.month_start;

--- a/wellsfargo/net-worth-tracker/tests/test_smoke.py
+++ b/wellsfargo/net-worth-tracker/tests/test_smoke.py
@@ -1,36 +1,157 @@
+"""Smoke tests for the net worth builder (no DB required)."""
 from __future__ import annotations
 
-import json
+import sys
+from datetime import date
 from pathlib import Path
 
+# Allow importing from scripts/
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
-FIXTURE_DIR = Path(__file__).parent / "fixtures"
-
-
-def _read_fixture(name: str) -> dict:
-    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
-
-
-def test_happy_path_fixture_is_successful() -> None:
-    payload = _read_fixture("happy_path.json")
-    assert payload["status"] == "ok"
-    assert payload["skill"] == "net-worth-tracker"
+from networth_builder import (  # noqa: E402
+    build_networth_summary,
+    compute_monthly_totals,
+    compute_running_balance,
+    render_markdown,
+)
 
 
-def test_connector_failure_fixture_has_error_code() -> None:
-    payload = _read_fixture("connector_failure.json")
-    assert payload["status"] == "error"
-    assert payload["error_code"] == "connector_failure"
+def _make_txn(amount: float, txn_date: str = "2025-06-15", category: str = "uncategorized") -> dict:
+    return {
+        "row_hash": f"hash_{abs(hash((amount, txn_date, category)))}",
+        "account_masked": "****1234",
+        "txn_date": txn_date,
+        "description_raw": f"Test txn {category}",
+        "amount": amount,
+        "currency": "USD",
+        "category": category,
+        "category_source": "test",
+        "confidence": 1.0,
+    }
 
 
-def test_policy_violation_fixture_has_error_code() -> None:
-    payload = _read_fixture("policy_violation.json")
-    assert payload["status"] == "error"
-    assert payload["error_code"] == "policy_violation"
+class TestComputeMonthlyTotals:
+    def test_groups_by_month_correctly(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "2025-01-10"),
+            _make_txn(-2000.0, "2025-01-20"),
+            _make_txn(3000.0, "2025-02-05"),
+            _make_txn(-1000.0, "2025-02-15"),
+            _make_txn(1500.0, "2025-03-01"),
+        ]
+        monthly = compute_monthly_totals(transactions)
+
+        assert len(monthly) == 3
+        assert monthly[0]["month_start"] == "2025-01-01"
+        assert monthly[0]["inflows"] == 5000.0
+        assert monthly[0]["outflows"] == -2000.0
+        assert monthly[0]["net"] == 3000.0
+        assert monthly[0]["txn_count"] == 2
+
+        assert monthly[1]["month_start"] == "2025-02-01"
+        assert monthly[1]["inflows"] == 3000.0
+        assert monthly[1]["outflows"] == -1000.0
+        assert monthly[1]["net"] == 2000.0
+        assert monthly[1]["txn_count"] == 2
+
+        assert monthly[2]["month_start"] == "2025-03-01"
+        assert monthly[2]["inflows"] == 1500.0
+        assert monthly[2]["outflows"] == 0.0
+        assert monthly[2]["net"] == 1500.0
+        assert monthly[2]["txn_count"] == 1
 
 
-def test_dry_run_fixture_blocks_live_execution() -> None:
-    payload = _read_fixture("dry_run_guard.json")
-    assert payload["dry_run"] is True
-    assert payload["blocked_action"] == "live_execution"
+class TestComputeRunningBalance:
+    def test_calculates_cumulative_balance(self) -> None:
+        monthly = [
+            {"month_start": "2025-01-01", "inflows": 5000.0, "outflows": -2000.0, "net": 3000.0, "txn_count": 2},
+            {"month_start": "2025-02-01", "inflows": 3000.0, "outflows": -1000.0, "net": 2000.0, "txn_count": 2},
+            {"month_start": "2025-03-01", "inflows": 1500.0, "outflows": -500.0, "net": 1000.0, "txn_count": 1},
+        ]
+        result = compute_running_balance(monthly, starting_balance=0.0)
 
+        assert result[0]["running_balance"] == 3000.0
+        assert result[1]["running_balance"] == 5000.0
+        assert result[2]["running_balance"] == 6000.0
+
+    def test_with_nonzero_starting_balance(self) -> None:
+        monthly = [
+            {"month_start": "2025-01-01", "inflows": 1000.0, "outflows": -500.0, "net": 500.0, "txn_count": 2},
+        ]
+        result = compute_running_balance(monthly, starting_balance=10000.0)
+
+        assert result[0]["running_balance"] == 10500.0
+
+
+class TestBuildNetworthSummary:
+    def test_with_mixed_transactions(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "2025-01-10"),
+            _make_txn(-2000.0, "2025-01-20"),
+            _make_txn(3000.0, "2025-02-05"),
+            _make_txn(-4000.0, "2025-02-15"),
+        ]
+        summary = build_networth_summary(transactions, starting_balance=0.0)
+
+        assert summary["total_inflows"] == 8000.0
+        assert summary["total_outflows"] == -6000.0
+        assert summary["net_change"] == 2000.0
+        assert summary["starting_balance"] == 0.0
+        assert summary["ending_balance"] == 2000.0
+        assert len(summary["monthly"]) == 2
+        assert summary["monthly"][0]["running_balance"] == 3000.0
+        assert summary["monthly"][1]["running_balance"] == 2000.0
+
+    def test_with_empty_input(self) -> None:
+        summary = build_networth_summary([], starting_balance=0.0)
+
+        assert summary["total_inflows"] == 0.0
+        assert summary["total_outflows"] == 0.0
+        assert summary["net_change"] == 0.0
+        assert summary["starting_balance"] == 0.0
+        assert summary["ending_balance"] == 0.0
+        assert len(summary["monthly"]) == 0
+
+    def test_with_starting_balance(self) -> None:
+        transactions = [
+            _make_txn(1000.0, "2025-03-10"),
+            _make_txn(-500.0, "2025-03-20"),
+        ]
+        summary = build_networth_summary(transactions, starting_balance=25000.0)
+
+        assert summary["starting_balance"] == 25000.0
+        assert summary["ending_balance"] == 25500.0
+        assert summary["net_change"] == 500.0
+        assert len(summary["monthly"]) == 1
+        assert summary["monthly"][0]["running_balance"] == 25500.0
+
+
+class TestRenderMarkdown:
+    def test_produces_valid_output(self) -> None:
+        transactions = [
+            _make_txn(5000.0, "2025-01-10"),
+            _make_txn(-2000.0, "2025-01-20"),
+            _make_txn(3000.0, "2025-02-05"),
+        ]
+        summary = build_networth_summary(transactions, starting_balance=1000.0)
+        md = render_markdown(
+            summary,
+            period_start=date(2025, 1, 1),
+            period_end=date(2025, 12, 31),
+            run_id="test-run-001",
+            txn_count=3,
+        )
+
+        assert "# Wells Fargo Net Worth Report" in md
+        assert "2025-01-01" in md
+        assert "2025-12-31" in md
+        assert "test-run-001" in md
+        assert "Starting Balance" in md
+        assert "Ending Balance" in md
+        assert "Net Change" in md
+        assert "Monthly Breakdown" in md
+        assert "Net Worth Trend" in md
+        assert "Inflows" in md
+        assert "Outflows" in md
+        assert "Running Balance" in md


### PR DESCRIPTION
## Summary
- New `wellsfargo/net-worth-tracker` skill tracking net worth trends over time
- Computes monthly inflow/outflow totals and cumulative running balance
- Supports configurable starting balance for accurate absolute tracking
- Persists monthly snapshots to SerenDB (`wf_networth_*` tables) with trend view
- Includes smoke tests (all passing)

## Test plan
- [x] Run pytest — all tests pass
- [ ] Verify SKILL.md frontmatter
- [ ] Confirm SerenDB schema applies cleanly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com