### PR TITLE
fix(polymarket): inject held positions for SELL order generation

### DIFF
--- a/polymarket/_shared/polymarket_live.py
+++ b/polymarket/_shared/polymarket_live.py
@@ -1047,6 +1047,64 @@ class DirectClobTrader:
             return []
 
 
+def inject_held_position_markets(
+    *,
+    raw_positions: Any,
+    markets: list[dict[str, Any]],
+    default_rebate_bps: float = 0.0,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    """Inject markets for held positions missing from the discovery list.
+
+    Without this, the bot never generates SELL orders for tokens it already
+    owns because those markets are not in the quote cycle.
+    """
+    sizes = positions_by_key(raw_positions)
+    if not sizes:
+        return markets
+
+    existing_tokens: set[str] = set()
+    for market in markets:
+        existing_tokens.add(safe_str(market.get("token_id"), ""))
+        existing_tokens.add(safe_str(market.get("market_id"), ""))
+    existing_tokens.discard("")
+
+    injected: list[dict[str, Any]] = []
+    for token_id, shares in sizes.items():
+        if shares <= 0 or token_id in existing_tokens:
+            continue
+        try:
+            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+            best_bid = safe_float(book.get("best_bid"), 0.0)
+            best_ask = safe_float(book.get("best_ask"), 0.0)
+            if not (0.0 < best_bid <= 1.0 and 0.0 < best_ask <= 1.0):
+                continue
+            midpoint = fetch_midpoint(token_id, fallback_mid=(best_bid + best_ask) / 2.0, timeout_seconds=timeout_seconds)
+            injected.append(
+                {
+                    "market_id": token_id,
+                    "question": f"held-position:{token_id[:12]}",
+                    "token_id": token_id,
+                    "mid_price": round(midpoint, 4),
+                    "best_bid": round(best_bid, 4),
+                    "best_ask": round(best_ask, 4),
+                    "seconds_to_resolution": 999999,
+                    "volatility_bps": round(abs(best_ask - best_bid) * 10000.0, 3),
+                    "rebate_bps": default_rebate_bps,
+                    "tick_size": safe_str(book.get("tick_size"), "0.01"),
+                    "neg_risk": bool(book.get("neg_risk", False)),
+                    "source": "held-position-injection",
+                }
+            )
+            existing_tokens.add(token_id)
+        except Exception:
+            continue
+
+    if injected:
+        return list(markets) + injected
+    return markets
+
+
 def single_market_inventory_notional(
     *,
     raw_positions: Any,
@@ -1343,3 +1401,54 @@ def execute_pair_trades(
             markets=markets,
         ),
     }
+
+
+def sell_held_inventory(
+    *,
+    trader: PolymarketPublisherTrader,
+    raw_positions: Any,
+    covered_token_ids: set[str],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    """Sell any held tokens not already covered by the main execution pass.
+
+    Pair bots may leave individual legs unsold because they only trade in
+    pairs.  This function generates SELL-only orders to unwind those positions.
+    """
+    sizes = positions_by_key(raw_positions)
+    sells: list[dict[str, Any]] = []
+    for token_id, shares in sizes.items():
+        if shares <= 0 or token_id in covered_token_ids:
+            continue
+        try:
+            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+            ask_price = safe_float(book.get("best_ask"), 0.0)
+            tick_size = safe_str(book.get("tick_size"), "0.01")
+            neg_risk = bool(book.get("neg_risk", False))
+            if ask_price <= 0.0:
+                continue
+            ask_price = snap_price(ask_price, tick_size, "SELL")
+            size = shares
+            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            response = trader.create_order(
+                token_id=token_id,
+                side="SELL",
+                price=ask_price,
+                size=size,
+                tick_size=tick_size,
+                neg_risk=neg_risk,
+                fee_rate_bps=fee_rate_bps,
+            )
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "price": ask_price,
+                    "size": round(size, 6),
+                    "source": "held-inventory-unwind",
+                    "response": response,
+                }
+            )
+        except Exception:
+            continue
+    return sells

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -29,6 +29,7 @@ from polymarket_live import (
     live_settings_from_execution,
     load_live_pair_markets,
     pair_leg_exposure_notional,
+    sell_held_inventory,
 )
 from pair_stateful_replay import (
     PairReplayParams,
@@ -1355,6 +1356,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
 
     exposure = config.get("state", {}).get("leg_exposure", {})
     leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    raw_positions: Any = []
     live_trader: DirectClobTrader | None = None
     if live_mode:
         try:
@@ -1362,8 +1364,9 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
                 skill_root=Path(__file__).resolve().parents[1],
                 client_name="high-throughput-paired-basis-maker",
             )
+            raw_positions = live_trader.get_positions()
             leg_exposure = pair_leg_exposure_notional(
-                raw_positions=live_trader.get_positions(),
+                raw_positions=raw_positions,
                 markets=markets,
             )
         except Exception as exc:
@@ -1432,6 +1435,20 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
         payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
         payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+        covered_tokens = {
+            _safe_str(o.get("token_id"), "")
+            for o in live_execution.get("orders_submitted", [])
+            if _safe_str(o.get("side"), "") == "SELL"
+        }
+        covered_tokens.discard("")
+        unwind_sells = sell_held_inventory(
+            trader=live_trader,
+            raw_positions=raw_positions,
+            covered_token_ids=covered_tokens,
+        )
+        if unwind_sells:
+            payload["live_execution"]["held_inventory_unwinds"] = unwind_sells
+            payload["strategy_summary"]["held_inventory_sells"] = len(unwind_sells)
     return payload
 
 

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -29,6 +29,7 @@ from polymarket_live import (
     live_settings_from_execution,
     load_live_pair_markets,
     pair_leg_exposure_notional,
+    sell_held_inventory,
 )
 from pair_stateful_replay import (
     PairReplayParams,
@@ -1417,6 +1418,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
 
     exposure = config.get("state", {}).get("leg_exposure", {})
     leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    raw_positions: Any = []
     live_trader: DirectClobTrader | None = None
     if live_mode:
         try:
@@ -1424,8 +1426,9 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
                 skill_root=Path(__file__).resolve().parents[1],
                 client_name="liquidity-paired-basis-maker",
             )
+            raw_positions = live_trader.get_positions()
             leg_exposure = pair_leg_exposure_notional(
-                raw_positions=live_trader.get_positions(),
+                raw_positions=raw_positions,
                 markets=markets,
             )
         except Exception as exc:
@@ -1494,6 +1497,20 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
         payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
         payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+        covered_tokens = {
+            _safe_str(o.get("token_id"), "")
+            for o in live_execution.get("orders_submitted", [])
+            if _safe_str(o.get("side"), "") == "SELL"
+        }
+        covered_tokens.discard("")
+        unwind_sells = sell_held_inventory(
+            trader=live_trader,
+            raw_positions=raw_positions,
+            covered_token_ids=covered_tokens,
+        )
+        if unwind_sells:
+            payload["live_execution"]["held_inventory_unwinds"] = unwind_sells
+            payload["strategy_summary"]["held_inventory_sells"] = len(unwind_sells)
     return payload
 
 

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -24,6 +24,7 @@ if str(SHARED_DIR) not in sys.path:
 from polymarket_live import (
     DirectClobTrader,
     execute_single_market_quotes,
+    inject_held_position_markets,
     live_settings_from_execution,
     load_live_single_markets,
     single_market_inventory_notional,
@@ -1619,8 +1620,14 @@ def run_once(
                 skill_root=Path(__file__).resolve().parents[1],
                 client_name="polymarket-maker-rebate-bot",
             )
+            raw_positions = live_trader.get_positions()
+            markets = inject_held_position_markets(
+                raw_positions=raw_positions,
+                markets=markets,
+                default_rebate_bps=params.default_rebate_bps,
+            )
             inventory_notional_by_market = single_market_inventory_notional(
-                raw_positions=live_trader.get_positions(),
+                raw_positions=raw_positions,
                 markets=markets,
             )
         except Exception as exc:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -29,6 +29,7 @@ from polymarket_live import (
     live_settings_from_execution,
     load_live_pair_markets,
     pair_leg_exposure_notional,
+    sell_held_inventory,
 )
 from pair_stateful_replay import (
     PairReplayParams,
@@ -1355,6 +1356,7 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
 
     exposure = config.get("state", {}).get("leg_exposure", {})
     leg_exposure = {str(k): _safe_float(v, 0.0) for k, v in exposure.items()}
+    raw_positions: Any = []
     live_trader: DirectClobTrader | None = None
     if live_mode:
         try:
@@ -1362,8 +1364,9 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
                 skill_root=Path(__file__).resolve().parents[1],
                 client_name="paired-market-basis-maker",
             )
+            raw_positions = live_trader.get_positions()
             leg_exposure = pair_leg_exposure_notional(
-                raw_positions=live_trader.get_positions(),
+                raw_positions=raw_positions,
                 markets=markets,
             )
         except Exception as exc:
@@ -1432,6 +1435,20 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
         payload["state"] = {"leg_exposure": live_execution.get("updated_leg_exposure", {})}
         payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
         payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+        covered_tokens = {
+            _safe_str(o.get("token_id"), "")
+            for o in live_execution.get("orders_submitted", [])
+            if _safe_str(o.get("side"), "") == "SELL"
+        }
+        covered_tokens.discard("")
+        unwind_sells = sell_held_inventory(
+            trader=live_trader,
+            raw_positions=raw_positions,
+            covered_token_ids=covered_tokens,
+        )
+        if unwind_sells:
+            payload["live_execution"]["held_inventory_unwinds"] = unwind_sells
+            payload["strategy_summary"]["held_inventory_sells"] = len(unwind_sells)
     return payload
 
 


### PR DESCRIPTION
## Summary

Fixes #83 — All Polymarket bots only generated BUY orders and never SELLs, causing one-directional inventory accumulation until USDC balance depletion.

- **Root cause**: Market discovery fetches NEW markets where the bot has no existing inventory. SELL orders require `available_shares > 0`, which is always 0 for newly-discovered markets. Markets where the bot already holds tokens from previous BUYs are never included in the quote cycle.
- **Shared lib**: Added `inject_held_position_markets()` to merge held-token markets into the discovery list, and `sell_held_inventory()` for pair bots to unwind individual held legs
- **maker-rebate-bot**: Injects held positions into market list before quoting so both BUY and SELL quotes are generated
- **3 pair bots** (high-throughput, liquidity, paired-market): After `execute_pair_trades`, runs `sell_held_inventory()` to unwind positions not covered by pair trades

## Affected Bots
- `polymarket/maker-rebate-bot` (single market)
- `polymarket/high-throughput-paired-basis-maker` (pair)
- `polymarket/liquidity-paired-basis-maker` (pair)
- `polymarket/paired-market-basis-maker` (pair)

## Test plan
- [ ] Verify maker-rebate-bot generates SELL orders for previously-bought positions in dry-run mode
- [ ] Verify JSONL logs show "held-position-injection" source for injected markets
- [ ] Verify pair bots emit "held_inventory_unwinds" in live_execution output
- [ ] Confirm bot no longer depletes USDC without generating offsetting sells

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com