### PR TITLE
fix(polymarket): remove dead polymarket-trading-serenai publisher

### DIFF
--- a/polymarket/_shared/polymarket_live.py
+++ b/polymarket/_shared/polymarket_live.py
@@ -18,14 +18,11 @@ from urllib.request import Request, urlopen
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
-SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
 SEREN_API_BASE = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}"
 SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"{SEREN_API_BASE}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
-SEREN_POLYMARKET_TRADING_URL_PREFIX = (
-    f"{SEREN_API_BASE}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
-)
+POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
 
@@ -476,13 +473,20 @@ def call_publisher_json(
         return json.loads(text)
 
 
-def fetch_trading_json(path: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
-    return call_publisher_json(
-        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-        method="GET",
-        path=path,
-        timeout_seconds=timeout_seconds,
+def _call_clob_json(path: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    request = Request(
+        f"{POLYMARKET_CLOB_BASE_URL}{path}",
+        headers={"Accept": "application/json", "User-Agent": "seren-polymarket-live/1.0"},
     )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
+def fetch_trading_json(path: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    return _call_clob_json(path=path, timeout_seconds=timeout_seconds)
 
 
 def fetch_markets_page(
@@ -524,9 +528,7 @@ def fetch_history(
             "fidelity": max(1, fidelity_minutes),
         }
     )
-    payload = call_publisher_json(
-        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-        method="GET",
+    payload = _call_clob_json(
         path=f"/prices-history?{query}",
         timeout_seconds=timeout_seconds,
     )
@@ -536,9 +538,7 @@ def fetch_history(
 
 
 def fetch_book(token_id: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
-    payload = call_publisher_json(
-        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-        method="GET",
+    payload = _call_clob_json(
         path=f"/book?{urlencode({'token_id': token_id})}",
         timeout_seconds=timeout_seconds,
     )
@@ -546,9 +546,7 @@ def fetch_book(token_id: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) 
 
 
 def fetch_midpoint(token_id: str, fallback_mid: float, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> float:
-    payload = call_publisher_json(
-        publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-        method="GET",
+    payload = _call_clob_json(
         path=f"/midpoint?{urlencode({'token_id': token_id})}",
         timeout_seconds=timeout_seconds,
     )
@@ -557,9 +555,7 @@ def fetch_midpoint(token_id: str, fallback_mid: float, timeout_seconds: float = 
 
 def fetch_fee_rate_bps(token_id: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> int:
     try:
-        payload = call_publisher_json(
-            publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-            method="GET",
+        payload = _call_clob_json(
             path=f"/fee-rate?{urlencode({'token_id': token_id})}",
             timeout_seconds=timeout_seconds,
         )
@@ -895,14 +891,26 @@ class PolymarketPublisherTrader:
         )
 
     def _call(self, method: str, path: str, body: Any = None) -> Any:
-        return call_publisher_json(
-            publisher=SEREN_POLYMARKET_TRADING_PUBLISHER,
-            method=method,
-            path=path,
-            headers=self._signed_headers(method, path, body=body),
-            body=body,
-            timeout_seconds=self.timeout_seconds,
+        req_headers = {
+            "Accept": "application/json",
+            "User-Agent": "seren-polymarket-live/1.0",
+        }
+        req_headers.update(self._signed_headers(method, path, body=body))
+        data = None
+        if body is not None:
+            req_headers["Content-Type"] = "application/json"
+            data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        request = Request(
+            f"{POLYMARKET_CLOB_BASE_URL}{path}",
+            headers=req_headers,
+            method=method.upper(),
+            data=data,
         )
+        with urlopen(request, timeout=self.timeout_seconds) as response:
+            text = response.read().decode("utf-8")
+            if not text:
+                return {}
+            return json.loads(text)
 
     def next_nonce(self) -> int:
         self._nonce += 1

--- a/polymarket/bot/.env.example
+++ b/polymarket/bot/.env.example
@@ -7,8 +7,8 @@ SEREN_API_KEY=your_seren_api_key_here
 # No POLY_* vars are required in this mode.
 SEREN_DESKTOP_PUBLISHER_AUTH=true
 
-# Optional publisher slug override (default tries sidecar slug first, then legacy fallback)
-# POLYMARKET_TRADING_PUBLISHERS=polymarket-trading,polymarket-trading-serenai
+# Optional publisher slug override (default: polymarket-trading)
+# POLYMARKET_TRADING_PUBLISHERS=polymarket-trading
 
 # Legacy direct header mode (optional fallback)
 # Set SEREN_DESKTOP_PUBLISHER_AUTH=false to force this mode.

--- a/polymarket/bot/IMPLEMENTATION_STATUS.md
+++ b/polymarket/bot/IMPLEMENTATION_STATUS.md
@@ -71,7 +71,7 @@
 **Status:** Fully implemented with sidecar-first publisher routing and legacy fallback
 
 **What was added:**
-- Order placement via sidecar slug (`polymarket-trading`) with fallback to `polymarket-trading-serenai`
+- Order placement via sidecar slug (`polymarket-trading`)
 - EIP-712 signing handled server-side by the publisher
 - Simplified client-side code (no cryptography needed)
 - Supports desktop keychain auth by default, legacy `POLY_*` headers as fallback

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -174,7 +174,7 @@ This skill helps users set up and manage an autonomous trading agent that:
   - Response includes: market IDs, questions, token IDs, prices, liquidity
   - Verified working with 100+ markets returned
 
-- `polymarket-trading` (preferred) / `polymarket-trading-serenai` (fallback) - Polymarket CLOB trading API
+- `polymarket-trading` - Polymarket CLOB trading API
   - Place/cancel orders with server-side EIP-712 signing
   - Query positions, open orders, balances
   - Desktop mode: uses keychain-backed publisher credentials
@@ -867,7 +867,7 @@ def calculate_position_size(fair_value, market_price, bankroll, max_kelly=0.06):
 
 **Seren Publishers Used:**
 - `polymarket-data` - Real-time market data (prices, liquidity, volumes)
-- `polymarket-trading` (preferred) / `polymarket-trading-serenai` (fallback) - Order placement with server-side signing
+- `polymarket-trading` - Order placement with server-side signing
 - `perplexity` - AI-powered market research
 - `seren-models` - LLM inference (Claude, GPT, Gemini, etc.)
 - `seren-cron` - Autonomous job scheduling

--- a/polymarket/bot/requirements.txt
+++ b/polymarket/bot/requirements.txt
@@ -2,7 +2,7 @@
 #
 # This skill uses Seren publishers for all Polymarket operations:
 # - polymarket-data: Market data (prices, volume, liquidity)
-# - polymarket-trading / polymarket-trading-serenai: Trading operations
+# - polymarket-trading: Trading operations
 
 # Core dependencies
 requests>=2.31.0

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -71,8 +71,7 @@ class PolymarketClient:
                 slug.strip() for slug in publishers_env.split(',') if slug.strip()
             ]
         else:
-            # Sidecar-native slug first, legacy slug second.
-            self.trading_publishers = ['polymarket-trading', 'polymarket-trading-serenai']
+            self.trading_publishers = ['polymarket-trading']
 
     def _get_auth_headers(self) -> Dict[str, str]:
         """Get authentication headers for Polymarket API"""

--- a/polymarket/bot/scripts/seren_client.py
+++ b/polymarket/bot/scripts/seren_client.py
@@ -2,7 +2,7 @@
 Seren Client - HTTP client for calling Seren MCP publishers
 
 Handles authentication and routing to Seren publishers:
-- polymarket-trading / polymarket-trading-serenai (trading)
+- polymarket-trading (trading)
 - perplexity (AI-powered research)
 - seren-models (LLM inference)
 - seren-cron (job scheduling)

--- a/polymarket/bot/scripts/test_polymarket_client_auth.py
+++ b/polymarket/bot/scripts/test_polymarket_client_auth.py
@@ -56,21 +56,16 @@ class TestPolymarketClientAuthMode:
 
 
 class TestPolymarketClientTradingFallback:
-    def test_falls_back_to_legacy_slug_on_404(self):
+    def test_raises_on_404_without_fallback(self):
         seren = _mock_seren()
-        seren.call_publisher.side_effect = [
-            Exception("Publisher call failed: 404 - not found"),
-            {'data': []},
-        ]
+        seren.call_publisher.side_effect = Exception("Publisher call failed: 404 - not found")
         client = PolymarketClient(seren_client=seren)
 
-        result = client._call_trading(method='GET', path='/positions')
-        assert result == {'data': []}
-        assert seren.call_publisher.call_count == 2
+        with pytest.raises(Exception, match=r"404"):
+            client._call_trading(method='GET', path='/positions')
+        assert seren.call_publisher.call_count == 1
         first_call = seren.call_publisher.call_args_list[0].kwargs
-        second_call = seren.call_publisher.call_args_list[1].kwargs
         assert first_call['publisher'] == 'polymarket-trading'
-        assert second_call['publisher'] == 'polymarket-trading-serenai'
 
     def test_desktop_auth_unauthorized_raises_helpful_error(self):
         seren = _mock_seren()

--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -33,7 +33,7 @@
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 12,
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
-    "clob_history_url": "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    "clob_history_url": "https://clob.polymarket.com/prices-history"
   },
   "strategy": {
     "bankroll_usd": 1000,

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -47,10 +47,9 @@ DISCLAIMER = (
 )
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
-SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-trading-serenai/"
+POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES = (
     SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX,
-    SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX,
 )
 MISSING_RUNTIME_AUTH_ERROR = (
     "missing_runtime_auth: set API_KEY (Seren Desktop runtime) or SEREN_API_KEY; "
@@ -98,7 +97,7 @@ class BacktestParams:
     history_interval: str = "max"
     history_fidelity_minutes: int = 60
     gamma_markets_url: str = "https://api.serendb.com/publishers/polymarket-data/markets"
-    clob_history_url: str = "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 12
 
 
@@ -149,8 +148,8 @@ def _safe_str(value: Any, default: str = "") -> str:
 
 def _canonicalize_history_url(url: str) -> str:
     trimmed = url.rstrip("/")
-    if trimmed.endswith("/prices-history"):
-        return trimmed[: -len("/prices-history")] + "/trades"
+    if trimmed.endswith("/trades"):
+        return trimmed[: -len("/trades")] + "/prices-history"
     return url
 
 
@@ -252,7 +251,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fidelity_minutes=max(1, _safe_int(raw.get("history_fidelity_minutes"), 60)),
         gamma_markets_url=_safe_str(raw.get("gamma_markets_url"), "https://api.serendb.com/publishers/polymarket-data/markets"),
         clob_history_url=_canonicalize_history_url(
-            _safe_str(raw.get("clob_history_url"), "https://api.serendb.com/publishers/polymarket-trading-serenai/trades")
+            _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
     )
@@ -451,7 +450,26 @@ def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] |
     return data
 
 
+def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    req = Request(
+        url,
+        headers={
+            "User-Agent": "high-throughput-paired-basis-maker/1.1",
+            "Accept": "application/json",
+        },
+    )
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _is_clob_direct_url(url: str) -> bool:
+    return url.startswith(f"{POLYMARKET_CLOB_BASE_URL}/")
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    if _is_clob_direct_url(url):
+        return _http_get_json_public(url, timeout=timeout)
+
     if not any(url.startswith(prefix) for prefix in SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES):
         raise ValueError(
             "policy_violation: backtest data source must use Seren Polymarket publisher "
@@ -589,8 +607,8 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
         if len(history) < bt.min_history_points:
             return None
         try:
-            book_payload = _http_get_json(
-                f"{SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX}book?{urlencode({'token_id': candidate['token_id']})}"
+            book_payload = _http_get_json_public(
+                f"{POLYMARKET_CLOB_BASE_URL}/book?{urlencode({'token_id': candidate['token_id']})}"
             )
         except Exception:
             book_payload = None

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -33,7 +33,7 @@
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 4,
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
-    "clob_history_url": "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    "clob_history_url": "https://clob.polymarket.com/prices-history"
   },
   "strategy": {
     "bankroll_usd": 1000,

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -43,15 +43,12 @@ SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
 SEREN_POLYMARKET_PUBLISHER_PREFIX = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}"
 SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
-SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
 SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
-SEREN_POLYMARKET_TRADING_URL_PREFIX = (
-    f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
-)
+POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_ALLOWED_POLYMARKET_PUBLISHERS = frozenset(
-    {SEREN_POLYMARKET_DATA_PUBLISHER, SEREN_POLYMARKET_TRADING_PUBLISHER}
+    {SEREN_POLYMARKET_DATA_PUBLISHER}
 )
 POLICY_VIOLATION_BACKTEST_SOURCE = "policy_violation: backtest data source must use Seren Polymarket publisher"
 MISSING_RUNTIME_AUTH_ERROR = (
@@ -107,7 +104,7 @@ class BacktestParams:
     history_interval: str = "max"
     history_fidelity_minutes: int = 60
     gamma_markets_url: str = f"{SEREN_POLYMARKET_DATA_URL_PREFIX}/markets"
-    clob_history_url: str = f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/trades"
+    clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 4
 
 
@@ -158,8 +155,8 @@ def _safe_str(value: Any, default: str = "") -> str:
 
 def _canonicalize_history_url(url: str) -> str:
     parsed = urlparse(url)
-    if parsed.path.endswith("/prices-history"):
-        path = parsed.path[: -len("/prices-history")] + "/trades"
+    if parsed.path.endswith("/trades"):
+        path = parsed.path[: -len("/trades")] + "/prices-history"
         return urlunparse(parsed._replace(path=path))
     return url
 
@@ -262,7 +259,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fidelity_minutes=max(1, _safe_int(raw.get("history_fidelity_minutes"), 60)),
         gamma_markets_url=_safe_str(raw.get("gamma_markets_url"), f"{SEREN_POLYMARKET_DATA_URL_PREFIX}/markets"),
         clob_history_url=_canonicalize_history_url(
-            _safe_str(raw.get("clob_history_url"), f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/trades")
+            _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 4)),
     )
@@ -469,6 +466,11 @@ def _parse_iso_ts(value: Any) -> int | None:
         return None
 
 
+def _is_clob_direct_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and parsed.netloc == "clob.polymarket.com"
+
+
 def _seren_publisher_target(url: str) -> tuple[str, str]:
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.netloc != SEREN_POLYMARKET_PUBLISHER_HOST:
@@ -481,7 +483,7 @@ def _seren_publisher_target(url: str) -> tuple[str, str]:
         raise ValueError(
             f"{POLICY_VIOLATION_BACKTEST_SOURCE}. "
             "Backtest URL must use a supported Seren Polymarket Publisher URL prefix "
-            f"('{SEREN_POLYMARKET_DATA_URL_PREFIX}/...' or '{SEREN_POLYMARKET_TRADING_URL_PREFIX}/...')."
+            f"('{SEREN_POLYMARKET_DATA_URL_PREFIX}/...')."
         )
     path_without_prefix = parsed.path[len(SEREN_PUBLISHERS_PREFIX) :]
     publisher_slug, _, remainder = path_without_prefix.partition("/")
@@ -526,7 +528,22 @@ def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dic
         return _unwrap_seren_response(raw)
 
 
+def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    req = Request(
+        url,
+        headers={
+            "User-Agent": "liquidity-paired-basis-maker/1.1",
+            "Accept": "application/json",
+        },
+    )
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    if _is_clob_direct_url(url):
+        return _http_get_json_public(url, timeout=timeout)
+
     _seren_publisher_target(url)
 
     api_key = _runtime_api_key()
@@ -651,8 +668,8 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
         if len(history) < bt.min_history_points:
             return None
         try:
-            book_payload = _http_get_json(
-                f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/book?{urlencode({'token_id': candidate['token_id']})}"
+            book_payload = _http_get_json_public(
+                f"{POLYMARKET_CLOB_BASE_URL}/book?{urlencode({'token_id': candidate['token_id']})}"
             )
         except Exception:
             book_payload = None

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -24,7 +24,7 @@
     "synthetic_orderbook_depth_usd": 125,
     "telemetry_path": "logs/polymarket-maker-rebate-backtest-telemetry.jsonl",
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
-    "clob_history_url": "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    "clob_history_url": "https://clob.polymarket.com/prices-history"
   },
   "strategy": {
     "bankroll_usd": 1000,

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -34,15 +34,12 @@ SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
 SEREN_POLYMARKET_PUBLISHER_PREFIX = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}"
 SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
-SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
 SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
-SEREN_POLYMARKET_TRADING_URL_PREFIX = (
-    f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
-)
+POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_ALLOWED_POLYMARKET_PUBLISHERS = frozenset(
-    {SEREN_POLYMARKET_DATA_PUBLISHER, SEREN_POLYMARKET_TRADING_PUBLISHER}
+    {SEREN_POLYMARKET_DATA_PUBLISHER}
 )
 POLICY_VIOLATION_BACKTEST_SOURCE = "policy_violation: backtest data source must use Seren Polymarket publisher"
 MISSING_RUNTIME_AUTH_ERROR = (
@@ -87,7 +84,7 @@ class BacktestParams:
     synthetic_orderbook_depth_usd: float = 125.0
     telemetry_path: str = "logs/polymarket-maker-rebate-backtest-telemetry.jsonl"
     gamma_markets_url: str = f"{SEREN_POLYMARKET_DATA_URL_PREFIX}/markets"
-    clob_history_url: str = f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/trades"
+    clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
 
 
 @dataclass(frozen=True)
@@ -252,8 +249,8 @@ def _extract_live_book(payload: dict[str, Any], mid_price: float) -> tuple[float
 
 def _canonicalize_history_url(url: str) -> str:
     parsed = urlparse(url)
-    if parsed.path.endswith("/prices-history"):
-        path = parsed.path[: -len("/prices-history")] + "/trades"
+    if parsed.path.endswith("/trades"):
+        path = parsed.path[: -len("/trades")] + "/prices-history"
         return urlunparse(parsed._replace(path=path))
     return url
 
@@ -327,7 +324,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         clob_history_url=_canonicalize_history_url(
             _safe_str(
                 backtest.get("clob_history_url"),
-                f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/trades",
+                f"{POLYMARKET_CLOB_BASE_URL}/prices-history",
             )
         ),
     )
@@ -594,6 +591,11 @@ def _history_point_from_row(row: Any, token_id: str) -> tuple[int, float] | None
     return ts, p
 
 
+def _is_clob_direct_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and parsed.netloc == "clob.polymarket.com"
+
+
 def _seren_publisher_target(url: str) -> tuple[str, str]:
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.netloc != SEREN_POLYMARKET_PUBLISHER_HOST:
@@ -606,7 +608,7 @@ def _seren_publisher_target(url: str) -> tuple[str, str]:
         raise ValueError(
             f"{POLICY_VIOLATION_BACKTEST_SOURCE}. "
             "Backtest URL must use a supported Seren Polymarket Publisher URL prefix "
-            f"('{SEREN_POLYMARKET_DATA_URL_PREFIX}/...' or '{SEREN_POLYMARKET_TRADING_URL_PREFIX}/...')."
+            f"('{SEREN_POLYMARKET_DATA_URL_PREFIX}/...')."
         )
     path_without_prefix = parsed.path[len(SEREN_PUBLISHERS_PREFIX) :]
     publisher_slug, _, remainder = path_without_prefix.partition("/")
@@ -651,7 +653,22 @@ def _http_get_json_via_api_key(url: str, api_key: str, timeout: int = 30) -> dic
         return _unwrap_seren_response(raw)
 
 
+def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    request = Request(
+        url,
+        headers={
+            "User-Agent": "seren-maker-rebate-bot/1.0",
+            "Accept": "application/json",
+        },
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    if _is_clob_direct_url(url):
+        return _http_get_json_public(url, timeout=timeout)
+
     _seren_publisher_target(url)
 
     api_key = _runtime_api_key()
@@ -893,8 +910,8 @@ def _fetch_live_markets(
         if len(history) < backtest_params.min_history_points:
             continue
         try:
-            book_payload = _http_get_json(
-                f"{SEREN_POLYMARKET_TRADING_URL_PREFIX}/book?{urlencode({'token_id': candidate['token_id']})}"
+            book_payload = _http_get_json_public(
+                f"{POLYMARKET_CLOB_BASE_URL}/book?{urlencode({'token_id': candidate['token_id']})}"
             )
         except Exception:
             book_payload = None

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -284,14 +284,14 @@ def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
         "https://api.serendb.com/publishers/polymarket-data/"
     )
     assert backtest.get("clob_history_url", "").startswith(
-        "https://api.serendb.com/publishers/polymarket-trading-serenai/"
+        "https://clob.polymarket.com/"
     )
-    assert backtest.get("clob_history_url", "").endswith("/trades")
+    assert backtest.get("clob_history_url", "").endswith("/prices-history")
 
 
 def test_backtest_rejects_non_seren_polymarket_data_source(tmp_path: Path) -> None:
     bad_gamma_url = "https://gamma" + "-api." + "polymarket.com/markets"
-    bad_clob_url = "https://clob." + "polymarket.com/prices-history"
+    bad_clob_url = "https://evil." + "example.com/prices-history"
     payload = {
         "execution": {"dry_run": True, "live_mode": False},
         "backtest": {

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -33,7 +33,7 @@
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 12,
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
-    "clob_history_url": "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    "clob_history_url": "https://clob.polymarket.com/prices-history"
   },
   "strategy": {
     "bankroll_usd": 1000,

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -47,10 +47,9 @@ DISCLAIMER = (
 )
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
-SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-trading-serenai/"
+POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES = (
     SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX,
-    SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX,
 )
 MISSING_RUNTIME_AUTH_ERROR = (
     "missing_runtime_auth: set API_KEY (Seren Desktop runtime) or SEREN_API_KEY; "
@@ -98,7 +97,7 @@ class BacktestParams:
     history_interval: str = "max"
     history_fidelity_minutes: int = 60
     gamma_markets_url: str = "https://api.serendb.com/publishers/polymarket-data/markets"
-    clob_history_url: str = "https://api.serendb.com/publishers/polymarket-trading-serenai/trades"
+    clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 12
 
 
@@ -149,8 +148,8 @@ def _safe_str(value: Any, default: str = "") -> str:
 
 def _canonicalize_history_url(url: str) -> str:
     trimmed = url.rstrip("/")
-    if trimmed.endswith("/prices-history"):
-        return trimmed[: -len("/prices-history")] + "/trades"
+    if trimmed.endswith("/trades"):
+        return trimmed[: -len("/trades")] + "/prices-history"
     return url
 
 
@@ -252,7 +251,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fidelity_minutes=max(1, _safe_int(raw.get("history_fidelity_minutes"), 60)),
         gamma_markets_url=_safe_str(raw.get("gamma_markets_url"), "https://api.serendb.com/publishers/polymarket-data/markets"),
         clob_history_url=_canonicalize_history_url(
-            _safe_str(raw.get("clob_history_url"), "https://api.serendb.com/publishers/polymarket-trading-serenai/trades")
+            _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
     )
@@ -451,7 +450,26 @@ def _unwrap_seren_response(data: dict[str, Any] | list[Any]) -> dict[str, Any] |
     return data
 
 
+def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    req = Request(
+        url,
+        headers={
+            "User-Agent": "paired-market-basis-maker/1.1",
+            "Accept": "application/json",
+        },
+    )
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _is_clob_direct_url(url: str) -> bool:
+    return url.startswith(f"{POLYMARKET_CLOB_BASE_URL}/")
+
+
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:
+    if _is_clob_direct_url(url):
+        return _http_get_json_public(url, timeout=timeout)
+
     if not any(url.startswith(prefix) for prefix in SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES):
         raise ValueError(
             "policy_violation: backtest data source must use Seren Polymarket publisher "
@@ -590,7 +608,7 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
             return None
         try:
             book_payload = _http_get_json(
-                f"{SEREN_POLYMARKET_TRADING_PUBLISHER_PREFIX}book?{urlencode({'token_id': candidate['token_id']})}"
+                f"{POLYMARKET_CLOB_BASE_URL}/book?{urlencode({'token_id': candidate['token_id']})}"
             )
         except Exception:
             book_payload = None


### PR DESCRIPTION
## Summary
- Removes all references to the deleted `polymarket-trading-serenai` Seren publisher across all 4 Polymarket backtest skills, shared module, bot skill, configs, tests, and docs (17 files)
- Trading data (price history, order book, midpoint) now calls `clob.polymarket.com` directly via public unauthenticated endpoints
- Fixes `_canonicalize_history_url` which was converting `/prices-history` → `/trades` (backwards) — now correctly normalizes legacy `/trades` URLs to `/prices-history`
- Market discovery continues through the `polymarket-data` Seren publisher as before

## Test plan
- [ ] Run maker-rebate-bot backtest and verify markets are found (was failing with `no_backtest_markets`)
- [ ] Run `pytest polymarket/maker-rebate-bot/tests/test_smoke.py` — updated assertions for new CLOB URL defaults
- [ ] Run `pytest polymarket/bot/scripts/test_polymarket_client_auth.py` — updated fallback test since legacy slug is removed
- [ ] Verify `clob.polymarket.com/prices-history` returns data with `?market=TOKEN_ID&interval=max&fidelity=60`
- [ ] Verify `clob.polymarket.com/book` returns orderbook data with `?token_id=TOKEN_ID`

Closes #88

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com