### PR TITLE
fix(polymarket): quick-start paths point to canonical skill runtime

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -51,7 +51,7 @@ Live execution requires both:
 ## Quick Start
 
 ```bash
-cd polymarket/high-throughput-paired-basis-maker
+cd ~/.config/seren/skills/polymarket-high-throughput-paired-basis-maker
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -51,7 +51,7 @@ Live execution requires both:
 ## Quick Start
 
 ```bash
-cd polymarket/liquidity-paired-basis-maker
+cd ~/.config/seren/skills/polymarket-liquidity-paired-basis-maker
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -47,7 +47,7 @@ Live execution also requires:
 ## Quick Start
 
 ```bash
-cd polymarket/maker-rebate-bot
+cd ~/.config/seren/skills/polymarket-maker-rebate-bot
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -51,7 +51,7 @@ Live execution requires both:
 ## Quick Start
 
 ```bash
-cd polymarket/paired-market-basis-maker
+cd ~/.config/seren/skills/polymarket-paired-market-basis-maker
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

- Updates Quick Start `cd` paths in 4 Polymarket SKILL.md files from repo-relative paths (e.g. `cd polymarket/maker-rebate-bot`) to canonical installed runtime paths (`~/.config/seren/skills/polymarket-*`)
- Affected skills: `maker-rebate-bot`, `liquidity-paired-basis-maker`, `paired-market-basis-maker`, `high-throughput-paired-basis-maker`
- `polymarket/bot` already used the correct path and was not changed

Closes #99

## Test plan

- [ ] Verify each updated SKILL.md references `~/.config/seren/skills/<skill-slug>` in its Quick Start block
- [ ] Confirm `polymarket/bot/SKILL.md` is unchanged (already correct)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com