### PR TITLE
fix(polymarket): unwrap Seren gateway envelope in _http_get_json_public (#100)

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -459,7 +459,8 @@ def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _is_clob_direct_url(url: str) -> bool:

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -537,7 +537,8 @@ def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -680,7 +680,8 @@ def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[
         },
     )
     with urlopen(request, timeout=timeout) as response:
-        return json.loads(response.read().decode("utf-8"))
+        raw = json.loads(response.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _http_get_json(url: str, timeout: int = 30) -> dict[str, Any] | list[Any]:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -459,7 +459,8 @@ def _http_get_json_public(url: str, timeout: int = 30) -> dict[str, Any] | list[
         },
     )
     with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        raw = json.loads(resp.read().decode("utf-8"))
+        return _unwrap_seren_response(raw)
 
 
 def _is_clob_direct_url(url: str) -> bool:


### PR DESCRIPTION
## Summary

- `_http_get_json_public()` in all 4 Polymarket backtest skills now calls `_unwrap_seren_response()` to handle Seren gateway response envelopes (`{"status": 200, "body": [...], "response_bytes": ...}`)
- Previously, only `_http_get_json_via_api_key()` and `_http_post_json()` unwrapped — `_http_get_json_public()` returned raw JSON, causing `isinstance(raw, list)` checks to fail and backtests to scan 0 markets
- The `polymarket/bot/` skill uses abstracted client classes and is not affected

### Files changed

| File | What changed |
|------|-------------|
| `polymarket/maker-rebate-bot/scripts/agent.py` | `_http_get_json_public()` now unwraps envelope |
| `polymarket/liquidity-paired-basis-maker/scripts/agent.py` | same |
| `polymarket/paired-market-basis-maker/scripts/agent.py` | same |
| `polymarket/high-throughput-paired-basis-maker/scripts/agent.py` | same |

Fixes #100.

## Test plan

- [ ] Run maker-rebate-bot backtest: `python3 scripts/agent.py --config config.example.json --run-type backtest` — should find 8+ markets instead of 0
- [ ] Verify `_unwrap_seren_response` is idempotent (bare lists/dicts pass through unchanged)
- [ ] Confirm all 4 files pass `python3 -c "import ast; ast.parse(open('...').read())"` syntax check

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com