### PR TITLE
fix(polymarket): submit live orders in maker bots

### DIFF
--- a/polymarket/_shared/polymarket_live.py
+++ b/polymarket/_shared/polymarket_live.py
@@ -1,0 +1,1249 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import select
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import pstdev
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
+SEREN_PUBLISHERS_PREFIX = "/publishers/"
+SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
+SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
+SEREN_API_BASE = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}"
+SEREN_POLYMARKET_DATA_URL_PREFIX = (
+    f"{SEREN_API_BASE}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
+)
+SEREN_POLYMARKET_TRADING_URL_PREFIX = (
+    f"{SEREN_API_BASE}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
+)
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_CHAIN_ID = 137
+
+
+def maybe_load_dotenv(skill_root: Path) -> None:
+    env_path = skill_root / ".env"
+    if not env_path.exists():
+        return
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[7:].strip()
+            key, sep, value = line.partition("=")
+            if sep != "=":
+                continue
+            key = key.strip()
+            if not key:
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            os.environ.setdefault(key, value)
+        return
+    load_dotenv(env_path, override=False)
+
+
+def safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def safe_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def parse_iso_ts(value: Any) -> int | None:
+    raw = safe_str(value, "")
+    if not raw:
+        return None
+    try:
+        return int(datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp())
+    except ValueError:
+        return None
+
+
+def json_to_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return parsed
+    return []
+
+
+def normalize_history(
+    raw_history: Any,
+    start_ts: int | None = None,
+    end_ts: int | None = None,
+) -> list[tuple[int, float]]:
+    rows: list[tuple[int, float]] = []
+    seen: set[int] = set()
+    if not isinstance(raw_history, list):
+        return rows
+
+    for item in raw_history:
+        t = -1
+        p = -1.0
+        if isinstance(item, dict):
+            t = safe_int(item.get("t"), -1)
+            p = safe_float(item.get("p"), -1.0)
+        elif isinstance(item, list | tuple) and len(item) >= 2:
+            t = safe_int(item[0], -1)
+            p = safe_float(item[1], -1.0)
+        if t < 0 or not (0.0 <= p <= 1.0) or t in seen:
+            continue
+        if start_ts is not None and t < start_ts:
+            continue
+        if end_ts is not None and t > end_ts:
+            continue
+        seen.add(t)
+        rows.append((t, p))
+
+    rows.sort(key=lambda row: row[0])
+    return rows
+
+
+def history_volatility_bps(history: list[tuple[int, float]], window_points: int) -> float:
+    window = max(2, window_points)
+    if len(history) < window + 1:
+        return 0.0
+    moves = [
+        abs((history[idx][1] - history[idx - 1][1]) * 10000.0)
+        for idx in range(1, len(history))
+    ]
+    recent = moves[-window:]
+    if len(recent) <= 1:
+        return recent[0] if recent else 0.0
+    return float(pstdev(recent))
+
+
+def last_move_bps(history: list[tuple[int, float]]) -> float:
+    if len(history) < 2:
+        return 0.0
+    return abs((history[-1][1] - history[-2][1]) * 10000.0)
+
+
+def best_price(levels: Any, fallback: float = 0.0) -> float:
+    if not isinstance(levels, list) or not levels:
+        return fallback
+    level = levels[0]
+    if isinstance(level, dict):
+        return safe_float(level.get("price"), fallback)
+    if isinstance(level, list | tuple) and level:
+        return safe_float(level[0], fallback)
+    return fallback
+
+
+def snap_price(price: float, tick_size: str, side: str) -> float:
+    tick = safe_float(tick_size, 0.01)
+    if tick <= 0:
+        tick = 0.01
+    normalized = clamp(price, tick, 1.0 - tick)
+    if side.upper() == "BUY":
+        snapped = math.floor(normalized / tick) * tick
+    else:
+        snapped = math.ceil(normalized / tick) * tick
+    decimals = max(0, len(tick_size.split(".")[1]) if "." in tick_size else 0)
+    return round(clamp(snapped, tick, 1.0 - tick), decimals)
+
+
+def parse_midpoint_payload(payload: Any, fallback_mid: float = 0.0) -> float:
+    if isinstance(payload, dict):
+        for key in ("mid", "midpoint", "price"):
+            value = safe_float(payload.get(key), -1.0)
+            if 0.0 <= value <= 1.0:
+                return value
+    return fallback_mid
+
+
+def parse_book_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "best_bid": 0.0,
+            "best_ask": 0.0,
+            "tick_size": "0.01",
+            "neg_risk": False,
+            "raw": payload,
+        }
+    best_bid = best_price(payload.get("bids"), 0.0)
+    best_ask = best_price(payload.get("asks"), 0.0)
+    tick_size = safe_str(
+        payload.get("tick_size", payload.get("minimum_tick_size", "0.01")),
+        "0.01",
+    )
+    return {
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "tick_size": tick_size,
+        "neg_risk": bool(payload.get("neg_risk", False)),
+        "raw": payload,
+    }
+
+
+def extract_token_id(raw_market: dict[str, Any]) -> str:
+    token_ids = json_to_list(raw_market.get("clobTokenIds"))
+    if token_ids:
+        token_id = safe_str(token_ids[0], "")
+        if token_id:
+            return token_id
+    return safe_str(raw_market.get("token_id"), safe_str(raw_market.get("market_id"), ""))
+
+
+def extract_event_id(raw_market: dict[str, Any]) -> str:
+    events = json_to_list(raw_market.get("events"))
+    if events and isinstance(events[0], dict):
+        event_id = safe_str(events[0].get("id"), "")
+        if event_id:
+            return event_id
+    for key in ("event_id", "seriesSlug", "category"):
+        value = safe_str(raw_market.get(key), "")
+        if value:
+            return value
+    return "misc"
+
+
+def infer_position_size(position: dict[str, Any]) -> float:
+    for key in (
+        "size",
+        "amount",
+        "quantity",
+        "position",
+        "balance",
+        "shares",
+        "outcomeTokens",
+        "token_balance",
+    ):
+        value = safe_float(position.get(key), float("nan"))
+        if not math.isnan(value):
+            return value
+    for key in ("amount", "balance", "position", "shares"):
+        nested = position.get("available", {})
+        if isinstance(nested, dict):
+            value = safe_float(nested.get(key), float("nan"))
+            if not math.isnan(value):
+                return value
+    return 0.0
+
+
+def _rows_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return [row for row in data if isinstance(row, dict)]
+    return []
+
+
+def positions_by_key(raw_positions: Any) -> dict[str, float]:
+    rows = _rows_from_payload(raw_positions)
+    out: dict[str, float] = {}
+    for row in rows:
+        size = infer_position_size(row)
+        for key in (
+            safe_str(row.get("asset_id"), ""),
+            safe_str(row.get("token_id"), ""),
+            safe_str(row.get("market"), ""),
+            safe_str(row.get("market_id"), ""),
+        ):
+            if key:
+                out[key] = size
+    return out
+
+
+def _read_mcp_exact(fd: int, size: int, timeout_seconds: float) -> bytes:
+    buf = bytearray()
+    while len(buf) < size:
+        ready, _, _ = select.select([fd], [], [], timeout_seconds)
+        if not ready:
+            raise TimeoutError("Timed out waiting for response from seren-mcp.")
+        chunk = os.read(fd, size - len(buf))
+        if not chunk:
+            raise RuntimeError("seren-mcp closed stdout before completing a response.")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _read_mcp_message(proc: subprocess.Popen[bytes], timeout_seconds: float) -> dict[str, Any]:
+    if proc.stdout is None:
+        raise RuntimeError("seren-mcp stdout is not available.")
+    fd = proc.stdout.fileno()
+    header_buf = bytearray()
+    while b"\r\n\r\n" not in header_buf:
+        header_buf.extend(_read_mcp_exact(fd, 1, timeout_seconds))
+        if len(header_buf) > 16384:
+            raise RuntimeError("Invalid MCP header: too large.")
+    header_raw, _ = header_buf.split(b"\r\n\r\n", 1)
+    headers: dict[str, str] = {}
+    for line in header_raw.decode("ascii", errors="ignore").split("\r\n"):
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    content_length = safe_int(headers.get("content-length"), -1)
+    if content_length < 0:
+        raise RuntimeError("Invalid MCP header: missing content-length.")
+    body = _read_mcp_exact(fd, content_length, timeout_seconds)
+    parsed = json.loads(body.decode("utf-8"))
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Invalid MCP response payload.")
+    return parsed
+
+
+def _write_mcp_message(proc: subprocess.Popen[bytes], payload: dict[str, Any]) -> None:
+    if proc.stdin is None:
+        raise RuntimeError("seren-mcp stdin is not available.")
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    proc.stdin.write(header)
+    proc.stdin.write(body)
+    proc.stdin.flush()
+
+
+def _mcp_request(
+    proc: subprocess.Popen[bytes],
+    request_id: int,
+    method: str,
+    params: dict[str, Any] | None,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    request: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        request["params"] = params
+    _write_mcp_message(proc, request)
+    while True:
+        message = _read_mcp_message(proc, timeout_seconds)
+        if message.get("id") != request_id:
+            continue
+        error = message.get("error")
+        if isinstance(error, dict):
+            raise RuntimeError(safe_str(error.get("message"), "MCP request failed."))
+        result = message.get("result")
+        if isinstance(result, dict):
+            return result
+        return {"value": result}
+
+
+def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        body = structured.get("body")
+        if isinstance(body, dict | list):
+            return body
+        return structured
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if safe_str(item.get("type"), "") != "text":
+                continue
+            text = safe_str(item.get("text"), "")
+            if not text:
+                continue
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                body = parsed.get("body")
+                if isinstance(body, dict | list):
+                    return body
+                return parsed
+            if isinstance(parsed, list):
+                return parsed
+    body = result.get("body")
+    if isinstance(body, dict | list):
+        return body
+    return result.get("value")
+
+
+def call_publisher_json(
+    publisher: str,
+    method: str,
+    path: str,
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    prefer_mcp = not api_key
+
+    if prefer_mcp:
+        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+        command = shlex.split(command_raw)
+        if not command:
+            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            _mcp_request(
+                proc=proc,
+                request_id=1,
+                method="initialize",
+                params={
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+                },
+                timeout_seconds=timeout_seconds,
+            )
+            _write_mcp_message(
+                proc,
+                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            )
+            result = _mcp_request(
+                proc=proc,
+                request_id=2,
+                method="tools/call",
+                params={
+                    "name": "call_publisher",
+                    "arguments": {
+                        "publisher": publisher,
+                        "method": method.upper(),
+                        "path": path,
+                        "headers": headers or {},
+                        "body": json.dumps(body) if body is not None else None,
+                        "response_format": "json",
+                    },
+                },
+                timeout_seconds=timeout_seconds,
+            )
+            return _extract_call_publisher_body(result)
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=1)
+
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    request = Request(
+        f"{SEREN_API_BASE}{SEREN_PUBLISHERS_PREFIX}{publisher}{path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
+def fetch_trading_json(path: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    return call_publisher_json(
+        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+        method="GET",
+        path=path,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def fetch_markets_page(
+    *,
+    limit: int,
+    offset: int = 0,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    query = urlencode(
+        {
+            "active": "true",
+            "closed": "false",
+            "limit": limit,
+            "offset": offset,
+            "order": "volume24hr",
+            "ascending": "false",
+        }
+    )
+    payload = call_publisher_json(
+        publisher=SEREN_POLYMARKET_DATA_PUBLISHER,
+        method="GET",
+        path=f"/markets?{query}",
+        timeout_seconds=timeout_seconds,
+    )
+    return payload if isinstance(payload, list) else []
+
+
+def fetch_history(
+    *,
+    token_id: str,
+    interval: str = "max",
+    fidelity_minutes: int = 60,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[tuple[int, float]]:
+    query = urlencode(
+        {
+            "market": token_id,
+            "interval": interval,
+            "fidelity": max(1, fidelity_minutes),
+        }
+    )
+    payload = call_publisher_json(
+        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+        method="GET",
+        path=f"/prices-history?{query}",
+        timeout_seconds=timeout_seconds,
+    )
+    if not isinstance(payload, dict):
+        return []
+    return normalize_history(json_to_list(payload.get("history")))
+
+
+def fetch_book(token_id: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    payload = call_publisher_json(
+        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+        method="GET",
+        path=f"/book?{urlencode({'token_id': token_id})}",
+        timeout_seconds=timeout_seconds,
+    )
+    return parse_book_payload(payload)
+
+
+def fetch_midpoint(token_id: str, fallback_mid: float, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> float:
+    payload = call_publisher_json(
+        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+        method="GET",
+        path=f"/midpoint?{urlencode({'token_id': token_id})}",
+        timeout_seconds=timeout_seconds,
+    )
+    return parse_midpoint_payload(payload, fallback_mid=fallback_mid)
+
+
+def fetch_fee_rate_bps(token_id: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> int:
+    try:
+        payload = call_publisher_json(
+            publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+            method="GET",
+            path=f"/fee-rate?{urlencode({'token_id': token_id})}",
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception:
+        return 0
+    if isinstance(payload, dict):
+        for key in ("fee_rate_bps", "feeRateBps", "rate_bps"):
+            value = safe_int(payload.get(key), -1)
+            if value >= 0:
+                return value
+    return 0
+
+
+def load_live_single_markets(
+    *,
+    markets_max: int,
+    min_seconds_to_resolution: int,
+    volatility_window_points: int,
+    min_history_points: int,
+    min_liquidity_usd: float,
+    markets_fetch_limit: int,
+    history_interval: str = "max",
+    history_fidelity_minutes: int = 60,
+    default_rebate_bps: float = 0.0,
+    shock_bps_threshold: float | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    now_ts = int(time.time())
+    selected: list[dict[str, Any]] = []
+    offset = 0
+    seen_tokens: set[str] = set()
+
+    while len(selected) < markets_max and offset < max(50, markets_fetch_limit):
+        page = fetch_markets_page(
+            limit=min(100, max(markets_fetch_limit, markets_max * 5)),
+            offset=offset,
+            timeout_seconds=timeout_seconds,
+        )
+        if not page:
+            break
+        for raw_market in page:
+            if not isinstance(raw_market, dict):
+                continue
+            token_id = extract_token_id(raw_market)
+            if not token_id or token_id in seen_tokens:
+                continue
+            seen_tokens.add(token_id)
+
+            liquidity = safe_float(raw_market.get("liquidity"), 0.0)
+            if liquidity < min_liquidity_usd:
+                continue
+
+            end_ts = parse_iso_ts(raw_market.get("endDate")) or safe_int(raw_market.get("end_ts"), 0)
+            ttl = max(0, end_ts - now_ts)
+            if ttl < min_seconds_to_resolution:
+                continue
+
+            history = fetch_history(
+                token_id=token_id,
+                interval=history_interval,
+                fidelity_minutes=history_fidelity_minutes,
+                timeout_seconds=timeout_seconds,
+            )
+            if len(history) < min_history_points:
+                continue
+
+            fallback_mid = history[-1][1]
+            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
+            best_bid = safe_float(book.get("best_bid"), 0.0)
+            best_ask = safe_float(book.get("best_ask"), 0.0)
+            if not (0.0 <= best_bid <= 1.0 and 0.0 <= best_ask <= 1.0 and best_bid <= best_ask):
+                continue
+
+            volatility_bps = history_volatility_bps(history, volatility_window_points)
+            shock_score = 0.0
+            if shock_bps_threshold is not None and shock_bps_threshold > 0:
+                shock_score = clamp(last_move_bps(history) / shock_bps_threshold, 0.0, 1.0)
+
+            market_id = safe_str(raw_market.get("id"), token_id)
+            selected.append(
+                {
+                    "market_id": market_id,
+                    "question": safe_str(raw_market.get("question"), market_id),
+                    "token_id": token_id,
+                    "mid_price": round(midpoint, 4),
+                    "best_bid": round(best_bid, 4),
+                    "best_ask": round(best_ask, 4),
+                    "seconds_to_resolution": ttl,
+                    "volatility_bps": round(volatility_bps, 3),
+                    "rebate_bps": round(
+                        safe_float(raw_market.get("rebate_bps"), default_rebate_bps),
+                        3,
+                    ),
+                    "tick_size": safe_str(book.get("tick_size"), "0.01"),
+                    "neg_risk": bool(book.get("neg_risk", False)),
+                    "news_shock_score": round(shock_score, 4),
+                    "breaking_news": False,
+                    "liquidity": round(liquidity, 4),
+                }
+            )
+            if len(selected) >= markets_max:
+                break
+
+        if len(page) < min(100, max(markets_fetch_limit, markets_max * 5)):
+            break
+        offset += len(page)
+
+    return selected
+
+
+def load_live_pair_markets(
+    *,
+    pairs_max: int,
+    min_seconds_to_resolution: int,
+    min_history_points: int,
+    min_liquidity_usd: float,
+    markets_fetch_page_size: int,
+    max_markets: int,
+    history_interval: str = "max",
+    history_fidelity_minutes: int = 60,
+    default_rebate_bps: float = 0.0,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    now_ts = int(time.time())
+    candidates: list[dict[str, Any]] = []
+    offset = 0
+    seen_tokens: set[str] = set()
+
+    while len(candidates) < max_markets:
+        page = fetch_markets_page(
+            limit=min(200, max(25, markets_fetch_page_size)),
+            offset=offset,
+            timeout_seconds=timeout_seconds,
+        )
+        if not page:
+            break
+        for raw_market in page:
+            if not isinstance(raw_market, dict):
+                continue
+            token_id = extract_token_id(raw_market)
+            if not token_id or token_id in seen_tokens:
+                continue
+            seen_tokens.add(token_id)
+            liquidity = safe_float(raw_market.get("liquidity"), 0.0)
+            if liquidity < min_liquidity_usd:
+                continue
+            end_ts = parse_iso_ts(raw_market.get("endDate")) or safe_int(raw_market.get("end_ts"), 0)
+            ttl = max(0, end_ts - now_ts)
+            if ttl < min_seconds_to_resolution:
+                continue
+            history = fetch_history(
+                token_id=token_id,
+                interval=history_interval,
+                fidelity_minutes=history_fidelity_minutes,
+                timeout_seconds=timeout_seconds,
+            )
+            if len(history) < min_history_points:
+                continue
+            fallback_mid = history[-1][1]
+            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
+            candidates.append(
+                {
+                    "market_id": safe_str(raw_market.get("id"), token_id),
+                    "question": safe_str(raw_market.get("question"), token_id),
+                    "event_id": extract_event_id(raw_market),
+                    "token_id": token_id,
+                    "end_ts": end_ts,
+                    "seconds_to_resolution": ttl,
+                    "mid_price": round(midpoint, 4),
+                    "best_bid": round(safe_float(book.get("best_bid"), 0.0), 4),
+                    "best_ask": round(safe_float(book.get("best_ask"), 0.0), 4),
+                    "tick_size": safe_str(book.get("tick_size"), "0.01"),
+                    "neg_risk": bool(book.get("neg_risk", False)),
+                    "rebate_bps": round(
+                        safe_float(raw_market.get("rebate_bps"), default_rebate_bps),
+                        3,
+                    ),
+                    "volume24hr": safe_float(raw_market.get("volume24hr"), 0.0),
+                    "history": history,
+                }
+            )
+            if len(candidates) >= max_markets:
+                break
+        if len(page) < min(200, max(25, markets_fetch_page_size)):
+            break
+        offset += len(page)
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for candidate in candidates:
+        grouped.setdefault(candidate["event_id"], []).append(candidate)
+
+    pairs: list[dict[str, Any]] = []
+    for group in grouped.values():
+        if len(group) < 2:
+            continue
+        ranked = sorted(group, key=lambda row: row["volume24hr"], reverse=True)
+        for idx in range(len(ranked) - 1):
+            primary = ranked[idx]
+            secondary = ranked[idx + 1]
+            index_secondary = {ts: px for ts, px in secondary["history"]}
+            basis_series = [
+                (px - index_secondary[ts]) * 10000.0
+                for ts, px in primary["history"]
+                if ts in index_secondary
+            ]
+            if len(basis_series) < min_history_points:
+                continue
+            pairs.append(
+                {
+                    "market_id": primary["market_id"],
+                    "pair_market_id": secondary["market_id"],
+                    "question": primary["question"],
+                    "pair_question": secondary["question"],
+                    "token_id": primary["token_id"],
+                    "pair_token_id": secondary["token_id"],
+                    "mid_price": primary["mid_price"],
+                    "pair_mid_price": secondary["mid_price"],
+                    "best_bid": primary["best_bid"],
+                    "best_ask": primary["best_ask"],
+                    "pair_best_bid": secondary["best_bid"],
+                    "pair_best_ask": secondary["best_ask"],
+                    "tick_size": primary["tick_size"],
+                    "pair_tick_size": secondary["tick_size"],
+                    "neg_risk": primary["neg_risk"],
+                    "pair_neg_risk": secondary["neg_risk"],
+                    "seconds_to_resolution": min(
+                        primary["seconds_to_resolution"],
+                        secondary["seconds_to_resolution"],
+                    ),
+                    "rebate_bps": round(
+                        (primary["rebate_bps"] + secondary["rebate_bps"]) / 2.0,
+                        3,
+                    ),
+                    "basis_volatility_bps": round(pstdev(basis_series[-min_history_points:]), 3),
+                }
+            )
+
+    pairs.sort(
+        key=lambda row: abs(
+            (safe_float(row.get("mid_price"), 0.0) - safe_float(row.get("pair_mid_price"), 0.0))
+            * 10000.0
+        ),
+        reverse=True,
+    )
+    return pairs[:pairs_max]
+
+
+@dataclass
+class LiveExecutionSettings:
+    poll_attempts: int = 2
+    poll_interval_seconds: float = 1.5
+    cancel_before_requote: bool = True
+
+
+class PolymarketPublisherTrader:
+    def __init__(
+        self,
+        *,
+        skill_root: Path,
+        client_name: str,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        maybe_load_dotenv(skill_root)
+        self.client_name = client_name
+        self.timeout_seconds = timeout_seconds
+        self._nonce = int(time.time() * 1000)
+
+        try:
+            from py_clob_client.clob_types import ApiCreds, OrderArgs, RequestArgs
+            from py_clob_client.headers.headers import create_level_2_headers
+            from py_clob_client.order_builder.builder import OrderBuilder
+            from py_clob_client.signer import Signer
+        except ImportError as exc:
+            raise RuntimeError(
+                "Live Polymarket execution requires `py-clob-client`. "
+                "Install it with `pip install py-clob-client` or add it to requirements.txt."
+            ) from exc
+
+        private_key = safe_str(
+            os.getenv("POLY_PRIVATE_KEY") or os.getenv("WALLET_PRIVATE_KEY"),
+            "",
+        ).strip()
+        api_key = safe_str(os.getenv("POLY_API_KEY"), "").strip()
+        api_passphrase = safe_str(os.getenv("POLY_PASSPHRASE"), "").strip()
+        api_secret = safe_str(os.getenv("POLY_SECRET"), "").strip()
+        if not private_key:
+            raise RuntimeError(
+                "Live Polymarket execution requires `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY` "
+                "in addition to POLY_API_KEY/POLY_PASSPHRASE/POLY_SECRET."
+            )
+        if not api_key or not api_passphrase or not api_secret:
+            raise RuntimeError(
+                "Missing required Polymarket L2 credentials. Set "
+                "`POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET`."
+            )
+
+        chain_id = safe_int(os.getenv("POLY_CHAIN_ID"), DEFAULT_CHAIN_ID)
+        signature_type = os.getenv("POLY_SIGNATURE_TYPE")
+        funder = safe_str(os.getenv("POLY_FUNDER"), "").strip() or None
+
+        self._api_creds = ApiCreds(
+            api_key=api_key,
+            api_secret=api_secret,
+            api_passphrase=api_passphrase,
+        )
+        self._request_args_type = RequestArgs
+        self._create_level_2_headers = create_level_2_headers
+        self._order_args_type = OrderArgs
+        self._order_builder = OrderBuilder(
+            Signer(private_key, chain_id),
+            sig_type=safe_int(signature_type, None) if signature_type else None,
+            funder=funder,
+        )
+        self.address = self._order_builder.signer.address()
+
+    def _signed_headers(self, method: str, path: str, body: Any = None) -> dict[str, str]:
+        serialized = None
+        if body is not None:
+            serialized = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
+        request_args = self._request_args_type(
+            method=method.upper(),
+            request_path=path,
+            body=body,
+            serialized_body=serialized,
+        )
+        return self._create_level_2_headers(
+            self._order_builder.signer,
+            self._api_creds,
+            request_args,
+        )
+
+    def _call(self, method: str, path: str, body: Any = None) -> Any:
+        return call_publisher_json(
+            publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
+            method=method,
+            path=path,
+            headers=self._signed_headers(method, path, body=body),
+            body=body,
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    def next_nonce(self) -> int:
+        self._nonce += 1
+        return self._nonce
+
+    def create_order(
+        self,
+        *,
+        token_id: str,
+        side: str,
+        price: float,
+        size: float,
+        tick_size: str,
+        neg_risk: bool,
+        fee_rate_bps: int,
+    ) -> dict[str, Any]:
+        from py_clob_client.clob_types import CreateOrderOptions
+
+        signed_order = self._order_builder.create_order(
+            self._order_args_type(
+                token_id=token_id,
+                price=price,
+                size=size,
+                side=side.upper(),
+                fee_rate_bps=fee_rate_bps,
+                nonce=self.next_nonce(),
+                expiration=0,
+            ),
+            CreateOrderOptions(
+                tick_size=tick_size,
+                neg_risk=neg_risk,
+            ),
+        )
+        body = {
+            "order": signed_order.dict(),
+            "owner": self._api_creds.api_key,
+            "orderType": "GTC",
+            "postOnly": True,
+        }
+        return self._call("POST", "/order", body=body)
+
+    def cancel_all(self) -> Any:
+        return self._call("DELETE", "/cancel-all")
+
+    def get_orders(self) -> Any:
+        return self._call("GET", "/orders")
+
+    def get_positions(self) -> Any:
+        return self._call("GET", "/positions")
+
+
+def single_market_inventory_notional(
+    *,
+    raw_positions: Any,
+    markets: list[dict[str, Any]],
+) -> dict[str, float]:
+    sizes = positions_by_key(raw_positions)
+    out: dict[str, float] = {}
+    for market in markets:
+        market_id = safe_str(market.get("market_id"), "")
+        token_id = safe_str(market.get("token_id"), market_id)
+        shares = sizes.get(token_id, sizes.get(market_id, 0.0))
+        out[market_id] = round(shares * safe_float(market.get("mid_price"), 0.0), 4)
+    return out
+
+
+def pair_leg_exposure_notional(
+    *,
+    raw_positions: Any,
+    markets: list[dict[str, Any]],
+) -> dict[str, float]:
+    sizes = positions_by_key(raw_positions)
+    out: dict[str, float] = {}
+    for market in markets:
+        for market_id_key, token_key, price_key in (
+            ("market_id", "token_id", "mid_price"),
+            ("pair_market_id", "pair_token_id", "pair_mid_price"),
+        ):
+            market_id = safe_str(market.get(market_id_key), "")
+            token_id = safe_str(market.get(token_key), market_id)
+            shares = sizes.get(token_id, sizes.get(market_id, 0.0))
+            out[market_id] = round(shares * safe_float(market.get(price_key), 0.0), 4)
+    return out
+
+
+def active_order_ids(raw_orders: Any) -> list[str]:
+    rows = _rows_from_payload(raw_orders)
+    out: list[str] = []
+    for row in rows:
+        for key in ("id", "orderID", "order_id"):
+            value = safe_str(row.get(key), "")
+            if value:
+                out.append(value)
+                break
+    return out
+
+
+def live_settings_from_execution(execution: dict[str, Any]) -> LiveExecutionSettings:
+    return LiveExecutionSettings(
+        poll_attempts=max(1, safe_int(execution.get("poll_attempts"), 2)),
+        poll_interval_seconds=max(0.0, safe_float(execution.get("poll_interval_seconds"), 1.5)),
+        cancel_before_requote=bool(execution.get("cancel_before_requote", True)),
+    )
+
+
+def execute_single_market_quotes(
+    *,
+    trader: PolymarketPublisherTrader,
+    quotes: list[dict[str, Any]],
+    markets: list[dict[str, Any]],
+    execution_settings: LiveExecutionSettings,
+) -> dict[str, Any]:
+    market_by_id = {
+        safe_str(market.get("market_id"), ""): market
+        for market in markets
+        if isinstance(market, dict)
+    }
+    raw_positions = trader.get_positions()
+    position_sizes = positions_by_key(raw_positions)
+    cancel_response = None
+    if execution_settings.cancel_before_requote:
+        cancel_response = trader.cancel_all()
+
+    placements: list[dict[str, Any]] = []
+    skips: list[dict[str, Any]] = []
+
+    for quote in quotes:
+        market = market_by_id.get(safe_str(quote.get("market_id"), ""))
+        if not market:
+            skips.append({"market_id": safe_str(quote.get("market_id"), ""), "reason": "missing_live_market"})
+            continue
+        token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
+        tick_size = safe_str(market.get("tick_size"), "0.01")
+        neg_risk = bool(market.get("neg_risk", False))
+        fee_rate_bps = fetch_fee_rate_bps(token_id)
+        quote_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
+        if quote_notional <= 0.0:
+            skips.append({"market_id": market["market_id"], "reason": "zero_quote_notional"})
+            continue
+
+        bid_price = snap_price(safe_float(quote.get("bid_price"), 0.0), tick_size, "BUY")
+        ask_price = snap_price(safe_float(quote.get("ask_price"), 0.0), tick_size, "SELL")
+
+        if bid_price > 0.0:
+            bid_size = quote_notional / max(bid_price, 1e-9)
+            response = trader.create_order(
+                token_id=token_id,
+                side="BUY",
+                price=bid_price,
+                size=bid_size,
+                tick_size=tick_size,
+                neg_risk=neg_risk,
+                fee_rate_bps=fee_rate_bps,
+            )
+            placements.append(
+                {
+                    "market_id": market["market_id"],
+                    "token_id": token_id,
+                    "side": "BUY",
+                    "price": bid_price,
+                    "size": round(bid_size, 6),
+                    "response": response,
+                }
+            )
+
+        available_shares = max(0.0, position_sizes.get(token_id, 0.0))
+        sell_notional = min(quote_notional, available_shares * max(ask_price, 0.0))
+        if ask_price > 0.0 and sell_notional > 0.0:
+            ask_size = sell_notional / max(ask_price, 1e-9)
+            response = trader.create_order(
+                token_id=token_id,
+                side="SELL",
+                price=ask_price,
+                size=ask_size,
+                tick_size=tick_size,
+                neg_risk=neg_risk,
+                fee_rate_bps=fee_rate_bps,
+            )
+            placements.append(
+                {
+                    "market_id": market["market_id"],
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "price": ask_price,
+                    "size": round(ask_size, 6),
+                    "response": response,
+                }
+            )
+        else:
+            skips.append(
+                {
+                    "market_id": market["market_id"],
+                    "reason": "insufficient_inventory_for_sell",
+                    "available_shares": round(available_shares, 6),
+                }
+            )
+
+    latest_orders: Any = []
+    latest_positions: Any = raw_positions
+    for _ in range(execution_settings.poll_attempts):
+        if execution_settings.poll_interval_seconds > 0:
+            time.sleep(execution_settings.poll_interval_seconds)
+        latest_orders = trader.get_orders()
+        latest_positions = trader.get_positions()
+
+    return {
+        "cancel_all": cancel_response,
+        "orders_submitted": placements,
+        "order_skips": skips,
+        "open_orders": latest_orders,
+        "open_order_ids": active_order_ids(latest_orders),
+        "positions": latest_positions,
+        "updated_inventory": single_market_inventory_notional(
+            raw_positions=latest_positions,
+            markets=markets,
+        ),
+    }
+
+
+def execute_pair_trades(
+    *,
+    trader: PolymarketPublisherTrader,
+    pair_trades: list[dict[str, Any]],
+    markets: list[dict[str, Any]],
+    execution_settings: LiveExecutionSettings,
+) -> dict[str, Any]:
+    market_by_id = {
+        safe_str(market.get("market_id"), ""): market
+        for market in markets
+        if isinstance(market, dict)
+    }
+    raw_positions = trader.get_positions()
+    position_sizes = positions_by_key(raw_positions)
+    cancel_response = None
+    if execution_settings.cancel_before_requote:
+        cancel_response = trader.cancel_all()
+
+    placements: list[dict[str, Any]] = []
+    skips: list[dict[str, Any]] = []
+
+    for trade in pair_trades:
+        market = market_by_id.get(safe_str(trade.get("market_id"), ""))
+        if not market:
+            skips.append({"market_id": safe_str(trade.get("market_id"), ""), "reason": "missing_live_pair"})
+            continue
+        pair_market_id = safe_str(market.get("pair_market_id"), "")
+        legs = trade.get("legs")
+        if not isinstance(legs, list) or len(legs) != 2:
+            skips.append({"market_id": market["market_id"], "reason": "invalid_pair_legs"})
+            continue
+
+        leg_specs: list[dict[str, Any]] = []
+        skip_reason = ""
+        for leg in legs:
+            if not isinstance(leg, dict):
+                skip_reason = "invalid_leg"
+                break
+            market_id = safe_str(leg.get("market_id"), "")
+            side = safe_str(leg.get("side"), "").upper()
+            if market_id == safe_str(market.get("market_id"), ""):
+                token_id = safe_str(market.get("token_id"), market_id)
+                price = safe_float(
+                    market.get("best_bid") if side == "BUY" else market.get("best_ask"),
+                    0.0,
+                )
+                tick_size = safe_str(market.get("tick_size"), "0.01")
+                neg_risk = bool(market.get("neg_risk", False))
+            elif market_id == pair_market_id:
+                token_id = safe_str(market.get("pair_token_id"), market_id)
+                price = safe_float(
+                    market.get("pair_best_bid") if side == "BUY" else market.get("pair_best_ask"),
+                    0.0,
+                )
+                tick_size = safe_str(market.get("pair_tick_size"), "0.01")
+                neg_risk = bool(market.get("pair_neg_risk", False))
+            else:
+                skip_reason = "unknown_leg_market"
+                break
+
+            if price <= 0.0:
+                skip_reason = "invalid_leg_price"
+                break
+
+            notional = max(0.0, safe_float(leg.get("notional_usd"), 0.0))
+            size = notional / max(price, 1e-9)
+            if side == "SELL":
+                available_shares = max(0.0, position_sizes.get(token_id, 0.0))
+                if available_shares + 1e-9 < size:
+                    skip_reason = "insufficient_inventory_for_pair_sell"
+                    break
+            leg_specs.append(
+                {
+                    "market_id": market_id,
+                    "token_id": token_id,
+                    "side": side,
+                    "price": snap_price(price, tick_size, side),
+                    "size": size,
+                    "tick_size": tick_size,
+                    "neg_risk": neg_risk,
+                }
+            )
+
+        if skip_reason:
+            skips.append(
+                {
+                    "market_id": market["market_id"],
+                    "pair_market_id": pair_market_id,
+                    "reason": skip_reason,
+                }
+            )
+            continue
+
+        for leg_spec in leg_specs:
+            fee_rate_bps = fetch_fee_rate_bps(leg_spec["token_id"])
+            response = trader.create_order(
+                token_id=leg_spec["token_id"],
+                side=leg_spec["side"],
+                price=leg_spec["price"],
+                size=leg_spec["size"],
+                tick_size=leg_spec["tick_size"],
+                neg_risk=leg_spec["neg_risk"],
+                fee_rate_bps=fee_rate_bps,
+            )
+            placements.append({**leg_spec, "response": response})
+
+    latest_orders: Any = []
+    latest_positions: Any = raw_positions
+    for _ in range(execution_settings.poll_attempts):
+        if execution_settings.poll_interval_seconds > 0:
+            time.sleep(execution_settings.poll_interval_seconds)
+        latest_orders = trader.get_orders()
+        latest_positions = trader.get_positions()
+
+    return {
+        "cancel_all": cancel_response,
+        "orders_submitted": placements,
+        "order_skips": skips,
+        "open_orders": latest_orders,
+        "open_order_ids": active_order_ids(latest_orders),
+        "positions": latest_positions,
+        "updated_leg_exposure": pair_leg_exposure_notional(
+            raw_positions=latest_positions,
+            markets=markets,
+        ),
+    }

--- a/polymarket/high-throughput-paired-basis-maker/.env.example
+++ b/polymarket/high-throughput-paired-basis-maker/.env.example
@@ -1,4 +1,14 @@
-SEREN_API_KEY=sb_your_api_key_here
+# Optional fallback when Seren Desktop runtime auth is unavailable.
+SEREN_API_KEY=
+# Optional override if seren-mcp is not on PATH, e.g.:
+# SEREN_MCP_COMMAND="npx -y @serendb/seren-mcp"
+SEREN_MCP_COMMAND=
+# Required for live order signing/submission:
+POLY_PRIVATE_KEY=
 POLY_API_KEY=
 POLY_PASSPHRASE=
 POLY_SECRET=
+# Optional advanced wallet settings:
+POLY_CHAIN_ID=137
+POLY_SIGNATURE_TYPE=
+POLY_FUNDER=

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -35,21 +35,26 @@ Live execution requires both:
 
 - `execution.live_mode=true` in config
 - `--yes-live` on the CLI
+- `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
 - `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
 - `.env.example` - environment template for API credentials
+- `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
 ## Quick Start
 
 ```bash
 cd polymarket/high-throughput-paired-basis-maker
+pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json
 ```
+
+If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -3,7 +3,11 @@
   "execution": {
     "dry_run": true,
     "live_mode": false,
-    "require_positive_backtest": true
+    "require_positive_backtest": true,
+    "prefer_live_market_data": true,
+    "cancel_before_requote": true,
+    "poll_attempts": 2,
+    "poll_interval_seconds": 1.5
   },
   "backtest": {
     "days": 270,

--- a/polymarket/high-throughput-paired-basis-maker/requirements.txt
+++ b/polymarket/high-throughput-paired-basis-maker/requirements.txt
@@ -1,0 +1,1 @@
+py-clob-client>=0.34.6

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import os
+import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -17,6 +18,18 @@ from statistics import pstdev
 from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "_shared"
+if str(SHARED_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_DIR))
+
+from polymarket_live import (
+    PolymarketPublisherTrader,
+    execute_pair_trades,
+    live_settings_from_execution,
+    load_live_pair_markets,
+    pair_leg_exposure_notional,
+)
 
 
 DISCLAIMER = (
@@ -147,6 +160,17 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
 def load_config(config_path: str) -> dict[str, Any]:
     payload = load_json(Path(config_path))
     return payload if isinstance(payload, dict) else {}
+
+
+def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
+    if not isinstance(state, dict) or not state:
+        return
+    current_state = config.get("state")
+    if not isinstance(current_state, dict):
+        current_state = {}
+        config["state"] = current_state
+    current_state.update(state)
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
 
 def to_strategy_params(config: dict[str, Any]) -> StrategyParams:
@@ -1093,8 +1117,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         }
 
     p = to_strategy_params(config)
-    exposure = config.get("state", {}).get("leg_exposure", {})
-    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    bt = to_backtest_params(config)
     try:
         markets = _load_trade_markets(config, markets_file)
     except Exception as exc:  # pragma: no cover - defensive runtime path
@@ -1110,6 +1133,55 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             "dry_run": True,
             "disclaimer": DISCLAIMER,
         }
+    market_source = "config"
+    if bool(execution.get("prefer_live_market_data", live_mode)):
+        try:
+            live_markets = load_live_pair_markets(
+                pairs_max=p.pairs_max,
+                min_seconds_to_resolution=p.min_seconds_to_resolution,
+                min_history_points=max(24, bt.min_history_points),
+                min_liquidity_usd=bt.min_liquidity_usd,
+                markets_fetch_page_size=max(bt.markets_fetch_page_size, p.pairs_max * 8, 40),
+                max_markets=bt.max_markets if bt.max_markets > 0 else max(p.pairs_max * 8, 40),
+                history_interval=bt.history_interval,
+                history_fidelity_minutes=bt.history_fidelity_minutes,
+                default_rebate_bps=p.maker_rebate_bps,
+            )
+        except Exception as exc:
+            if not markets:
+                return {
+                    "status": "error",
+                    "error_code": "live_market_data_load_failed",
+                    "message": str(exc),
+                    "dry_run": True,
+                    "disclaimer": DISCLAIMER,
+                }
+            live_markets = []
+        if live_markets:
+            markets = live_markets
+            market_source = "live-seren-publisher"
+
+    exposure = config.get("state", {}).get("leg_exposure", {})
+    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    live_trader: PolymarketPublisherTrader | None = None
+    if live_mode:
+        try:
+            live_trader = PolymarketPublisherTrader(
+                skill_root=Path(__file__).resolve().parents[1],
+                client_name="high-throughput-paired-basis-maker",
+            )
+            leg_exposure = pair_leg_exposure_notional(
+                raw_positions=live_trader.get_positions(),
+                markets=markets,
+            )
+        except Exception as exc:
+            return {
+                "status": "error",
+                "error_code": "live_execution_init_failed",
+                "message": str(exc),
+                "dry_run": True,
+                "disclaimer": DISCLAIMER,
+            }
 
     trades: list[dict[str, Any]] = []
     skips: list[dict[str, Any]] = []
@@ -1139,11 +1211,12 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             )
 
     mode = "live" if live_mode and yes_live and not dry_run else "dry-run"
-    return {
+    payload: dict[str, Any] = {
         "status": "ok",
         "skill": "high-throughput-paired-basis-maker",
         "mode": mode,
         "dry_run": mode != "live",
+        "market_source": market_source,
         "strategy_summary": {
             "pairs_considered": len(markets),
             "pairs_quoted": len(trades),
@@ -1156,6 +1229,18 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         "skips": skips,
         "disclaimer": DISCLAIMER,
     }
+    if mode == "live" and live_trader is not None:
+        live_execution = execute_pair_trades(
+            trader=live_trader,
+            pair_trades=trades,
+            markets=markets,
+            execution_settings=live_settings_from_execution(execution),
+        )
+        payload["live_execution"] = live_execution
+        payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
+        payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
+        payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+    return payload
 
 
 def main() -> int:
@@ -1194,6 +1279,11 @@ def main() -> int:
 
     trade = run_trade(config=config, markets_file=args.markets_file, yes_live=args.yes_live)
     ok = trade.get("status") == "ok"
+    if ok and isinstance(trade.get("state"), dict):
+        try:
+            _persist_runtime_state(args.config, config, trade["state"])
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            trade["state_writeback_warning"] = str(exc)
     payload = {
         "status": "ok" if ok else "error",
         "skill": "high-throughput-paired-basis-maker",

--- a/polymarket/liquidity-paired-basis-maker/.env.example
+++ b/polymarket/liquidity-paired-basis-maker/.env.example
@@ -1,3 +1,14 @@
-# Generated SkillForge environment template for liquidity-paired-basis-maker
-# No required secrets for this skill.
-
+# Optional fallback when Seren Desktop runtime auth is unavailable.
+SEREN_API_KEY=
+# Optional override if seren-mcp is not on PATH, e.g.:
+# SEREN_MCP_COMMAND="npx -y @serendb/seren-mcp"
+SEREN_MCP_COMMAND=
+# Required for live order signing/submission:
+POLY_PRIVATE_KEY=
+POLY_API_KEY=
+POLY_PASSPHRASE=
+POLY_SECRET=
+# Optional advanced wallet settings:
+POLY_CHAIN_ID=137
+POLY_SIGNATURE_TYPE=
+POLY_FUNDER=

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -35,23 +35,26 @@ Live execution requires both:
 
 - `execution.live_mode=true` in config
 - `--yes-live` on the CLI
+- `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
 - `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
-- `.env.example` - optional auth/env template (`API_KEY` in Seren Desktop runtime or `SEREN_API_KEY` standalone)
+- `.env.example` - optional fallback auth/env template (`SEREN_API_KEY` only if runtime auth is unavailable)
+- `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
 ## Quick Start
 
 ```bash
-cd artifacts/polymarket/liquidity-paired-basis-maker
+cd polymarket/liquidity-paired-basis-maker
+pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json
 ```
 
-If you are logged into Seren Desktop, the runtime can use injected `API_KEY` auth automatically.
+If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -3,7 +3,11 @@
   "execution": {
     "dry_run": true,
     "live_mode": false,
-    "require_positive_backtest": true
+    "require_positive_backtest": true,
+    "prefer_live_market_data": true,
+    "cancel_before_requote": true,
+    "poll_attempts": 2,
+    "poll_interval_seconds": 1.5
   },
   "backtest": {
     "days": 90,

--- a/polymarket/liquidity-paired-basis-maker/requirements.txt
+++ b/polymarket/liquidity-paired-basis-maker/requirements.txt
@@ -1,0 +1,1 @@
+py-clob-client>=0.34.6

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import os
+import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -17,6 +18,18 @@ from statistics import pstdev
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "_shared"
+if str(SHARED_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_DIR))
+
+from polymarket_live import (
+    PolymarketPublisherTrader,
+    execute_pair_trades,
+    live_settings_from_execution,
+    load_live_pair_markets,
+    pair_leg_exposure_notional,
+)
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -157,6 +170,17 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
 def load_config(config_path: str) -> dict[str, Any]:
     payload = load_json(Path(config_path))
     return payload if isinstance(payload, dict) else {}
+
+
+def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
+    if not isinstance(state, dict) or not state:
+        return
+    current_state = config.get("state")
+    if not isinstance(current_state, dict):
+        current_state = {}
+        config["state"] = current_state
+    current_state.update(state)
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
 
 def to_strategy_params(config: dict[str, Any]) -> StrategyParams:
@@ -1155,8 +1179,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         }
 
     p = to_strategy_params(config)
-    exposure = config.get("state", {}).get("leg_exposure", {})
-    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    bt = to_backtest_params(config)
     try:
         markets = _load_trade_markets(config, markets_file)
     except Exception as exc:  # pragma: no cover - defensive runtime path
@@ -1172,6 +1195,55 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             "dry_run": True,
             "disclaimer": DISCLAIMER,
         }
+    market_source = "config"
+    if bool(execution.get("prefer_live_market_data", live_mode)):
+        try:
+            live_markets = load_live_pair_markets(
+                pairs_max=p.pairs_max,
+                min_seconds_to_resolution=p.min_seconds_to_resolution,
+                min_history_points=max(24, bt.min_history_points),
+                min_liquidity_usd=bt.min_liquidity_usd,
+                markets_fetch_page_size=max(bt.markets_fetch_page_size, p.pairs_max * 8, 40),
+                max_markets=bt.max_markets if bt.max_markets > 0 else max(p.pairs_max * 8, 40),
+                history_interval=bt.history_interval,
+                history_fidelity_minutes=bt.history_fidelity_minutes,
+                default_rebate_bps=p.maker_rebate_bps,
+            )
+        except Exception as exc:
+            if not markets:
+                return {
+                    "status": "error",
+                    "error_code": "live_market_data_load_failed",
+                    "message": str(exc),
+                    "dry_run": True,
+                    "disclaimer": DISCLAIMER,
+                }
+            live_markets = []
+        if live_markets:
+            markets = live_markets
+            market_source = "live-seren-publisher"
+
+    exposure = config.get("state", {}).get("leg_exposure", {})
+    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    live_trader: PolymarketPublisherTrader | None = None
+    if live_mode:
+        try:
+            live_trader = PolymarketPublisherTrader(
+                skill_root=Path(__file__).resolve().parents[1],
+                client_name="liquidity-paired-basis-maker",
+            )
+            leg_exposure = pair_leg_exposure_notional(
+                raw_positions=live_trader.get_positions(),
+                markets=markets,
+            )
+        except Exception as exc:
+            return {
+                "status": "error",
+                "error_code": "live_execution_init_failed",
+                "message": str(exc),
+                "dry_run": True,
+                "disclaimer": DISCLAIMER,
+            }
 
     trades: list[dict[str, Any]] = []
     skips: list[dict[str, Any]] = []
@@ -1201,11 +1273,12 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             )
 
     mode = "live" if live_mode and yes_live and not dry_run else "dry-run"
-    return {
+    payload: dict[str, Any] = {
         "status": "ok",
         "skill": "liquidity-paired-basis-maker",
         "mode": mode,
         "dry_run": mode != "live",
+        "market_source": market_source,
         "strategy_summary": {
             "pairs_considered": len(markets),
             "pairs_quoted": len(trades),
@@ -1218,6 +1291,18 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         "skips": skips,
         "disclaimer": DISCLAIMER,
     }
+    if mode == "live" and live_trader is not None:
+        live_execution = execute_pair_trades(
+            trader=live_trader,
+            pair_trades=trades,
+            markets=markets,
+            execution_settings=live_settings_from_execution(execution),
+        )
+        payload["live_execution"] = live_execution
+        payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
+        payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
+        payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+    return payload
 
 
 def main() -> int:
@@ -1256,6 +1341,11 @@ def main() -> int:
 
     trade = run_trade(config=config, markets_file=args.markets_file, yes_live=args.yes_live)
     ok = trade.get("status") == "ok"
+    if ok and isinstance(trade.get("state"), dict):
+        try:
+            _persist_runtime_state(args.config, config, trade["state"])
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            trade["state_writeback_warning"] = str(exc)
     payload = {
         "status": "ok" if ok else "error",
         "skill": "liquidity-paired-basis-maker",

--- a/polymarket/maker-rebate-bot/.env.example
+++ b/polymarket/maker-rebate-bot/.env.example
@@ -1,4 +1,14 @@
-SEREN_API_KEY=sb_your_api_key_here
+# Optional fallback when Seren Desktop runtime auth is unavailable.
+SEREN_API_KEY=
+# Optional override if seren-mcp is not on PATH, e.g.:
+# SEREN_MCP_COMMAND="npx -y @serendb/seren-mcp"
+SEREN_MCP_COMMAND=
+# Required for live order signing/submission:
+POLY_PRIVATE_KEY=
 POLY_API_KEY=
 POLY_PASSPHRASE=
 POLY_SECRET=
+# Optional advanced wallet settings:
+POLY_CHAIN_ID=137
+POLY_SIGNATURE_TYPE=
+POLY_FUNDER=

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -28,22 +28,30 @@ description: "Provide two-sided liquidity on Polymarket with rebate-aware quotin
 - `monitor`: alias for quote-style dry monitoring output.
 - `live`: requires both `execution.live_mode=true` in config and `--yes-live` CLI confirmation.
 
+Live execution also requires:
+
+- `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) for EIP-712 order signing
+- `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` for authenticated submission
+
 ## Runtime Files
 
 - `scripts/agent.py` - rebate-aware quoting engine with risk guards
 - `config.example.json` - baseline strategy and 90-day backtest parameters
-- `.env.example` - environment variable template for API credentials
+- `.env.example` - optional fallback auth/env template (`SEREN_API_KEY` only if runtime auth is unavailable)
+- `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
 ## Quick Start
 
 ```bash
-cd artifacts/polymarket-maker-rebate-bot
+cd polymarket/maker-rebate-bot
+pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json
 ```
 
 This runs the default 90-day backtest and returns a decision hint to keep paper-only or proceed to quote mode.
+If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
 
 ## Run Quote Mode (After Backtest Review)
 
@@ -74,6 +82,7 @@ Each backtest market object should include:
 ## Safety Notes
 
 - Live execution is never enabled by default.
+- Live quote cycles cancel stale orders, fetch fresh market snapshots, and then poll open orders/positions after requoting.
 - Backtests are estimates and can materially differ from live outcomes.
 - Quotes are blocked when estimated edge is negative.
 - Markets close to resolution are excluded.

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -2,7 +2,11 @@
   "skill": "polymarket-maker-rebate-bot",
   "execution": {
     "dry_run": true,
-    "live_mode": false
+    "live_mode": false,
+    "prefer_live_market_data": true,
+    "cancel_before_requote": true,
+    "poll_attempts": 2,
+    "poll_interval_seconds": 1.5
   },
   "backtest": {
     "days": 90,

--- a/polymarket/maker-rebate-bot/requirements.txt
+++ b/polymarket/maker-rebate-bot/requirements.txt
@@ -1,0 +1,1 @@
+py-clob-client>=0.34.6

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -14,6 +15,18 @@ from statistics import pstdev
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "_shared"
+if str(SHARED_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_DIR))
+
+from polymarket_live import (
+    PolymarketPublisherTrader,
+    execute_single_market_quotes,
+    live_settings_from_execution,
+    load_live_single_markets,
+    single_market_inventory_notional,
+)
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -109,6 +122,17 @@ def load_json_file(path: Path) -> dict[str, Any]:
 
 def load_config(config_path: str) -> dict[str, Any]:
     return load_json_file(Path(config_path))
+
+
+def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
+    if not isinstance(state, dict) or not state:
+        return
+    current_state = config.get("state")
+    if not isinstance(current_state, dict):
+        current_state = {}
+        config["state"] = current_state
+    current_state.update(state)
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
 
 def _coerce_market_rows(payload: Any) -> list[dict[str, Any]]:
@@ -1039,7 +1063,8 @@ def run_once(
     yes_live: bool,
 ) -> dict[str, Any]:
     params = to_params(config)
-    execution = config.get("execution", {})
+    execution = config.get("execution", {}) if isinstance(config.get("execution"), dict) else {}
+    backtest_params = to_backtest_params(config)
     live_mode = bool(execution.get("live_mode", False))
     dry_run = bool(execution.get("dry_run", True))
 
@@ -1060,10 +1085,57 @@ def run_once(
             "dry_run": True,
         }
 
+    prefer_live_market_data = bool(execution.get("prefer_live_market_data", live_mode))
+    market_source = "config"
+    if prefer_live_market_data:
+        try:
+            live_markets = load_live_single_markets(
+                markets_max=params.markets_max,
+                min_seconds_to_resolution=params.min_seconds_to_resolution,
+                volatility_window_points=backtest_params.volatility_window_points,
+                min_history_points=max(24, backtest_params.volatility_window_points * 4),
+                min_liquidity_usd=backtest_params.min_liquidity_usd,
+                markets_fetch_limit=max(params.markets_max * 5, backtest_params.markets_fetch_limit),
+                history_interval="max",
+                history_fidelity_minutes=backtest_params.fidelity_minutes,
+                default_rebate_bps=params.default_rebate_bps,
+                timeout_seconds=30.0,
+            )
+        except Exception as exc:
+            if not markets:
+                return {
+                    "status": "error",
+                    "error_code": "live_market_data_load_failed",
+                    "message": str(exc),
+                    "dry_run": True,
+                }
+            live_markets = []
+        if live_markets:
+            markets = live_markets
+            market_source = "live-seren-publisher"
+
     inventory = config.get("state", {}).get("inventory", {})
     inventory_notional_by_market = {
         str(k): _safe_float(v, 0.0) for k, v in inventory.items()
     }
+    live_trader: PolymarketPublisherTrader | None = None
+    if live_mode:
+        try:
+            live_trader = PolymarketPublisherTrader(
+                skill_root=Path(__file__).resolve().parents[1],
+                client_name="polymarket-maker-rebate-bot",
+            )
+            inventory_notional_by_market = single_market_inventory_notional(
+                raw_positions=live_trader.get_positions(),
+                markets=markets,
+            )
+        except Exception as exc:
+            return {
+                "status": "error",
+                "error_code": "live_execution_init_failed",
+                "message": str(exc),
+                "dry_run": True,
+            }
 
     proposals: list[dict[str, Any]] = []
     rejected: list[dict[str, Any]] = []
@@ -1101,11 +1173,12 @@ def run_once(
             )
 
     mode = "live" if live_mode and yes_live and not dry_run else "dry-run"
-    return {
+    payload: dict[str, Any] = {
         "status": "ok",
         "skill": "polymarket-maker-rebate-bot",
         "mode": mode,
         "dry_run": mode != "live",
+        "market_source": market_source,
         "strategy_summary": {
             "bankroll_usd": params.bankroll_usd,
             "markets_considered": len(markets),
@@ -1117,6 +1190,18 @@ def run_once(
         "quotes": proposals,
         "skips": rejected,
     }
+    if mode == "live" and live_trader is not None:
+        live_execution = execute_single_market_quotes(
+            trader=live_trader,
+            quotes=proposals,
+            markets=markets,
+            execution_settings=live_settings_from_execution(execution),
+        )
+        payload["live_execution"] = live_execution
+        payload["state"] = {"inventory": live_execution.get("updated_inventory", {})}
+        payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
+        payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+    return payload
 
 
 def run_quote(config: dict[str, Any], markets_file: str | None, yes_live: bool) -> dict[str, Any]:
@@ -1148,6 +1233,11 @@ def main() -> int:
         )
     else:
         result = run_quote(config=config, markets_file=args.markets_file, yes_live=args.yes_live)
+        if result.get("status") == "ok" and isinstance(result.get("state"), dict):
+            try:
+                _persist_runtime_state(args.config, config, result["state"])
+            except Exception as exc:  # pragma: no cover - defensive runtime path
+                result["state_writeback_warning"] = str(exc)
     print(json.dumps(result, sort_keys=True))
     return 0 if result.get("status") == "ok" else 1
 

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -228,3 +228,127 @@ def test_backtest_rejects_non_seren_polymarket_data_source(tmp_path: Path) -> No
     assert output["status"] == "error"
     assert output["error_code"] == "backtest_data_load_failed"
     assert "Seren Polymarket Publisher" in output["message"]
+
+
+def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> None:
+    agent = _load_agent_module()
+    load_calls: list[dict[str, object]] = []
+    execute_calls: list[dict[str, object]] = []
+
+    class FakeTrader:
+        def __init__(self, *, skill_root: Path, client_name: str, timeout_seconds: float = 30.0) -> None:
+            self.skill_root = skill_root
+            self.client_name = client_name
+            self.timeout_seconds = timeout_seconds
+
+        def get_positions(self) -> list[dict[str, object]]:
+            return [{"asset_id": "TOKEN-LIVE-1", "size": 4.0}]
+
+    def fake_load_live_single_markets(**kwargs):
+        load_calls.append(kwargs)
+        return [
+            {
+                "market_id": "LIVE-MKT-1",
+                "question": "Will live event happen?",
+                "token_id": "TOKEN-LIVE-1",
+                "mid_price": 0.48,
+                "best_bid": 0.47,
+                "best_ask": 0.49,
+                "seconds_to_resolution": 86400,
+                "volatility_bps": 50,
+                "rebate_bps": 2.5,
+                "tick_size": "0.01",
+                "neg_risk": False,
+            }
+        ]
+
+    def fake_execute_single_market_quotes(*, trader, quotes, markets, execution_settings):
+        execute_calls.append(
+            {
+                "client_name": trader.client_name,
+                "quotes": quotes,
+                "markets": markets,
+                "poll_attempts": execution_settings.poll_attempts,
+            }
+        )
+        return {
+            "orders_submitted": [{"id": "ORDER-1"}, {"id": "ORDER-2"}],
+            "open_order_ids": ["ORDER-1"],
+            "updated_inventory": {"LIVE-MKT-1": 12.5},
+        }
+
+    monkeypatch.setattr(agent, "PolymarketPublisherTrader", FakeTrader)
+    monkeypatch.setattr(agent, "load_live_single_markets", fake_load_live_single_markets)
+    monkeypatch.setattr(agent, "execute_single_market_quotes", fake_execute_single_market_quotes)
+
+    result = agent.run_once(
+        config={
+            "execution": {
+                "dry_run": False,
+                "live_mode": True,
+                "prefer_live_market_data": True,
+                "poll_attempts": 3,
+            },
+            "backtest": {
+                "volatility_window_points": 24,
+                "min_liquidity_usd": 0,
+                "markets_fetch_limit": 5,
+                "fidelity_minutes": 60,
+            },
+            "strategy": {
+                "bankroll_usd": 1000,
+                "markets_max": 1,
+                "min_seconds_to_resolution": 60,
+                "min_edge_bps": 2,
+                "default_rebate_bps": 3,
+                "expected_unwind_cost_bps": 1.5,
+                "adverse_selection_bps": 1.0,
+                "min_spread_bps": 20,
+                "max_spread_bps": 150,
+                "volatility_spread_multiplier": 0.35,
+                "base_order_notional_usd": 25,
+                "max_notional_per_market_usd": 125,
+                "max_total_notional_usd": 500,
+                "max_position_notional_usd": 150,
+                "inventory_skew_strength_bps": 25,
+            },
+            "state": {"inventory": {"CONFIG-MKT": 1.0}},
+        },
+        markets=[
+            {
+                "market_id": "CONFIG-MKT",
+                "mid_price": 0.2,
+                "best_bid": 0.19,
+                "best_ask": 0.21,
+                "seconds_to_resolution": 1000,
+                "volatility_bps": 10,
+            }
+        ],
+        yes_live=True,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "live"
+    assert result["market_source"] == "live-seren-publisher"
+    assert result["state"] == {"inventory": {"LIVE-MKT-1": 12.5}}
+    assert result["strategy_summary"]["orders_submitted"] == 2
+    assert result["strategy_summary"]["open_orders"] == 1
+    assert load_calls and load_calls[0]["markets_max"] == 1
+    assert execute_calls and execute_calls[0]["client_name"] == "polymarket-maker-rebate-bot"
+    assert execute_calls[0]["quotes"][0]["market_id"] == "LIVE-MKT-1"
+
+
+def test_persist_runtime_state_updates_config_file(tmp_path: Path) -> None:
+    agent = _load_agent_module()
+    config_path = tmp_path / "config.json"
+    config = {"state": {"inventory": {"OLD": 1.0}}}
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    agent._persist_runtime_state(
+        str(config_path),
+        config,
+        {"inventory": {"LIVE-MKT-1": 12.5}},
+    )
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["state"]["inventory"] == {"LIVE-MKT-1": 12.5}

--- a/polymarket/paired-market-basis-maker/.env.example
+++ b/polymarket/paired-market-basis-maker/.env.example
@@ -1,4 +1,14 @@
-SEREN_API_KEY=sb_your_api_key_here
+# Optional fallback when Seren Desktop runtime auth is unavailable.
+SEREN_API_KEY=
+# Optional override if seren-mcp is not on PATH, e.g.:
+# SEREN_MCP_COMMAND="npx -y @serendb/seren-mcp"
+SEREN_MCP_COMMAND=
+# Required for live order signing/submission:
+POLY_PRIVATE_KEY=
 POLY_API_KEY=
 POLY_PASSPHRASE=
 POLY_SECRET=
+# Optional advanced wallet settings:
+POLY_CHAIN_ID=137
+POLY_SIGNATURE_TYPE=
+POLY_FUNDER=

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -35,21 +35,26 @@ Live execution requires both:
 
 - `execution.live_mode=true` in config
 - `--yes-live` on the CLI
+- `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
 - `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
 - `.env.example` - environment template for API credentials
+- `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
 ## Quick Start
 
 ```bash
 cd polymarket/paired-market-basis-maker
+pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json
 ```
+
+If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -3,7 +3,11 @@
   "execution": {
     "dry_run": true,
     "live_mode": false,
-    "require_positive_backtest": true
+    "require_positive_backtest": true,
+    "prefer_live_market_data": true,
+    "cancel_before_requote": true,
+    "poll_attempts": 2,
+    "poll_interval_seconds": 1.5
   },
   "backtest": {
     "days": 270,

--- a/polymarket/paired-market-basis-maker/requirements.txt
+++ b/polymarket/paired-market-basis-maker/requirements.txt
@@ -1,0 +1,1 @@
+py-clob-client>=0.34.6

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import os
+import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -17,6 +18,18 @@ from statistics import pstdev
 from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "_shared"
+if str(SHARED_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_DIR))
+
+from polymarket_live import (
+    PolymarketPublisherTrader,
+    execute_pair_trades,
+    live_settings_from_execution,
+    load_live_pair_markets,
+    pair_leg_exposure_notional,
+)
 
 
 DISCLAIMER = (
@@ -147,6 +160,17 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
 def load_config(config_path: str) -> dict[str, Any]:
     payload = load_json(Path(config_path))
     return payload if isinstance(payload, dict) else {}
+
+
+def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
+    if not isinstance(state, dict) or not state:
+        return
+    current_state = config.get("state")
+    if not isinstance(current_state, dict):
+        current_state = {}
+        config["state"] = current_state
+    current_state.update(state)
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
 
 def to_strategy_params(config: dict[str, Any]) -> StrategyParams:
@@ -1093,8 +1117,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         }
 
     p = to_strategy_params(config)
-    exposure = config.get("state", {}).get("leg_exposure", {})
-    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    bt = to_backtest_params(config)
     try:
         markets = _load_trade_markets(config, markets_file)
     except Exception as exc:  # pragma: no cover - defensive runtime path
@@ -1110,6 +1133,55 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             "dry_run": True,
             "disclaimer": DISCLAIMER,
         }
+    market_source = "config"
+    if bool(execution.get("prefer_live_market_data", live_mode)):
+        try:
+            live_markets = load_live_pair_markets(
+                pairs_max=p.pairs_max,
+                min_seconds_to_resolution=p.min_seconds_to_resolution,
+                min_history_points=max(24, bt.min_history_points),
+                min_liquidity_usd=bt.min_liquidity_usd,
+                markets_fetch_page_size=max(bt.markets_fetch_page_size, p.pairs_max * 8, 40),
+                max_markets=bt.max_markets if bt.max_markets > 0 else max(p.pairs_max * 8, 40),
+                history_interval=bt.history_interval,
+                history_fidelity_minutes=bt.history_fidelity_minutes,
+                default_rebate_bps=p.maker_rebate_bps,
+            )
+        except Exception as exc:
+            if not markets:
+                return {
+                    "status": "error",
+                    "error_code": "live_market_data_load_failed",
+                    "message": str(exc),
+                    "dry_run": True,
+                    "disclaimer": DISCLAIMER,
+                }
+            live_markets = []
+        if live_markets:
+            markets = live_markets
+            market_source = "live-seren-publisher"
+
+    exposure = config.get("state", {}).get("leg_exposure", {})
+    leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    live_trader: PolymarketPublisherTrader | None = None
+    if live_mode:
+        try:
+            live_trader = PolymarketPublisherTrader(
+                skill_root=Path(__file__).resolve().parents[1],
+                client_name="paired-market-basis-maker",
+            )
+            leg_exposure = pair_leg_exposure_notional(
+                raw_positions=live_trader.get_positions(),
+                markets=markets,
+            )
+        except Exception as exc:
+            return {
+                "status": "error",
+                "error_code": "live_execution_init_failed",
+                "message": str(exc),
+                "dry_run": True,
+                "disclaimer": DISCLAIMER,
+            }
 
     trades: list[dict[str, Any]] = []
     skips: list[dict[str, Any]] = []
@@ -1139,11 +1211,12 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             )
 
     mode = "live" if live_mode and yes_live and not dry_run else "dry-run"
-    return {
+    payload: dict[str, Any] = {
         "status": "ok",
         "skill": "paired-market-basis-maker",
         "mode": mode,
         "dry_run": mode != "live",
+        "market_source": market_source,
         "strategy_summary": {
             "pairs_considered": len(markets),
             "pairs_quoted": len(trades),
@@ -1156,6 +1229,18 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         "skips": skips,
         "disclaimer": DISCLAIMER,
     }
+    if mode == "live" and live_trader is not None:
+        live_execution = execute_pair_trades(
+            trader=live_trader,
+            pair_trades=trades,
+            markets=markets,
+            execution_settings=live_settings_from_execution(execution),
+        )
+        payload["live_execution"] = live_execution
+        payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
+        payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
+        payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+    return payload
 
 
 def main() -> int:
@@ -1194,6 +1279,11 @@ def main() -> int:
 
     trade = run_trade(config=config, markets_file=args.markets_file, yes_live=args.yes_live)
     ok = trade.get("status") == "ok"
+    if ok and isinstance(trade.get("state"), dict):
+        try:
+            _persist_runtime_state(args.config, config, trade["state"])
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            trade["state_writeback_warning"] = str(exc)
     payload = {
         "status": "ok" if ok else "error",
         "skill": "paired-market-basis-maker",

--- a/polymarket/paired-market-basis-maker/tests/test_smoke.py
+++ b/polymarket/paired-market-basis-maker/tests/test_smoke.py
@@ -151,3 +151,124 @@ def test_trade_mode_fetches_live_pairs_when_config_markets_is_empty(monkeypatch)
     assert result["pair_trades"][0]["market_id"] == "LIVE-PAIR-1A"
     assert result["pair_trades"][0]["pair_market_id"] == "LIVE-PAIR-1B"
     assert any("/publishers/polymarket-data/markets?" in url for url in fetched_urls)
+
+
+def test_live_trade_mode_uses_live_pair_loader_and_executor(monkeypatch) -> None:
+    module = _load_agent_module()
+    load_calls: list[dict[str, object]] = []
+    execute_calls: list[dict[str, object]] = []
+
+    class FakeTrader:
+        def __init__(self, *, skill_root: Path, client_name: str, timeout_seconds: float = 30.0) -> None:
+            self.skill_root = skill_root
+            self.client_name = client_name
+            self.timeout_seconds = timeout_seconds
+
+        def get_positions(self) -> list[dict[str, object]]:
+            return [
+                {"asset_id": "TOKEN-PAIR-1A", "size": 3.0},
+                {"asset_id": "TOKEN-PAIR-1B", "size": 2.0},
+            ]
+
+    def fake_load_live_pair_markets(**kwargs):
+        load_calls.append(kwargs)
+        return [
+            {
+                "market_id": "LIVE-PAIR-1A",
+                "pair_market_id": "LIVE-PAIR-1B",
+                "question": "Primary leg",
+                "pair_question": "Pair leg",
+                "token_id": "TOKEN-PAIR-1A",
+                "pair_token_id": "TOKEN-PAIR-1B",
+                "mid_price": 0.62,
+                "pair_mid_price": 0.41,
+                "best_bid": 0.61,
+                "best_ask": 0.63,
+                "pair_best_bid": 0.4,
+                "pair_best_ask": 0.42,
+                "tick_size": "0.01",
+                "pair_tick_size": "0.01",
+                "neg_risk": False,
+                "pair_neg_risk": False,
+                "seconds_to_resolution": 86400,
+                "rebate_bps": 2.3,
+                "basis_volatility_bps": 80,
+            }
+        ]
+
+    def fake_execute_pair_trades(*, trader, pair_trades, markets, execution_settings):
+        execute_calls.append(
+            {
+                "client_name": trader.client_name,
+                "pair_trades": pair_trades,
+                "markets": markets,
+                "poll_attempts": execution_settings.poll_attempts,
+            }
+        )
+        return {
+            "orders_submitted": [{"id": "PAIR-ORDER-1"}, {"id": "PAIR-ORDER-2"}],
+            "open_order_ids": ["PAIR-ORDER-1", "PAIR-ORDER-2"],
+            "updated_leg_exposure": {"LIVE-PAIR-1A": 7.5, "LIVE-PAIR-1B": -7.5},
+        }
+
+    monkeypatch.setattr(module, "PolymarketPublisherTrader", FakeTrader)
+    monkeypatch.setattr(module, "load_live_pair_markets", fake_load_live_pair_markets)
+    monkeypatch.setattr(module, "execute_pair_trades", fake_execute_pair_trades)
+
+    result = module.run_trade(
+        config={
+            "execution": {
+                "dry_run": False,
+                "live_mode": True,
+                "prefer_live_market_data": True,
+                "poll_attempts": 4,
+            },
+            "backtest": {
+                "min_history_points": 72,
+                "min_liquidity_usd": 0,
+                "markets_fetch_page_size": 10,
+                "max_markets": 2,
+                "history_interval": "max",
+                "history_fidelity_minutes": 60,
+            },
+            "strategy": {
+                "bankroll_usd": 1000,
+                "pairs_max": 1,
+                "min_seconds_to_resolution": 60,
+                "min_edge_bps": 2.0,
+                "maker_rebate_bps": 2.3,
+                "expected_unwind_cost_bps": 1.5,
+                "adverse_selection_bps": 1.1,
+                "basis_entry_bps": 35,
+                "basis_exit_bps": 10,
+                "expected_convergence_ratio": 0.35,
+                "base_pair_notional_usd": 550,
+                "max_notional_per_pair_usd": 750,
+                "max_total_notional_usd": 1600,
+                "max_leg_notional_usd": 800,
+            },
+            "state": {"leg_exposure": {"CONFIG-PAIR-A": 1.0}},
+            "markets": [
+                {
+                    "market_id": "CONFIG-PAIR-A",
+                    "pair_market_id": "CONFIG-PAIR-B",
+                    "mid_price": 0.51,
+                    "pair_mid_price": 0.5,
+                    "seconds_to_resolution": 1000,
+                    "basis_volatility_bps": 5,
+                }
+            ],
+        },
+        markets_file=None,
+        yes_live=True,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "live"
+    assert result["market_source"] == "live-seren-publisher"
+    assert result["state"] == {"leg_exposure": {"LIVE-PAIR-1A": 7.5, "LIVE-PAIR-1B": -7.5}}
+    assert result["strategy_summary"]["orders_submitted"] == 2
+    assert result["strategy_summary"]["open_orders"] == 2
+    assert load_calls and load_calls[0]["pairs_max"] == 1
+    assert execute_calls and execute_calls[0]["client_name"] == "paired-market-basis-maker"
+    assert execute_calls[0]["pair_trades"][0]["market_id"] == "LIVE-PAIR-1A"


### PR DESCRIPTION
## Summary
- add a shared live Polymarket execution helper for market loading, signed order submission, polling, and inventory/exposure calculation
- wire the maker and paired Polymarket runtimes to use the real live path instead of only relabeling output as `live`
- persist updated runtime state back into `config.json` and document the live credentials/dependencies in examples and skill docs

## Testing
- `python3 -m py_compile polymarket/_shared/polymarket_live.py polymarket/maker-rebate-bot/scripts/agent.py polymarket/paired-market-basis-maker/scripts/agent.py polymarket/liquidity-paired-basis-maker/scripts/agent.py polymarket/high-throughput-paired-basis-maker/scripts/agent.py`
- `pytest --import-mode=importlib polymarket/maker-rebate-bot/tests/test_smoke.py polymarket/paired-market-basis-maker/tests/test_smoke.py polymarket/liquidity-paired-basis-maker/tests/test_smoke.py polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py`

Closes #75.
