### PR TITLE
fix(backtest): add interval=max to CLOB prices-history queries

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -588,15 +588,19 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
 
     def _fetch_candidate_history(candidate: dict[str, Any]) -> dict[str, Any] | None:
         history_limit = max(bt.min_history_points * 12, 1000)
-        history_query = urlencode(
-            {
-                "market": candidate["token_id"],
-                "limit": history_limit,
-            }
+        queries = (
+            {"market": candidate["token_id"], "interval": bt.history_interval, "fidelity": bt.history_fidelity_minutes},
+            {"market": candidate["token_id"], "limit": history_limit},
         )
-        try:
-            payload = _http_get_json(f"{bt.clob_history_url}?{history_query}")
-        except Exception:
+        payload = None
+        for params in queries:
+            try:
+                payload = _http_get_json(f"{bt.clob_history_url}?{urlencode(params)}")
+                if payload:
+                    break
+            except Exception:
+                continue
+        if payload is None:
             return None
         history = _normalize_history(
             payload,

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -649,15 +649,19 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
 
     def _fetch_candidate_history(candidate: dict[str, Any]) -> dict[str, Any] | None:
         history_limit = max(bt.min_history_points * 12, 1000)
-        history_query = urlencode(
-            {
-                "market": candidate["token_id"],
-                "limit": history_limit,
-            }
+        queries = (
+            {"market": candidate["token_id"], "interval": bt.history_interval, "fidelity": bt.history_fidelity_minutes},
+            {"market": candidate["token_id"], "limit": history_limit},
         )
-        try:
-            payload = _http_get_json(f"{bt.clob_history_url}?{history_query}")
-        except Exception:
+        payload = None
+        for params in queries:
+            try:
+                payload = _http_get_json(f"{bt.clob_history_url}?{urlencode(params)}")
+                if payload:
+                    break
+            except Exception:
+                continue
+        if payload is None:
             return None
         history = _normalize_history(
             payload,

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -728,7 +728,9 @@ def _fetch_market_history(
     end_ts: int,
 ) -> list[tuple[int, float]]:
     history_limit = max(backtest_params.min_history_points * 12, 1000)
+    fidelity = backtest_params.fidelity_minutes
     queries = (
+        {"market": token_id, "interval": "max", "fidelity": fidelity},
         {"market": token_id, "limit": history_limit},
         {"asset_id": token_id, "limit": history_limit},
         {"token_id": token_id, "limit": history_limit},

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -588,15 +588,19 @@ def _fetch_live_backtest_pairs(p: StrategyParams, bt: BacktestParams, start_ts: 
 
     def _fetch_candidate_history(candidate: dict[str, Any]) -> dict[str, Any] | None:
         history_limit = max(bt.min_history_points * 12, 1000)
-        history_query = urlencode(
-            {
-                "market": candidate["token_id"],
-                "limit": history_limit,
-            }
+        queries = (
+            {"market": candidate["token_id"], "interval": bt.history_interval, "fidelity": bt.history_fidelity_minutes},
+            {"market": candidate["token_id"], "limit": history_limit},
         )
-        try:
-            payload = _http_get_json(f"{bt.clob_history_url}?{history_query}")
-        except Exception:
+        payload = None
+        for params in queries:
+            try:
+                payload = _http_get_json(f"{bt.clob_history_url}?{urlencode(params)}")
+                if payload:
+                    break
+            except Exception:
+                continue
+        if payload is None:
             return None
         history = _normalize_history(
             payload,


### PR DESCRIPTION
## Summary
- Add `interval=max` + `fidelity` as primary query strategy for CLOB `/prices-history` endpoint across all 4 Polymarket skills
- Fall back to `limit`-based query if the `interval=max` query returns no data
- Paired skills now use their existing `history_interval` and `history_fidelity_minutes` config fields that were previously unused in query construction

## Files changed
- `polymarket/maker-rebate-bot/scripts/agent.py`
- `polymarket/paired-market-basis-maker/scripts/agent.py`
- `polymarket/high-throughput-paired-basis-maker/scripts/agent.py`
- `polymarket/liquidity-paired-basis-maker/scripts/agent.py`

Closes #92

## Test plan
- [ ] Run maker-rebate-bot backtest with $100 bankroll — verify markets return sufficient history data
- [ ] Confirm no `no_backtest_markets` failures
- [ ] Verify credible return percentages (bounded by allocated capital)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com