### PR TITLE
chore: add standard For Claude section to skills missing it

### DIFF
--- a/alpaca/saas-short-trader/SKILL.md
+++ b/alpaca/saas-short-trader/SKILL.md
@@ -5,6 +5,10 @@ description: "Alpaca-branded SaaS short trader with MCP-native execution: scores
 
 # Alpaca SaaS Short Trader
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Autonomous strategy agent for shorting SaaS names under AI-driven multiple compression.
 
 Default backend is MCP-native:

--- a/alpaca/sass-short-trader-delta-neutral/SKILL.md
+++ b/alpaca/sass-short-trader-delta-neutral/SKILL.md
@@ -5,6 +5,10 @@ description: "Alpaca-branded SaaS delta-neutral trader with MCP-native execution
 
 # Alpaca SaaS Short Trader Delta Neutral
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Autonomous strategy agent for shorting SaaS names under AI-driven multiple compression while adding a long market hedge to target near delta-neutral exposure.
 
 Default backend is MCP-native:

--- a/alphagrowth/euler-base-vault-bot/SKILL.md
+++ b/alphagrowth/euler-base-vault-bot/SKILL.md
@@ -5,6 +5,10 @@ description: "Deposit USDC into the AlphaGrowth Base Vault on Euler Finance, col
 
 # Euler Base Vault Bot
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - deposit USDC into the AlphaGrowth Euler vault on Base

--- a/apollo/api/SKILL.md
+++ b/apollo/api/SKILL.md
@@ -5,6 +5,10 @@ description: "Apollo.io API for people and company enrichment, prospecting, and 
 
 # Apollo
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Apollo.io API for people and company enrichment, prospecting, and sales intelligence
 
 ## API Endpoints

--- a/benjamin-black-consulting/ai-governance-assessment/SKILL.md
+++ b/benjamin-black-consulting/ai-governance-assessment/SKILL.md
@@ -5,6 +5,10 @@ description: "Assess AI governance maturity for compliance/risk leaders: evaluat
 
 # AI Governance Readiness Assessment
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Assess your organization's AI governance maturity with results saved to SerenDB.
 
 ## What This Skill Provides

--- a/coinbase/grid-trader/SKILL.md
+++ b/coinbase/grid-trader/SKILL.md
@@ -5,6 +5,10 @@ description: "Automated grid trading bot for Coinbase Exchange — profits from 
 
 # Coinbase Grid Trader
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Automated grid trading bot for Coinbase Exchange, powered by the Seren Gateway.
 
 ## What This Skill Provides

--- a/coinbase/smart-dca-bot/SKILL.md
+++ b/coinbase/smart-dca-bot/SKILL.md
@@ -5,6 +5,10 @@ description: "AI-optimized Coinbase Smart DCA bot with single-asset, portfolio, 
 
 # Coinbase Smart DCA Bot
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 AI-assisted dollar-cost averaging (DCA) bot for Coinbase Advanced Trade with three modes:
 - `single_asset`
 - `portfolio`

--- a/crypto-bullseye-zone/tax/SKILL.md
+++ b/crypto-bullseye-zone/tax/SKILL.md
@@ -6,6 +6,10 @@ description: "Use when a user has a Form 1099-DA from a crypto exchange and want
 
 # CryptoBullseyeZone Tax Reconciler
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## Overview
 
 This skill reviews and analyzes Form 1099-DA from crypto exchanges so users understand what they're filing and can spot issues before submitting Form 8949. The primary mode is a single-file 1099-DA review — no tax software export is needed.

--- a/curve/curve-gauge-yield-trader/SKILL.md
+++ b/curve/curve-gauge-yield-trader/SKILL.md
@@ -5,6 +5,10 @@ description: "Multi-chain Curve gauge yield trading skill with paper-first defau
 
 # Curve Gauge Yield Trader
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - find the best curve gauge rewards

--- a/egeria/cmintro-loan/SKILL.md
+++ b/egeria/cmintro-loan/SKILL.md
@@ -6,6 +6,10 @@ license: Apache-2.0
 
 # Ovadiya Loan Qualification
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 This skill qualifies potential borrowers for non-recourse loans against publicly listed equities or crypto assets, or for institutional block trades, without revealing the lending partner (Ovadiya).
 
 ## When to Use

--- a/egeria/grant-intake/SKILL.md
+++ b/egeria/grant-intake/SKILL.md
@@ -6,6 +6,10 @@ license: Apache-2.0
 
 # Grant Intake
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Structured five-phase grant consultant intake to produce a Grant Readiness Summary and Organizational Profile.
 
 ## When to Use

--- a/egeria/lender-loan/SKILL.md
+++ b/egeria/lender-loan/SKILL.md
@@ -6,6 +6,10 @@ license: Apache-2.0
 
 # Lender Loan Qualification
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 This skill qualifies potential borrowers for non-recourse loans against publicly listed equities or crypto assets, or for institutional block trades, without revealing the lending partner.
 
 ## When to Use

--- a/kraken/1099-da-tax-reconciler/SKILL.md
+++ b/kraken/1099-da-tax-reconciler/SKILL.md
@@ -6,6 +6,10 @@ description: "Use when a user has a Form 1099-DA from Kraken and wants to review
 
 # Kraken 1099-DA Tax Reconciler
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## Overview
 
 This skill reviews and verifies Form 1099-DA from Kraken so users understand what they're filing and can spot issues before submitting Form 8949.

--- a/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
+++ b/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
@@ -5,6 +5,10 @@ description: "Reconcile CARF/DAC8 exchange-reported crypto transactions against 
 
 # CARF / DAC8 Crypto Asset Reporting
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Local-first reconciliation skill for OECD CARF and EU DAC8 reporting data.
 
 ## When to Use

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -5,6 +5,10 @@ description: "Automated grid trading bot for Kraken — profits from BTC volatil
 
 # Kraken Grid Trader
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Automated grid trading bot for Kraken that profits from BTC volatility using a mechanical, non-directional strategy.
 
 ## What This Skill Provides

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -5,6 +5,10 @@ description: "Kraken customer skill that converts user goals into a concrete Kra
 
 # Kraken Money Mode Router
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Route users to the best Kraken product flow fast.
 
 Use this skill when a user asks things like:

--- a/kraken/smart-dca-bot/SKILL.md
+++ b/kraken/smart-dca-bot/SKILL.md
@@ -5,6 +5,10 @@ description: "AI-optimized Kraken DCA bot with single-asset, portfolio, and scan
 
 # Kraken Smart DCA Bot
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 AI-assisted dollar-cost averaging (DCA) bot for Kraken with three modes:
 - `single_asset`
 - `portfolio`

--- a/ledger/ledger-signing/SKILL.md
+++ b/ledger/ledger-signing/SKILL.md
@@ -5,6 +5,10 @@ description: "Guide Ledger device owners through secure transaction and message 
 
 # Ledger Signing
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Direct USB/HID runtime execution for Ledger signing flows.
 
 ## When to Use

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -5,6 +5,10 @@ description: "Run a paired-market basis strategy on Polymarket with mandatory ba
 
 # High-Throughput Paired Basis Maker
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - trade relative-value dislocations between logically linked Polymarket contracts

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -5,6 +5,10 @@ description: "Run a liquidity-filtered paired-market basis strategy on Polymarke
 
 # Liquidity Paired Basis Maker
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - trade relative-value dislocations between logically linked Polymarket contracts

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -5,6 +5,10 @@ description: "Provide two-sided liquidity on Polymarket with rebate-aware quotin
 
 # Polymarket Maker Rebate Bot
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - run a fast 90-day backtest on Polymarket maker-rebate logic before trading

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -5,6 +5,10 @@ description: "Run a paired-market basis strategy on Polymarket with mandatory ba
 
 # Paired Market Basis Maker
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - trade relative-value dislocations between logically linked Polymarket contracts

--- a/seren/api/SKILL.md
+++ b/seren/api/SKILL.md
@@ -5,6 +5,10 @@ description: "Use Seren API directly for agent registration/authentication, acco
 
 # Seren API
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Use this skill whenever a user needs direct platform-level Seren API calls (not just one publisher).
 
 Canonical references:

--- a/seren/customer-support-intake/SKILL.md
+++ b/seren/customer-support-intake/SKILL.md
@@ -5,6 +5,10 @@ description: "Secure customer support evidence collection for SerenDesktop incid
 
 # Customer Support Intake
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - collect support logs for seren desktop

--- a/seren/getting-started/SKILL.md
+++ b/seren/getting-started/SKILL.md
@@ -5,6 +5,10 @@ description: "Learn how to use skills, add them to threads, invoke them, and cre
 
 # Getting Started with Skills
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## Overview
 Skills extend your agent's capabilities with specialized knowledge, workflows, and tool integrations. This guide will help you understand how to use skills effectively.
 

--- a/seren/seren-cloud/SKILL.md
+++ b/seren/seren-cloud/SKILL.md
@@ -5,6 +5,10 @@ description: "Deploy and operate hosted skills through the first-class seren-clo
 
 # Seren Cloud
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Use this skill when a user wants to deploy or run skills in Seren-managed cloud runtime.
 
 ## API

--- a/seren/seren-db/SKILL.md
+++ b/seren/seren-db/SKILL.md
@@ -5,6 +5,10 @@ description: "Create, manage, and query SerenDB databases through the first-clas
 
 # Seren DB
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Use this skill when a user wants to create, manage, or query SerenDB serverless Postgres databases.
 
 ## API

--- a/seren/seren-publishers/SKILL.md
+++ b/seren/seren-publishers/SKILL.md
@@ -5,6 +5,10 @@ description: "Search and discover Seren publishers — find the right tool for w
 
 # Seren Publishers
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Use this skill when a user wants to discover, evaluate, or call publishers from the Seren marketplace.
 
 ## API

--- a/seren/skill-creator/SKILL.md
+++ b/seren/skill-creator/SKILL.md
@@ -5,6 +5,10 @@ description: "Create or update skills that comply with the Agent Skills specific
 
 # Skill Creator
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 Use this skill to create new skills or modernize existing ones in this repository.
 
 ## When To Use

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -5,6 +5,10 @@ description: "Plan and evaluate Spectra PT yield trades using the Spectra MCP se
 
 # Spectra Pt Yield Trader
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## Workflow Summary
 
 1. `validate_inputs` validates chain, size, slippage, and safety caps.

--- a/wellsfargo/bank-statement-processing/SKILL.md
+++ b/wellsfargo/bank-statement-processing/SKILL.md
@@ -5,6 +5,10 @@ description: "Wells Fargo bank statement retrieval skill for Seren Desktop: runt
 
 # Wells Fargo Bank Statements
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When To Use
 
 - Download Wells Fargo monthly statements as PDFs.

--- a/wellsfargo/budget-tracker/SKILL.md
+++ b/wellsfargo/budget-tracker/SKILL.md
@@ -5,6 +5,10 @@ description: "Compare actual Wells Fargo spending against user-defined monthly b
 
 # Budget Tracker
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - compare budget vs actual spending

--- a/wellsfargo/cash-flow-statement/SKILL.md
+++ b/wellsfargo/cash-flow-statement/SKILL.md
@@ -5,6 +5,10 @@ description: "Generate operating, investing, and financing cash flow statements 
 
 # Wells Fargo Cash Flow Statement
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When To Use
 
 - Generate cash flow statements broken into Operating, Investing, and Financing activities.

--- a/wellsfargo/income-statement/SKILL.md
+++ b/wellsfargo/income-statement/SKILL.md
@@ -5,6 +5,10 @@ description: "Generate categorized income statements from Wells Fargo transactio
 
 # Wells Fargo Income Statement
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When To Use
 
 - Generate monthly or multi-month income statements from Wells Fargo transaction data.

--- a/wellsfargo/net-worth-tracker/SKILL.md
+++ b/wellsfargo/net-worth-tracker/SKILL.md
@@ -5,6 +5,10 @@ description: "Track account balances from Wells Fargo statement data with option
 
 # Net Worth Tracker
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - track my net worth over time

--- a/wellsfargo/recurring-transactions/SKILL.md
+++ b/wellsfargo/recurring-transactions/SKILL.md
@@ -5,6 +5,10 @@ description: "Detect and track recurring subscriptions, bills, and regular payme
 
 # Wells Fargo Recurring Transactions
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When To Use
 
 - Detect recurring subscriptions, bills, and regular payments from transaction history.

--- a/wellsfargo/tax-prep/SKILL.md
+++ b/wellsfargo/tax-prep/SKILL.md
@@ -5,6 +5,10 @@ description: "Map Wells Fargo transaction categories to IRS tax line items, calc
 
 # Tax Prep
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - prepare tax summary from wells fargo data

--- a/wellsfargo/vendor-analysis/SKILL.md
+++ b/wellsfargo/vendor-analysis/SKILL.md
@@ -5,6 +5,10 @@ description: "Group Wells Fargo transactions by normalized vendor name, rank by 
 
 # Vendor Analysis
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - analyze vendor spending

--- a/zkp2p/peer-to-peer-payments-exchange/SKILL.md
+++ b/zkp2p/peer-to-peer-payments-exchange/SKILL.md
@@ -5,6 +5,10 @@ description: "Route and execute peer-to-peer fiat-to-crypto payment and exchange
 
 # Peer To Peer Payments Exchange
 
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
 ## When to Use
 
 - exchange fiat and usdc peer to peer


### PR DESCRIPTION
## Summary
- add the standard `## For Claude: How to Use This Skill` section to all `SKILL.md` files that did not already have a `For Claude` section
- insert the section immediately after the first H1 in each updated file
- leave existing custom `For Claude` sections unchanged

## Scope
- 39 `SKILL.md` files updated
- 0 files left without a `For Claude` section

## Validation
- verified with ripgrep that every `SKILL.md` now contains a `For Claude` heading