### PR TITLE
fix: harden MCP runtime and document required CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ org/skill-name/
 └── .env.example           # Environment template (optional)
 ```
 
+## Runtime CLI Requirements
+
+Some skills invoke local CLIs at runtime in addition to Python packages:
+
+- `seren-mcp` for MCP-native persistence in:
+  - `kraken/grid-trader`
+  - `coinbase/grid-trader`
+  - `kraken/money-mode-router`
+- `seren` (authenticated via `seren auth`) for auto-resolving SerenDB URLs when `WF_SERENDB_URL` is not set in:
+  - `wellsfargo/net-worth-tracker`
+  - `wellsfargo/income-statement`
+  - `wellsfargo/cash-flow-statement`
+  - `wellsfargo/recurring-transactions`
+
 ## Adding a Skill
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -28,7 +28,7 @@ from serendb_store import SerenDBStore
 import pair_selector
 
 
-def _get_seren_api_key() -> str | None:
+def _get_seren_api_key() -> Optional[str]:
     return os.getenv("SEREN_API_KEY") or os.getenv("API_KEY")
 
 

--- a/coinbase/grid-trader/scripts/serendb_store.py
+++ b/coinbase/grid-trader/scripts/serendb_store.py
@@ -1,10 +1,11 @@
-"""SerenDB persistence for Coinbase Grid Trader via local seren-mcp."""
+"""SerenDB persistence for Coinbase Grid Trader via local MCP CLI."""
 
 from __future__ import annotations
 
 import json
 import os
 import select
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 class SerenMCPError(RuntimeError):
-    """Raised when a local seren-mcp tool call fails."""
+    """Raised when a local MCP tool call fails."""
 
 
 @dataclass
@@ -27,9 +28,17 @@ class _SerenMCPClient:
     def __init__(self, api_key: str, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
         self.api_key = api_key
         self.mcp_command = mcp_command
+        self._mcp_command_parts = self._parse_mcp_command(mcp_command)
         self.timeout_seconds = timeout_seconds
         self._process: Optional[subprocess.Popen[str]] = None
         self._next_id = 1
+
+    @staticmethod
+    def _parse_mcp_command(command: str) -> List[str]:
+        parts = shlex.split(command)
+        if not parts:
+            raise SerenMCPError("MCP command is empty")
+        return parts
 
     def start(self) -> None:
         if self._process is not None:
@@ -39,7 +48,7 @@ class _SerenMCPClient:
         env["API_KEY"] = self.api_key
 
         self._process = subprocess.Popen(
-            [self.mcp_command, "start"],
+            [*self._mcp_command_parts, "start"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -49,7 +58,7 @@ class _SerenMCPClient:
         )
 
         if self._process.stdin is None or self._process.stdout is None:
-            raise SerenMCPError("Failed to open stdio pipes for seren-mcp")
+            raise SerenMCPError("Failed to open stdio pipes for MCP CLI")
 
         init_response = self._request(
             "initialize",
@@ -60,7 +69,7 @@ class _SerenMCPClient:
             },
         )
         if "error" in init_response:
-            raise SerenMCPError(init_response["error"].get("message", "seren-mcp initialize failed"))
+            raise SerenMCPError(init_response["error"].get("message", "MCP initialize failed"))
 
         self._notify("notifications/initialized", {})
 
@@ -109,24 +118,24 @@ class _SerenMCPClient:
 
     def _send(self, message: Dict[str, Any]) -> None:
         if self._process is None or self._process.stdin is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
         self._process.stdin.write(json.dumps(message) + "\n")
         self._process.stdin.flush()
 
     def _read_message(self, timeout: float) -> Optional[Dict[str, Any]]:
         if self._process is None or self._process.stdout is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
 
         ready, _, _ = select.select([self._process.stdout], [], [], timeout)
         if not ready:
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp exited unexpectedly")
+                raise SerenMCPError("MCP process exited unexpectedly")
             return None
 
         line = self._process.stdout.readline()
         if line == "":
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp closed stdout unexpectedly")
+                raise SerenMCPError("MCP process closed stdout unexpectedly")
             return None
 
         payload = line.strip()
@@ -412,7 +421,7 @@ class SerenDBStore:
 
         if not self.auto_create:
             raise SerenMCPError(
-                "Target SerenDB database not found via seren-mcp. "
+                "Target SerenDB database not found via MCP. "
                 "Set SERENDB_DATABASE/SERENDB_PROJECT_NAME or enable SERENDB_AUTO_CREATE=true."
             )
 

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -29,7 +29,7 @@ from serendb_store import SerenDBStore
 import pair_selector
 
 
-def _get_seren_api_key() -> str | None:
+def _get_seren_api_key() -> Optional[str]:
     return os.getenv("SEREN_API_KEY") or os.getenv("API_KEY")
 
 

--- a/kraken/grid-trader/scripts/serendb_store.py
+++ b/kraken/grid-trader/scripts/serendb_store.py
@@ -1,10 +1,11 @@
-"""SerenDB persistence for Kraken Grid Trader via local seren-mcp."""
+"""SerenDB persistence for Kraken Grid Trader via local MCP CLI."""
 
 from __future__ import annotations
 
 import json
 import os
 import select
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 class SerenMCPError(RuntimeError):
-    """Raised when a local seren-mcp tool call fails."""
+    """Raised when a local MCP tool call fails."""
 
 
 @dataclass
@@ -27,9 +28,17 @@ class _SerenMCPClient:
     def __init__(self, api_key: str, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
         self.api_key = api_key
         self.mcp_command = mcp_command
+        self._mcp_command_parts = self._parse_mcp_command(mcp_command)
         self.timeout_seconds = timeout_seconds
         self._process: Optional[subprocess.Popen[str]] = None
         self._next_id = 1
+
+    @staticmethod
+    def _parse_mcp_command(command: str) -> List[str]:
+        parts = shlex.split(command)
+        if not parts:
+            raise SerenMCPError("MCP command is empty")
+        return parts
 
     def start(self) -> None:
         if self._process is not None:
@@ -39,7 +48,7 @@ class _SerenMCPClient:
         env["API_KEY"] = self.api_key
 
         self._process = subprocess.Popen(
-            [self.mcp_command, "start"],
+            [*self._mcp_command_parts, "start"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -49,7 +58,7 @@ class _SerenMCPClient:
         )
 
         if self._process.stdin is None or self._process.stdout is None:
-            raise SerenMCPError("Failed to open stdio pipes for seren-mcp")
+            raise SerenMCPError("Failed to open stdio pipes for MCP CLI")
 
         init_response = self._request(
             "initialize",
@@ -60,7 +69,7 @@ class _SerenMCPClient:
             },
         )
         if "error" in init_response:
-            raise SerenMCPError(init_response["error"].get("message", "seren-mcp initialize failed"))
+            raise SerenMCPError(init_response["error"].get("message", "MCP initialize failed"))
 
         self._notify("notifications/initialized", {})
 
@@ -109,24 +118,24 @@ class _SerenMCPClient:
 
     def _send(self, message: Dict[str, Any]) -> None:
         if self._process is None or self._process.stdin is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
         self._process.stdin.write(json.dumps(message) + "\n")
         self._process.stdin.flush()
 
     def _read_message(self, timeout: float) -> Optional[Dict[str, Any]]:
         if self._process is None or self._process.stdout is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
 
         ready, _, _ = select.select([self._process.stdout], [], [], timeout)
         if not ready:
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp exited unexpectedly")
+                raise SerenMCPError("MCP process exited unexpectedly")
             return None
 
         line = self._process.stdout.readline()
         if line == "":
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp closed stdout unexpectedly")
+                raise SerenMCPError("MCP process closed stdout unexpectedly")
             return None
 
         payload = line.strip()
@@ -412,7 +421,7 @@ class SerenDBStore:
 
         if not self.auto_create:
             raise SerenMCPError(
-                "Target SerenDB database not found via seren-mcp. "
+                "Target SerenDB database not found via MCP. "
                 "Set SERENDB_DATABASE/SERENDB_PROJECT_NAME or enable SERENDB_AUTO_CREATE=true."
             )
 

--- a/kraken/money-mode-router/.env.example
+++ b/kraken/money-mode-router/.env.example
@@ -1,7 +1,7 @@
 # Seren API key for Kraken publisher calls
 SEREN_API_KEY=sb_your_key_here
 
-# MCP-native SerenDB target (optional, resolved via local seren-mcp)
+# MCP-native SerenDB target (optional, resolved via local MCP CLI)
 # If SERENDB_DATABASE is unset:
 # 1) Reuse an existing Kraken-related database if found
 # 2) Otherwise auto-create project/database: krakent/krakent

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when a user asks things like:
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Ensure `seren-mcp` is available locally and authenticated (Seren Desktop login context).
+2. Ensure `seren-mcp` is available locally and authenticated (Seren Desktop login context). Override with `SEREN_MCP_COMMAND` if needed.
 3. Set `SEREN_API_KEY` (required for Kraken account context and MCP auth when running standalone).
 4. Optionally set MCP DB target env vars (`SERENDB_PROJECT_NAME`, `SERENDB_DATABASE`, optional branch/region).
    - If `SERENDB_DATABASE` is not set, the router first tries to reuse an existing Kraken-related database.

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 
@@ -204,7 +204,7 @@ def format_report(
     return "\n".join(lines)
 
 
-def _get_seren_api_key() -> str | None:
+def _get_seren_api_key() -> Optional[str]:
     return os.getenv("SEREN_API_KEY") or os.getenv("API_KEY")
 
 
@@ -239,12 +239,12 @@ def run_init_db(args: argparse.Namespace) -> int:
     try:
         store.ensure_schema()
     except Exception as exc:  # noqa: BLE001
-        print(f"Router persistence failed via seren-mcp: {exc}", file=sys.stderr)
+        print(f"Router persistence failed via MCP: {exc}", file=sys.stderr)
         return 1
     finally:
         store.close()
 
-    print("SerenDB schema initialized via seren-mcp.")
+    print("SerenDB schema initialized via MCP.")
     return 0
 
 
@@ -276,19 +276,37 @@ def run_recommend(args: argparse.Namespace) -> int:
     session_id = str(uuid.uuid4())
     profile_name = args.profile_name
 
-    try:
-        store = _build_store_from_env()
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+    store: Optional[SerenDBStore] = None
+
+    def persist(context: str, fn) -> None:
+        nonlocal store
+        if store is None:
+            return
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            print(f"WARNING: Router persistence failed ({context}): {exc}", file=sys.stderr)
+            try:
+                store.close()
+            finally:
+                store = None
 
     try:
-        store.ensure_schema()
-        store.create_session(session_id, profile_name)
-        store.save_answers(session_id, answers)
-
         account_snapshot: Dict[str, Any] = {}
         api_key = _get_seren_api_key()
+
+        try:
+            store = _build_store_from_env()
+            store.ensure_schema()
+            store.create_session(session_id, profile_name)
+            store.save_answers(session_id, answers)
+        except Exception as exc:  # noqa: BLE001
+            print(f"WARNING: Router persistence unavailable: {exc}", file=sys.stderr)
+            if store is not None:
+                try:
+                    store.close()
+                finally:
+                    store = None
 
         if api_key:
             kraken = KrakenClient(
@@ -299,33 +317,37 @@ def run_recommend(args: argparse.Namespace) -> int:
                     "KRAKEN_TRADING_FALLBACK_PUBLISHER",
                     os.getenv("KRAKEN_SPOT_PUBLISHER", "kraken-spot-trading"),
                 ),
-                kraken_api_key=os.getenv("KRAKEN_API_KEY"),
-                kraken_api_secret=os.getenv("KRAKEN_API_SECRET"),
             )
             account_snapshot = kraken.get_account_snapshot()
-            store.save_event(session_id, "account_snapshot", account_snapshot)
+            persist("account_snapshot", lambda: store.save_event(session_id, "account_snapshot", account_snapshot))
         else:
-            store.save_event(session_id, "account_snapshot", {"skipped": "SEREN_API_KEY not set"})
+            persist(
+                "account_snapshot_skipped",
+                lambda: store.save_event(session_id, "account_snapshot", {"skipped": "SEREN_API_KEY not set"}),
+            )
 
         engine = ModeEngine(config)
         ranked, mode_coverage = engine.recommend(answers)
 
         recommendations = [asdict(item) for item in ranked]
-        store.save_recommendations(session_id, recommendations)
+        persist("recommendations", lambda: store.save_recommendations(session_id, recommendations))
 
         primary_mode = recommendations[0]["mode_id"]
         action_plan = engine.build_action_plan(primary_mode)
-        store.save_actions(session_id, primary_mode, action_plan)
+        persist("actions", lambda: store.save_actions(session_id, primary_mode, action_plan))
 
-        store.save_event(session_id, "mode_coverage", mode_coverage)
-        store.save_event(
-            session_id,
+        persist("mode_coverage", lambda: store.save_event(session_id, "mode_coverage", mode_coverage))
+        persist(
             "final_result",
-            {
-                "primary_mode": primary_mode,
-                "backup_mode": recommendations[1]["mode_id"] if len(recommendations) > 1 else None,
-                "answers": answers,
-            },
+            lambda: store.save_event(
+                session_id,
+                "final_result",
+                {
+                    "primary_mode": primary_mode,
+                    "backup_mode": recommendations[1]["mode_id"] if len(recommendations) > 1 else None,
+                    "answers": answers,
+                },
+            ),
         )
 
         report = format_report(
@@ -347,10 +369,11 @@ def run_recommend(args: argparse.Namespace) -> int:
             }
             print(json.dumps(result_payload, indent=2))
     except Exception as exc:  # noqa: BLE001
-        print(f"Router persistence failed via seren-mcp: {exc}", file=sys.stderr)
+        print(f"Router execution failed: {exc}", file=sys.stderr)
         return 1
     finally:
-        store.close()
+        if store is not None:
+            store.close()
 
     return 0
 

--- a/kraken/money-mode-router/scripts/serendb_store.py
+++ b/kraken/money-mode-router/scripts/serendb_store.py
@@ -1,10 +1,11 @@
-"""SerenDB persistence for Kraken Money Mode Router via local seren-mcp."""
+"""SerenDB persistence for Kraken Money Mode Router via local MCP CLI."""
 
 from __future__ import annotations
 
 import json
 import os
 import select
+import shlex
 import subprocess
 import time
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 class SerenMCPError(RuntimeError):
-    """Raised when a local seren-mcp tool call fails."""
+    """Raised when a local MCP tool call fails."""
 
 
 @dataclass
@@ -27,9 +28,17 @@ class _SerenMCPClient:
     def __init__(self, api_key: Optional[str] = None, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
         self.api_key = api_key
         self.mcp_command = mcp_command
+        self._mcp_command_parts = self._parse_mcp_command(mcp_command)
         self.timeout_seconds = timeout_seconds
         self._process: Optional[subprocess.Popen[str]] = None
         self._next_id = 1
+
+    @staticmethod
+    def _parse_mcp_command(command: str) -> List[str]:
+        parts = shlex.split(command)
+        if not parts:
+            raise SerenMCPError("MCP command is empty")
+        return parts
 
     def start(self) -> None:
         if self._process is not None:
@@ -40,7 +49,7 @@ class _SerenMCPClient:
             env["API_KEY"] = self.api_key
 
         self._process = subprocess.Popen(
-            [self.mcp_command, "start"],
+            [*self._mcp_command_parts, "start"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -50,7 +59,7 @@ class _SerenMCPClient:
         )
 
         if self._process.stdin is None or self._process.stdout is None:
-            raise SerenMCPError("Failed to open stdio pipes for seren-mcp")
+            raise SerenMCPError("Failed to open stdio pipes for MCP CLI")
 
         init_response = self._request(
             "initialize",
@@ -61,7 +70,7 @@ class _SerenMCPClient:
             },
         )
         if "error" in init_response:
-            raise SerenMCPError(init_response["error"].get("message", "seren-mcp initialize failed"))
+            raise SerenMCPError(init_response["error"].get("message", "MCP initialize failed"))
 
         self._notify("notifications/initialized", {})
 
@@ -110,24 +119,24 @@ class _SerenMCPClient:
 
     def _send(self, message: Dict[str, Any]) -> None:
         if self._process is None or self._process.stdin is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
         self._process.stdin.write(json.dumps(message) + "\n")
         self._process.stdin.flush()
 
     def _read_message(self, timeout: float) -> Optional[Dict[str, Any]]:
         if self._process is None or self._process.stdout is None:
-            raise SerenMCPError("seren-mcp process is not started")
+            raise SerenMCPError("MCP process is not started")
 
         ready, _, _ = select.select([self._process.stdout], [], [], timeout)
         if not ready:
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp exited unexpectedly")
+                raise SerenMCPError("MCP process exited unexpectedly")
             return None
 
         line = self._process.stdout.readline()
         if line == "":
             if self._process.poll() is not None:
-                raise SerenMCPError("seren-mcp closed stdout unexpectedly")
+                raise SerenMCPError("MCP process closed stdout unexpectedly")
             return None
 
         payload = line.strip()
@@ -364,7 +373,7 @@ class SerenDBStore:
 
         if not self.auto_create:
             raise SerenMCPError(
-                "Target SerenDB database not found via seren-mcp. "
+                "Target SerenDB database not found via MCP. "
                 "Set SERENDB_DATABASE/SERENDB_PROJECT_NAME or enable SERENDB_AUTO_CREATE=true."
             )
 

--- a/wellsfargo/cash-flow-statement/SKILL.md
+++ b/wellsfargo/cash-flow-statement/SKILL.md
@@ -16,6 +16,7 @@ description: "Generate operating, investing, and financing cash flow statements 
 
 - The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
 - SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+- If `WF_SERENDB_URL` is not set, the `seren` CLI must be installed and authenticated (`seren auth`) so DB URL auto-resolution can run.
 
 ## Safety Profile
 

--- a/wellsfargo/income-statement/SKILL.md
+++ b/wellsfargo/income-statement/SKILL.md
@@ -16,6 +16,7 @@ description: "Generate categorized income statements from Wells Fargo transactio
 
 - The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
 - SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
+- If `WF_SERENDB_URL` is not set, the `seren` CLI must be installed and authenticated (`seren auth`) so DB URL auto-resolution can run.
 
 ## Safety Profile
 

--- a/wellsfargo/net-worth-tracker/SKILL.md
+++ b/wellsfargo/net-worth-tracker/SKILL.md
@@ -11,6 +11,10 @@ description: "Track account balances from Wells Fargo statement data with option
 - generate balance sheet from wells fargo data
 - show net worth trajectory
 
+## Prerequisites
+
+- If `WF_SERENDB_URL` is not set, the `seren` CLI must be installed and authenticated (`seren auth`) so DB URL auto-resolution can run.
+
 ## Workflow Summary
 
 1. `resolve_serendb` uses `connector.serendb.connect`

--- a/wellsfargo/recurring-transactions/SKILL.md
+++ b/wellsfargo/recurring-transactions/SKILL.md
@@ -17,6 +17,7 @@ description: "Detect and track recurring subscriptions, bills, and regular payme
 - The `bank-statement-processing` skill must have completed at least one successful run with SerenDB sync enabled.
 - SerenDB must contain populated `wf_transactions` and `wf_txn_categories` tables.
 - At least 3 months of transaction data recommended for accurate detection.
+- If `WF_SERENDB_URL` is not set, the `seren` CLI must be installed and authenticated (`seren auth`) so DB URL auto-resolution can run.
 
 ## Safety Profile
 


### PR DESCRIPTION
## Summary
- fix Kraken money-mode-router recommendation flow to continue when MCP persistence is unavailable instead of hard-failing
- remove unsupported Kraken client constructor args in money-mode-router
- make Python type hints compatible with Python 3.9 in grid trader and money-mode-router agents
- allow `SEREN_MCP_COMMAND` values with arguments by parsing command parts in MCP store wrappers
- document missing local CLI requirements (`seren-mcp` and `seren`) in README and affected Wells Fargo/Kraken skill docs

## Validation
- python3 -m py_compile coinbase/grid-trader/scripts/agent.py coinbase/grid-trader/scripts/serendb_store.py kraken/grid-trader/scripts/agent.py kraken/grid-trader/scripts/serendb_store.py kraken/money-mode-router/scripts/agent.py kraken/money-mode-router/scripts/serendb_store.py

Fixes #43
