### PR TITLE
fix(backtest): allocate capital per market, add bankruptcy halt

### DIFF
--- a/polymarket/_shared/pair_stateful_replay.py
+++ b/polymarket/_shared/pair_stateful_replay.py
@@ -289,6 +289,7 @@ def _fill_fraction(
 def simulate_pair_backtest(
     market: dict[str, Any],
     params: PairReplayParams,
+    allocated_capital: float = 0.0,
 ) -> dict[str, Any]:
     primary_history: list[tuple[int, float]] = market["history"]
     pair_history: list[tuple[int, float]] = market["pair_history"]
@@ -305,6 +306,7 @@ def simulate_pair_backtest(
         aligned_primary.append((t, primary_price))
         aligned_pair.append((t, pair_price))
 
+    capital = allocated_capital if allocated_capital > 0.0 else params.bankroll_usd
     window = max(3, params.volatility_window_points)
     if len(aligned_primary) < max(params.min_history_points, window + 2):
         return {
@@ -316,7 +318,7 @@ def simulate_pair_backtest(
             "fill_events": 0,
             "filled_notional_usd": 0.0,
             "pnl_usd": 0.0,
-            "equity_curve": [params.bankroll_usd],
+            "equity_curve": [capital],
             "telemetry": [],
             "event_pnls": [],
             "orderbook_mode": _safe_str(market.get("orderbook_mode"), "unknown"),
@@ -328,7 +330,7 @@ def simulate_pair_backtest(
 
     primary_position_shares = 0.0
     pair_position_shares = 0.0
-    cash_usd = params.bankroll_usd
+    cash_usd = capital
     considered = 0
     quoted = 0
     skipped = 0
@@ -336,7 +338,7 @@ def simulate_pair_backtest(
     filled_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     event_pnls: list[float] = []
-    equity_curve = [params.bankroll_usd]
+    equity_curve = [capital]
     basis_series_bps = [
         (aligned_primary[idx][1] - aligned_pair[idx][1]) * 10000.0 for idx in range(len(aligned_primary))
     ]
@@ -588,6 +590,7 @@ def simulate_pair_backtest(
             pair_price=next_pair_mid,
             unwind_cost_bps=params.expected_unwind_cost_bps,
         )
+        equity_after = max(0.0, equity_after)
         equity_curve.append(equity_after)
         if (
             primary_fill_notional > 0.0
@@ -623,6 +626,8 @@ def simulate_pair_backtest(
             }
         )
         telemetry.append(record)
+        if equity_after <= 0.0:
+            break
 
     ending_equity = _pair_equity(
         cash_usd=cash_usd,
@@ -643,7 +648,7 @@ def simulate_pair_backtest(
         "skipped_points": skipped,
         "fill_events": fill_events,
         "filled_notional_usd": round(filled_notional, 4),
-        "pnl_usd": round(ending_equity - params.bankroll_usd, 6),
+        "pnl_usd": round(ending_equity - capital, 6),
         "equity_curve": equity_curve,
         "telemetry": telemetry,
         "event_pnls": event_pnls,

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -842,7 +842,7 @@ def _sharpe_like_score(event_pnls: list[float], bankroll_usd: float, days: int) 
     return (mean / stdev) * math.sqrt(events_per_year)
 
 
-def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams) -> dict[str, Any]:
+def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams, allocated_capital: float = 0.0) -> dict[str, Any]:
     replay_params = _to_pair_replay_params(p, bt)
     history = market.get("history", [])
     pair_history = market.get("pair_history", [])
@@ -861,7 +861,7 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
         orderbook_mode = _combine_orderbook_mode(primary_mode, pair_mode)
     if orderbook_mode:
         market = {**market, "orderbook_mode": orderbook_mode}
-    result = simulate_pair_backtest(market=market, params=replay_params)
+    result = simulate_pair_backtest(market=market, params=replay_params, allocated_capital=allocated_capital)
     return {
         **result,
         "traded_points": result["quoted_points"],
@@ -927,9 +927,11 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
+    num_pairs = len(markets)
+    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
 
     for market in markets:
-        result = _simulate_pair(market, p, bt)
+        result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
         summaries.append(
             {
                 "market_id": result["market_id"],

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -903,7 +903,7 @@ def _sharpe_like_score(event_pnls: list[float], bankroll_usd: float, days: int) 
     return (mean / stdev) * math.sqrt(events_per_year)
 
 
-def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams) -> dict[str, Any]:
+def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams, allocated_capital: float = 0.0) -> dict[str, Any]:
     replay_params = _to_pair_replay_params(p, bt)
     history = market.get("history", [])
     pair_history = market.get("pair_history", [])
@@ -922,7 +922,7 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
         orderbook_mode = _combine_orderbook_mode(primary_mode, pair_mode)
     if orderbook_mode:
         market = {**market, "orderbook_mode": orderbook_mode}
-    result = simulate_pair_backtest(market=market, params=replay_params)
+    result = simulate_pair_backtest(market=market, params=replay_params, allocated_capital=allocated_capital)
     return {
         **result,
         "traded_points": result["quoted_points"],
@@ -988,9 +988,11 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
+    num_pairs = len(markets)
+    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
 
     for market in markets:
-        result = _simulate_pair(market, p, bt)
+        result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
         summaries.append(
             {
                 "market_id": result["market_id"],

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -1182,7 +1182,9 @@ def _simulate_market_backtest(
     market: dict[str, Any],
     strategy_params: StrategyParams,
     backtest_params: BacktestParams,
+    allocated_capital: float = 0.0,
 ) -> dict[str, Any]:
+    capital = allocated_capital if allocated_capital > 0.0 else strategy_params.bankroll_usd
     history: list[tuple[int, float]] = market["history"]
     orderbooks: dict[int, OrderBookSnapshot] = market.get("orderbooks", {})
     window = backtest_params.volatility_window_points
@@ -1196,7 +1198,7 @@ def _simulate_market_backtest(
             "fill_events": 0,
             "filled_notional_usd": 0.0,
             "pnl_usd": 0.0,
-            "equity_curve": [strategy_params.bankroll_usd],
+            "equity_curve": [capital],
             "telemetry": [],
             "orderbook_mode": market.get("orderbook_mode", "unknown"),
         }
@@ -1207,7 +1209,7 @@ def _simulate_market_backtest(
     end_ts = _safe_int(market.get("end_ts"), 0)
     moves_bps = [abs((history[i][1] - history[i - 1][1]) * 10000.0) for i in range(1, len(history))]
 
-    cash_usd = strategy_params.bankroll_usd
+    cash_usd = capital
     position_shares = 0.0
     considered = 0
     quoted = 0
@@ -1215,7 +1217,7 @@ def _simulate_market_backtest(
     fill_events = 0
     filled_notional = 0.0
     telemetry: list[dict[str, Any]] = []
-    equity_curve = [strategy_params.bankroll_usd]
+    equity_curve = [capital]
 
     for i in range(window, len(history) - 1):
         t, mid_price = history[i]
@@ -1349,6 +1351,7 @@ def _simulate_market_backtest(
             mark_price=next_price,
             unwind_cost_bps=strategy_params.expected_unwind_cost_bps,
         )
+        equity_after = max(0.0, equity_after)
         equity_curve.append(equity_after)
         record.update(
             {
@@ -1362,6 +1365,8 @@ def _simulate_market_backtest(
             }
         )
         telemetry.append(record)
+        if equity_after <= 0.0:
+            break
 
     ending_equity = _liquidation_equity(
         cash_usd=cash_usd,
@@ -1379,7 +1384,7 @@ def _simulate_market_backtest(
         "skipped_points": skipped,
         "fill_events": fill_events,
         "filled_notional_usd": round(filled_notional, 4),
-        "pnl_usd": round(ending_equity - strategy_params.bankroll_usd, 6),
+        "pnl_usd": round(ending_equity - capital, 6),
         "equity_curve": equity_curve,
         "telemetry": telemetry,
         "orderbook_mode": market.get("orderbook_mode", "unknown"),
@@ -1452,11 +1457,16 @@ def run_backtest(
     telemetry_records: list[dict[str, Any]] = []
     orderbook_modes: set[str] = set()
 
-    for market in markets[: strategy_params.markets_max]:
+    selected_markets = markets[: strategy_params.markets_max]
+    num_markets = len(selected_markets)
+    capital_per_market = strategy_params.bankroll_usd / max(1, num_markets)
+
+    for market in selected_markets:
         summary = _simulate_market_backtest(
             market=market,
             strategy_params=strategy_params,
             backtest_params=backtest_params,
+            allocated_capital=capital_per_market,
         )
         market_summaries.append(
             {
@@ -1483,7 +1493,7 @@ def run_backtest(
             equity_curve.extend([equity_curve[-1]] * (len(market_equity_curve) - len(equity_curve)))
         for idx, value in enumerate(market_equity_curve):
             if idx < len(equity_curve):
-                equity_curve[idx] += value - strategy_params.bankroll_usd
+                equity_curve[idx] += value - capital_per_market
 
     ending_equity = equity_curve[-1]
     total_pnl = ending_equity - strategy_params.bankroll_usd

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -842,7 +842,7 @@ def _sharpe_like_score(event_pnls: list[float], bankroll_usd: float, days: int) 
     return (mean / stdev) * math.sqrt(events_per_year)
 
 
-def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams) -> dict[str, Any]:
+def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams, allocated_capital: float = 0.0) -> dict[str, Any]:
     replay_params = _to_pair_replay_params(p, bt)
     history = market.get("history", [])
     pair_history = market.get("pair_history", [])
@@ -861,7 +861,7 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
         orderbook_mode = _combine_orderbook_mode(primary_mode, pair_mode)
     if orderbook_mode:
         market = {**market, "orderbook_mode": orderbook_mode}
-    result = simulate_pair_backtest(market=market, params=replay_params)
+    result = simulate_pair_backtest(market=market, params=replay_params, allocated_capital=allocated_capital)
     return {
         **result,
         "traded_points": result["quoted_points"],
@@ -927,9 +927,11 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
+    num_pairs = len(markets)
+    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
 
     for market in markets:
-        result = _simulate_pair(market, p, bt)
+        result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
         summaries.append(
             {
                 "market_id": result["market_id"],


### PR DESCRIPTION
## Summary
- Each market simulation was seeded with the full bankroll, so 20 markets on a 100 dollar bankroll effectively simulated with 2000 dollars. This produced impossible returns like -120%.
- Now bankroll / num_markets is allocated per market, so total deployed capital equals the actual bankroll
- Adds bankruptcy check: trading halts when equity hits zero, equity floored at 0
- Fixes all 4 Polymarket backtest skills and the shared pair_stateful_replay.py

## Test plan
- [ ] Run maker-rebate-bot backtest with 100 dollar bankroll - verify return stays in [-100%, +inf) range
- [ ] Verify per-market PnL sums to aggregate PnL (no capital duplication)
- [ ] Run paired-market-basis-maker backtest - verify same bounded return behavior
- [ ] Verify bankrupt markets stop trading (fill_events should be 0 after equity hits 0)

Closes #90

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com