### PR TITLE
fix(polymarket): unwrap Seren gateway response envelope

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -444,6 +444,13 @@ def _parse_iso_ts(value: Any) -> int | None:
         return None
 
 
+def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Unwrap Seren gateway response envelope {status, body, ...} -> body."""
+    if isinstance(data, dict) and "body" in data and "status" in data:
+        return data["body"]
+    return data
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
     if not any(url.startswith(prefix) for prefix in SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES):
         raise ValueError(
@@ -462,7 +469,8 @@ def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _align_histories(primary: list[tuple[int, float]], secondary: list[tuple[int, float]]) -> tuple[list[tuple[int, float]], list[tuple[int, float]]]:

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -505,6 +505,13 @@ def _runtime_api_key() -> str:
     return ""
 
 
+def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Unwrap Seren gateway response envelope {status, body, ...} -> body."""
+    if isinstance(data, dict) and "body" in data and "status" in data:
+        return data["body"]
+    return data
+
+
 def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
     req = Request(
         url,
@@ -515,7 +522,8 @@ def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dic
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -630,6 +630,13 @@ def _runtime_api_key() -> str:
     return ""
 
 
+def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Unwrap Seren gateway response envelope {status, body, ...} -> body."""
+    if isinstance(data, dict) and "body" in data and "status" in data:
+        return data["body"]
+    return data
+
+
 def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
     request = Request(
         url,
@@ -640,7 +647,8 @@ def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dic
         },
     )
     with urlopen(request, timeout=timeout) as response:
-        return json.loads(response.read().decode("utf-8"))
+        raw = json.loads(response.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -444,6 +444,13 @@ def _parse_iso_ts(value: Any) -> int | None:
         return None
 
 
+def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Unwrap Seren gateway response envelope {status, body, ...} -> body."""
+    if isinstance(data, dict) and "body" in data and "status" in data:
+        return data["body"]
+    return data
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
     if not any(url.startswith(prefix) for prefix in SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES):
         raise ValueError(
@@ -462,7 +469,8 @@ def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _align_histories(primary: list[tuple[int, float]], secondary: list[tuple[int, float]]) -> tuple[list[tuple[int, float]], list[tuple[int, float]]]:


### PR DESCRIPTION
## Summary
- Seren publisher API wraps all responses in `{status, body, ...}` envelope but `_http_get_json` returned the raw envelope
- Callers like `_fetch_live_markets` checked `isinstance(raw, list)` which always failed on the dict envelope, causing backtests to find zero markets
- Added `_unwrap_seren_response()` helper to extract the `body` payload before returning from `_http_get_json` / `_http_get_json_via_api_key`

**Affected skills (all 4 patched):**
- `polymarket/maker-rebate-bot`
- `polymarket/paired-market-basis-maker`
- `polymarket/liquidity-paired-basis-maker`
- `polymarket/high-throughput-paired-basis-maker`

Closes #86

## Test plan
- [ ] Run `--run-type backtest --backtest-days 90` on maker-rebate-bot and verify markets are now found
- [ ] Verify `_unwrap_seren_response` passes through non-envelope responses unchanged
- [ ] Verify history normalization still works (it already handled the body wrapper independently)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com