### PR TITLE
fix(auth): align Polymarket skill to bootstrap-first auth policy

### DIFF
--- a/polymarket/bot/.env.example
+++ b/polymarket/bot/.env.example
@@ -1,6 +1,6 @@
-# Seren API Configuration
-# Get your API key from: https://app.serendb.com/settings/api-keys
-SEREN_API_KEY=your_seren_api_key_here
+# Seren auth is resolved from Desktop session context by default.
+# If session auth is unavailable, run auth_bootstrap before using this skill.
+# Manual SEREN_API_KEY setup is unsupported.
 
 # Desktop sidecar/keychain mode (recommended)
 # In Seren Desktop, configure Polymarket publisher credentials in Settings > Publisher MCPs.

--- a/polymarket/bot/QUICKSTART.md
+++ b/polymarket/bot/QUICKSTART.md
@@ -6,9 +6,9 @@ Get the Polymarket Trading Bot running in 5 minutes.
 
 - Python 3.9+
 - $550+ total budget (see [SKILL.md Phase 4](SKILL.md#phase-4-fund-your-wallets) for why)
-- Seren gateway auth via:
-  - `SEREN_API_KEY` (standalone), or
-  - runtime `API_KEY` when launched by Seren Desktop
+- Seren auth via Desktop/MCP session context (preferred)
+- Fallback auth path: run `auth_bootstrap` before running the bot
+- Manual `SEREN_API_KEY` setup is unsupported
 
 ## One-Command Setup (Recommended)
 
@@ -42,7 +42,6 @@ cp .env.example .env
 Edit `.env` and add:
 
 ```bash
-SEREN_API_KEY=your_actual_key_here
 SEREN_DESKTOP_PUBLISHER_AUTH=true
 ```
 
@@ -68,7 +67,7 @@ Review the settings - defaults are safe for testing.
 # Syntax validation (no credentials needed)
 python3 scripts/test_syntax.py
 
-# Dry-run test (needs SEREN_API_KEY or runtime API_KEY)
+# Dry-run test (requires active auth context)
 python3 scripts/test_dry_run.py
 ```
 
@@ -122,15 +121,12 @@ tail -f logs/trading_*.log
 pip3 install -r requirements.txt
 ```
 
-### "SEREN_API_KEY/API_KEY not found"
+### "Seren auth context missing"
 
-Check your `.env` file:
-
-```bash
-cat .env | grep SEREN_API_KEY
-```
-
-For desktop-launched runs, `API_KEY` may be injected automatically.
+Use the supported auth path:
+1. Confirm Seren Desktop session auth is active.
+2. If session auth is unavailable, run `auth_bootstrap`.
+3. Retry the command.
 
 ### "Polymarket desktop publisher authentication failed"
 

--- a/polymarket/bot/README.md
+++ b/polymarket/bot/README.md
@@ -28,8 +28,12 @@ Copy the example environment file and fill in your credentials:
 cp .env.example .env
 ```
 
-Edit `.env` and add:
-- **SEREN_API_KEY** (or runtime `API_KEY` when launched by Seren Desktop): Get from [app.serendb.com/settings/api-keys](https://app.serendb.com/settings/api-keys)
+Auth prerequisites:
+- Preferred: Seren Desktop session auth + Polymarket publisher credentials configured in Settings -> Publisher MCPs
+- Fallback: run `auth_bootstrap`, then retry
+- Manual `SEREN_API_KEY` setup is unsupported
+
+Edit `.env` and set:
 - **SEREN_DESKTOP_PUBLISHER_AUTH=true** (recommended): use desktop sidecar/keychain publisher auth
 
 Desktop sidecar/keychain flow (recommended):

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -224,12 +224,14 @@ cp .env.example .env
 Edit `.env` and add:
 
 ```bash
-# Seren API key (standalone mode) - get from https://app.serendb.com/settings/api-keys
-SEREN_API_KEY=your_seren_api_key_here
-
 # Desktop sidecar/keychain mode (recommended)
 SEREN_DESKTOP_PUBLISHER_AUTH=true
 ```
+
+Auth prerequisites:
+- Preferred: Seren Desktop session auth + Polymarket publisher credentials configured in Settings > Publisher MCPs
+- Fallback: run `auth_bootstrap`, then retry
+- Manual `SEREN_API_KEY` setup is unsupported
 
 **Desktop sidecar flow (recommended):**
 1. Open Seren Desktop
@@ -908,10 +910,10 @@ Per scan cycle:
 
 ## Troubleshooting
 
-### "SEREN_API_KEY/API_KEY is required"
-- Create `.env` file from `.env.example`
-- Add `SEREN_API_KEY` for standalone runs
-- For desktop-launched runs, ensure runtime `API_KEY` is injected
+### "Seren auth context missing"
+- Confirm Seren Desktop session auth is active
+- If session auth is unavailable, run `auth_bootstrap`
+- Retry the command
 
 ### "Polymarket credentials required"
 - Recommended: enable desktop keychain mode in `.env` with `SEREN_DESKTOP_PUBLISHER_AUTH=true`

--- a/polymarket/bot/scripts/seren_client.py
+++ b/polymarket/bot/scripts/seren_client.py
@@ -22,13 +22,13 @@ class SerenClient:
         Initialize Seren client
 
         Args:
-            api_key: Seren API key (defaults to SEREN_API_KEY or API_KEY env var)
+            api_key: Optional runtime key override (otherwise uses env-resolved auth context)
         """
         self.api_key = api_key or os.getenv('SEREN_API_KEY') or os.getenv('API_KEY')
         if not self.api_key:
             raise ValueError(
-                "Seren API key is required. Set SEREN_API_KEY (standalone) "
-                "or API_KEY (Seren Desktop runtime)."
+                "E_AUTH_BOOTSTRAP_REQUIRED: Seren auth context missing. "
+                "Use Desktop/MCP session auth, or run auth_bootstrap and retry."
             )
 
         self.gateway_url = os.getenv('SEREN_GATEWAY_URL', "https://api.serendb.com")

--- a/polymarket/bot/scripts/setup_cron.py
+++ b/polymarket/bot/scripts/setup_cron.py
@@ -49,8 +49,7 @@ def main():
     except Exception as e:
         print(f"Error initializing Seren client: {e}")
         print(
-            "\nMake sure SEREN_API_KEY (standalone) or API_KEY "
-            "(Seren Desktop runtime) is available."
+            "\nEnsure Desktop/MCP session auth is active, or run auth_bootstrap and retry."
         )
         sys.exit(1)
 

--- a/polymarket/bot/scripts/setup_serendb.py
+++ b/polymarket/bot/scripts/setup_serendb.py
@@ -65,15 +65,12 @@ def main():
 
     # Check for API key
     if not (os.getenv('SEREN_API_KEY') or os.getenv('API_KEY')):
-        print("❌ Error: Seren API key not found")
+        print("❌ Error: Seren auth context missing")
         print()
-        print("Set your API key (standalone mode):")
-        print("  export SEREN_API_KEY='your-api-key'")
-        print()
-        print("Or add it to .env file:")
-        print("  SEREN_API_KEY=your-api-key")
-        print()
-        print("When launched by Seren Desktop, API_KEY may be injected automatically.")
+        print("Use the supported auth path:")
+        print("  1. Ensure Seren Desktop session auth is active")
+        print("  2. If session auth is unavailable, run auth_bootstrap")
+        print("  3. Retry setup")
         print()
         sys.exit(1)
 

--- a/polymarket/bot/scripts/setup_test.sh
+++ b/polymarket/bot/scripts/setup_test.sh
@@ -38,24 +38,17 @@ if [ -f .env ]; then
     echo "   To reconfigure, delete .env and run this script again"
 else
     echo ""
-    echo "Enter your SEREN_API_KEY (optional if API_KEY is injected by Seren Desktop):"
-    echo "(Get it from https://app.serendb.com/settings/api-keys)"
-    read -r SEREN_API_KEY
-
-    if [ -z "$SEREN_API_KEY" ] && [ -z "${API_KEY:-}" ]; then
-        echo "❌ Missing gateway key. Provide SEREN_API_KEY or run with API_KEY injected."
+    if [ -z "${SEREN_API_KEY:-}" ] && [ -z "${API_KEY:-}" ]; then
+        echo "❌ Missing auth context."
+        echo "   Ensure Seren Desktop session auth is active"
+        echo "   or run auth_bootstrap, then rerun this script."
         exit 1
     fi
 
-    if [ -n "$SEREN_API_KEY" ]; then
-        SEREN_KEY_LINE="SEREN_API_KEY=$SEREN_API_KEY"
-    else
-        SEREN_KEY_LINE="# SEREN_API_KEY is not set here (using runtime API_KEY instead)"
-    fi
-
     cat > .env << EOF2
-# Seren API credentials (required via SEREN_API_KEY or runtime API_KEY)
-$SEREN_KEY_LINE
+# Seren auth is resolved from Desktop session context by default.
+# If session auth is unavailable, run auth_bootstrap before using this skill.
+# Manual SEREN_API_KEY setup is unsupported.
 
 # Desktop sidecar/keychain mode (recommended)
 # Configure Polymarket publisher credentials in Seren Desktop Settings > Publisher MCPs.

--- a/polymarket/bot/scripts/test_dry_run.py
+++ b/polymarket/bot/scripts/test_dry_run.py
@@ -47,9 +47,9 @@ for var in optional_vars:
         missing_optional.append(var)
 
 if not seren_api_key:
-    print("❌ Missing required key: SEREN_API_KEY or API_KEY")
-    print("   Set SEREN_API_KEY in .env for standalone runs")
-    print("   or launch via Seren Desktop with API_KEY injected")
+    print("❌ Missing auth context: Desktop/MCP session or runtime key")
+    print("   Ensure Desktop session auth is active")
+    print("   or run auth_bootstrap and retry")
     sys.exit(1)
 
 desktop_auth = os.getenv('SEREN_DESKTOP_PUBLISHER_AUTH', 'true').strip().lower() in (
@@ -62,7 +62,7 @@ elif missing_optional:
 else:
     print("✅ Legacy Polymarket credentials found")
 
-print("✅ Seren gateway key found (SEREN_API_KEY/API_KEY)")
+print("✅ Seren auth context found")
 print()
 
 # Test 3: Initialize Seren client

--- a/polymarket/bot/scripts/test_seren_client.py
+++ b/polymarket/bot/scripts/test_seren_client.py
@@ -117,5 +117,5 @@ class TestSerenClientApiKeyResolution:
         with patch.dict('os.environ', {}, clear=True), patch(
             'seren_client.requests.Session'
         ):
-            with pytest.raises(ValueError, match=r"SEREN_API_KEY.*API_KEY"):
+            with pytest.raises(ValueError, match=r"E_AUTH_BOOTSTRAP_REQUIRED"):
                 SerenClient()


### PR DESCRIPTION
## Summary
- update Polymarket skill docs/templates to the auth-upgrade contract:
  - Desktop/MCP session auth preferred
  - `auth_bootstrap` fallback
  - manual `SEREN_API_KEY` setup explicitly unsupported
- remove manual Seren key setup snippets from SKILL/README/QUICKSTART/.env.example
- align user-facing runtime/setup/test auth messages to bootstrap guidance (`E_AUTH_BOOTSTRAP_REQUIRED`)

## Scope
- `polymarket/bot`

## Validation
- `python3 -m py_compile polymarket/bot/scripts/seren_client.py polymarket/bot/scripts/setup_serendb.py polymarket/bot/scripts/setup_cron.py polymarket/bot/scripts/test_dry_run.py polymarket/bot/scripts/test_seren_client.py`
- `bash -n polymarket/bot/scripts/setup_test.sh`
- `python3 -m pytest polymarket/bot/scripts/test_seren_client.py`
- `uv run --directory /Users/taariqlewis/Projects/Seren_Projects/seren-skillforge-auth-gate python -m skillforge auth-check --path /Users/taariqlewis/Projects/Seren_Projects/seren-skills-polymarket-auth/polymarket`
