### PR TITLE
fix(auth): align Kraken skills to bootstrap-first auth policy

### DIFF
--- a/kraken/grid-trader/.env.example
+++ b/kraken/grid-trader/.env.example
@@ -1,6 +1,6 @@
-# Seren Gateway API Key
-# Get your API key at: https://serendb.com
-SEREN_API_KEY=sb_your_key_here
+# Seren auth is resolved from Desktop session context by default.
+# If session auth is unavailable, run auth_bootstrap before using this skill.
+# Manual SEREN_API_KEY setup is unsupported.
 
 # Desktop sidecar/keychain mode is the default for Kraken publisher auth.
 # Configure Kraken publisher API key in Seren Desktop Settings > Publisher MCPs.

--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -42,16 +42,16 @@ pip install -r requirements.txt
 ```bash
 # Copy example env file
 cp .env.example .env
-
-# Add your Seren API key
-echo "SEREN_API_KEY=sb_your_key_here" > .env
 ```
 
-Desktop sidecar/keychain flow (recommended):
+Auth prerequisites:
+- Preferred: Seren Desktop session auth + Kraken publisher credentials in Settings -> Publisher MCPs
+- Fallback: run `auth_bootstrap`, then retry
+- Manual `SEREN_API_KEY` setup is unsupported
+
+Desktop sidecar/keychain flow:
 - Configure Kraken publisher credentials in Seren Desktop Settings → Publisher MCPs
 - Keep default publisher slug order (`kraken-trading`, fallback `kraken-spot-trading`)
-
-Get your Seren API key at: https://serendb.com
 
 Optional MCP-native SerenDB settings in `.env`:
 
@@ -231,13 +231,12 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 
 ## Troubleshooting
 
-### "SEREN_API_KEY is required"
+### "Seren auth context missing"
 
-Create a `.env` file with your API key:
-
-```bash
-echo "SEREN_API_KEY=sb_your_key_here" > .env
-```
+Use the supported auth path:
+1. Confirm Seren Desktop session auth is active.
+2. If session auth is unavailable, run `auth_bootstrap`.
+3. Retry `python scripts/agent.py ...`.
 
 ### "Kraken publisher authentication failed"
 

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -20,11 +20,13 @@ Grid trading places buy and sell orders at regular price intervals (the "grid").
 
 ## Setup
 
-1. Configure Kraken publisher credentials in Seren Desktop Settings → Publisher MCPs (desktop sidecar/keychain flow)
-2. Copy `.env.example` to `.env` and set `SEREN_API_KEY`
-3. Copy `config.example.json` to `config.json` and configure your grid parameters
-4. Install dependencies: `pip install -r requirements.txt`
-5. Run: `python scripts/agent.py`
+1. Ensure Seren Desktop session auth is active and Kraken publisher credentials are configured in Settings -> Publisher MCPs.
+2. If session auth is unavailable, run `auth_bootstrap` and retry.
+3. Manual `SEREN_API_KEY` setup is unsupported.
+4. Copy `.env.example` to `.env` (optional for local overrides).
+5. Copy `config.example.json` to `config.json` and configure your grid parameters.
+6. Install dependencies: `pip install -r requirements.txt`.
+7. Run: `python scripts/agent.py`.
 
 ## SerenDB Persistence (MCP-native)
 

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -28,6 +28,11 @@ from logger import GridTraderLogger
 from serendb_store import SerenDBStore
 import pair_selector
 
+AUTH_BOOTSTRAP_REQUIRED_MESSAGE = (
+    "E_AUTH_BOOTSTRAP_REQUIRED: Seren auth context missing. "
+    "Use Desktop/MCP session auth, or run auth_bootstrap and retry."
+)
+
 
 def _get_seren_api_key() -> str | None:
     return os.getenv("SEREN_API_KEY") or os.getenv("API_KEY")
@@ -43,7 +48,7 @@ def _env_flag(name: str, default: bool = True) -> bool:
 def _build_store_from_env() -> SerenDBStore:
     api_key = _get_seren_api_key()
     if not api_key:
-        raise ValueError("SEREN_API_KEY is required (or API_KEY when launched by Seren Desktop).")
+        raise ValueError(AUTH_BOOTSTRAP_REQUIRED_MESSAGE)
 
     return SerenDBStore(
         api_key=api_key,
@@ -75,9 +80,9 @@ class KrakenGridTrader:
         self.is_dry_run = dry_run
 
         # Initialize clients
-        api_key = os.getenv('SEREN_API_KEY')
+        api_key = _get_seren_api_key()
         if not api_key:
-            raise ValueError("SEREN_API_KEY environment variable is required")
+            raise ValueError(AUTH_BOOTSTRAP_REQUIRED_MESSAGE)
 
         self.seren = SerenClient(api_key=api_key)
         self.logger = GridTraderLogger(logs_dir='logs')

--- a/kraken/money-mode-router/.env.example
+++ b/kraken/money-mode-router/.env.example
@@ -1,5 +1,6 @@
-# Seren API key for Kraken publisher calls
-SEREN_API_KEY=sb_your_key_here
+# Seren auth is resolved from Desktop session context by default.
+# If session auth is unavailable, run auth_bootstrap before using this skill.
+# Manual SEREN_API_KEY setup is unsupported.
 
 # MCP-native SerenDB target (optional, resolved via local seren-mcp)
 # If SERENDB_DATABASE is unset:

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -32,13 +32,14 @@ Use this skill when a user asks things like:
 
 1. Copy `.env.example` to `.env`.
 2. Ensure `seren-mcp` is available locally and authenticated (Seren Desktop login context).
-3. Set `SEREN_API_KEY` (required for Kraken account context and MCP auth when running standalone).
-4. Optionally set MCP DB target env vars (`SERENDB_PROJECT_NAME`, `SERENDB_DATABASE`, optional branch/region).
+3. Use auth precedence: Desktop/MCP session first, `auth_bootstrap` fallback.
+4. Manual `SEREN_API_KEY` setup is unsupported.
+5. Optionally set MCP DB target env vars (`SERENDB_PROJECT_NAME`, `SERENDB_DATABASE`, optional branch/region).
    - If `SERENDB_DATABASE` is not set, the router first tries to reuse an existing Kraken-related database.
    - If none exists, it auto-creates `krakent` project + `krakent` database (when `SERENDB_AUTO_CREATE=true`).
-5. Copy `config.example.json` to `config.json`.
-6. Install dependencies: `pip install -r requirements.txt`.
-7. Optional publisher overrides:
+6. Copy `config.example.json` to `config.json`.
+7. Install dependencies: `pip install -r requirements.txt`.
+8. Optional publisher overrides:
    - `KRAKEN_TRADING_PUBLISHER` (default `kraken-trading`)
    - `KRAKEN_TRADING_FALLBACK_PUBLISHER` (default `kraken-spot-trading`)
    - Legacy alias: `KRAKEN_SPOT_PUBLISHER` (treated as fallback)

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -80,6 +80,11 @@ QUESTION_SET: List[Dict[str, Any]] = [
     },
 ]
 
+AUTH_BOOTSTRAP_REQUIRED_MESSAGE = (
+    "E_AUTH_BOOTSTRAP_REQUIRED: Seren auth context missing. "
+    "Use Desktop/MCP session auth, or run auth_bootstrap and retry."
+)
+
 
 def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as handle:
@@ -305,7 +310,11 @@ def run_recommend(args: argparse.Namespace) -> int:
             account_snapshot = kraken.get_account_snapshot()
             store.save_event(session_id, "account_snapshot", account_snapshot)
         else:
-            store.save_event(session_id, "account_snapshot", {"skipped": "SEREN_API_KEY not set"})
+            store.save_event(
+                session_id,
+                "account_snapshot",
+                {"skipped": AUTH_BOOTSTRAP_REQUIRED_MESSAGE},
+            )
 
         engine = ModeEngine(config)
         ranked, mode_coverage = engine.recommend(answers)


### PR DESCRIPTION
## Summary
- update Kraken skill docs/templates to the auth-upgrade contract:
  - Desktop/MCP session auth preferred
  - `auth_bootstrap` fallback
  - manual `SEREN_API_KEY` setup explicitly unsupported
- remove manual Seren key setup snippets from Kraken docs
- align user-facing runtime auth errors/events to bootstrap guidance (`E_AUTH_BOOTSTRAP_REQUIRED`)

## Scope
- `kraken/grid-trader`
- `kraken/money-mode-router`

## Validation
- `python3 -m py_compile kraken/grid-trader/scripts/agent.py kraken/money-mode-router/scripts/agent.py`
- `uv run --directory /Users/taariqlewis/Projects/Seren_Projects/seren-skillforge-auth-gate python -m skillforge auth-check --path /Users/taariqlewis/Projects/Seren_Projects/seren-skills-kraken-auth/kraken`
