### PR TITLE
fix(polymarket): add venv-first setup for py-clob-client skills

### DIFF
--- a/polymarket/_shared/polymarket_live.py
+++ b/polymarket/_shared/polymarket_live.py
@@ -837,7 +837,8 @@ class PolymarketPublisherTrader:
         except ImportError as exc:
             raise RuntimeError(
                 "Live Polymarket execution requires `py-clob-client`. "
-                "Install it with `pip install py-clob-client` or add it to requirements.txt."
+                "Create and activate a virtual environment first, then run "
+                "`python -m pip install -r requirements.txt`."
             ) from exc
 
         private_key = safe_str(

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -48,7 +48,10 @@ Live execution requires both:
 
 ```bash
 cd polymarket/high-throughput-paired-basis-maker
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -48,7 +48,10 @@ Live execution requires both:
 
 ```bash
 cd polymarket/liquidity-paired-basis-maker
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -44,7 +44,10 @@ Live execution also requires:
 
 ```bash
 cd polymarket/maker-rebate-bot
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -48,7 +48,10 @@ Live execution requires both:
 
 ```bash
 cd polymarket/paired-market-basis-maker
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 cp .env.example .env
 cp config.example.json config.json
 python3 scripts/agent.py --config config.json


### PR DESCRIPTION
## Summary
- update Quick Start setup for all four `py-clob-client` Polymarket skills to use a local virtual environment first
- replace direct `pip install -r requirements.txt` with:
  - `python3 -m venv .venv`
  - `source .venv/bin/activate`
  - `python -m pip install --upgrade pip`
  - `python -m pip install -r requirements.txt`
- improve shared live-runtime import error guidance to point users to venv-first dependency install

## Affected Skills
- `polymarket/maker-rebate-bot`
- `polymarket/high-throughput-paired-basis-maker`
- `polymarket/paired-market-basis-maker`
- `polymarket/liquidity-paired-basis-maker`

## Validation
- `python3 -m compileall polymarket/_shared/polymarket_live.py`
- `python3 -m pytest polymarket/maker-rebate-bot/tests polymarket/high-throughput-paired-basis-maker/tests polymarket/paired-market-basis-maker/tests polymarket/liquidity-paired-basis-maker/tests` (fails in this environment because `pytest` is not installed)

Closes #78
