### PR TITLE
feat(polymarket): prompt users to enable Seren Predictions after backtest

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -77,6 +77,21 @@ python3 scripts/agent.py --config config.json --backtest-file tests/fixtures/bac
 
 Set `backtest.telemetry_path` to capture JSONL replay telemetry for each decision step.
 
+## Seren Predictions Intelligence
+
+After a backtest completes, the output will suggest enabling **Seren Predictions** if it is not already active. This optional feature uses computed pair-specific endpoints to:
+
+- Validate pair correlation strength with cross-platform data
+- Rank pairs by basis deviation sigma for better entry signals
+- Filter for pairs where cross-platform data confirms mean-reversion potential
+
+Endpoints used (computed, not consensus):
+
+- `GET /api/polymarket/pairs/suggested` ($0.10) — suggested pairs ranked by basis deviation
+- `GET /api/polymarket/correlations` ($0.10) — pair correlation and basis spread statistics
+
+To enable, set `predictions_enabled: true` in the `backtest` section of your `config.json`. Estimated cost: ~$0.20 SerenBucks per backtest run.
+
 ## Disclaimer
 
 This skill can lose money. Basis spreads can persist or widen, hedge legs can slip, and liquidity can fail during volatility. Backtests are hypothetical and do not guarantee future results. This skill is software tooling and not financial advice. Use dry-run first and only trade with risk capital.

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -48,6 +48,10 @@ DISCLAIMER = (
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_URL_PREFIX = (
+    f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
+)
 SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES = (
     SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX,
 )
@@ -99,6 +103,12 @@ class BacktestParams:
     gamma_markets_url: str = "https://api.serendb.com/publishers/polymarket-data/markets"
     clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 12
+    # Seren Predictions intelligence (costs SerenBucks per call)
+    predictions_enabled: bool = False
+    predictions_pairs_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/pairs/suggested"
+    predictions_correlations_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/correlations"
+    predictions_volatility_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/volatility"
+    predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
 def parse_args() -> argparse.Namespace:
@@ -254,6 +264,8 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
             _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
+        predictions_enabled=bool(raw.get("predictions_enabled", False)),
+        predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
     )
 
 
@@ -884,6 +896,99 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/v1/billing/balance",
+            headers={
+                "User-Agent": "high-throughput-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
+    except Exception:
+        return 0.0
+
+
+def _fetch_predictions_pair_signals(
+    backtest_params: "BacktestParams",
+) -> dict[str, Any]:
+    """Fetch pair-specific intelligence from Seren Predictions computed endpoints.
+
+    Uses GET /api/polymarket/pairs/suggested and GET /api/polymarket/correlations
+    to enrich pair selection with cross-platform basis deviation and correlation data.
+    Returns dict with 'suggested_pairs' and 'correlations' keys. Costs SerenBucks.
+    """
+    if not backtest_params.predictions_enabled:
+        return {}
+
+    api_key = os.getenv("API_KEY", "").strip() or os.getenv("SEREN_API_KEY", "").strip()
+    if not api_key:
+        return {}
+
+    balance = _check_serenbucks_balance(api_key)
+    estimated_cost = 0.20  # pairs/suggested ($0.10) + correlations ($0.10)
+    if balance < estimated_cost:
+        print(
+            f"WARNING: SerenBucks balance (${balance:.2f}) may be insufficient for "
+            f"predictions intelligence (estimated ${estimated_cost:.2f}). "
+            f"Top up at https://serendb.com/billing to use Seren Predictions.",
+            file=sys.stderr,
+        )
+        if balance <= 0.0:
+            return {}
+
+    result: dict[str, Any] = {}
+
+    # Fetch suggested pairs ranked by basis deviation sigma
+    try:
+        params = urlencode({"min_r": "0.70", "min_basis_deviation_sigma": "1.0", "days": "90", "limit": "50"})
+        url = f"{backtest_params.predictions_pairs_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "high-throughput-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["suggested_pairs"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["suggested_pairs"] = data
+    except Exception:
+        pass
+
+    # Fetch correlations for pair validation
+    try:
+        params = urlencode({"min_r": "0.70", "days": "90", "limit": "100"})
+        url = f"{backtest_params.predictions_correlations_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "high-throughput-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["correlations"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["correlations"] = data
+    except Exception:
+        pass
+
+    return result
+
+
 def run_backtest(
     config: dict[str, Any],
     backtest_days: int | None,
@@ -1013,11 +1118,31 @@ def run_backtest(
 
     write_telemetry_records(bt.telemetry_path, telemetry)
 
+    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
+    predictions = _fetch_predictions_pair_signals(backtest_params=bt)
+    predictions_pairs_count = len(predictions.get("suggested_pairs", []))
+    predictions_correlations_count = len(predictions.get("correlations", []))
+
     return {
         "status": "ok",
         "skill": "high-throughput-paired-basis-maker",
         "mode": "backtest",
         "dry_run": True,
+        "predictions_intelligence": {
+            "enabled": bt.predictions_enabled,
+            "publisher": SEREN_PREDICTIONS_PUBLISHER,
+            "suggested_pairs_found": predictions_pairs_count,
+            "correlations_found": predictions_correlations_count,
+            "endpoints_used": [
+                "GET /api/polymarket/pairs/suggested ($0.10)",
+                "GET /api/polymarket/correlations ($0.10)",
+            ],
+            "note": (
+                "Seren Predictions intelligence active — costs SerenBucks per run."
+                if bt.predictions_enabled
+                else "Disabled. Set predictions_enabled: true in config to activate (costs SerenBucks)."
+            ),
+        },
         "backtest_summary": {
             "days": days,
             "days_range": {"min": bt.days_min, "max": bt.days_max},
@@ -1055,6 +1180,32 @@ def run_backtest(
         },
         "pairs": sorted(summaries, key=lambda row: row["pnl_usd"], reverse=True),
         "disclaimer": DISCLAIMER,
+        **(
+            {
+                "predictions_upgrade_prompt": {
+                    "message": (
+                        "Improve your pair selection with Seren Predictions intelligence. "
+                        "Cross-platform correlation analysis and basis deviation signals can "
+                        "identify stronger pairs and better entry timing. "
+                        "Estimated cost: ~$0.20 per backtest run."
+                    ),
+                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
+                    "publisher": "seren-polymarket-predictions",
+                    "estimated_cost_usd": 0.20,
+                    "endpoints_used": [
+                        "GET /api/polymarket/pairs/suggested ($0.10)",
+                        "GET /api/polymarket/correlations ($0.10)",
+                    ],
+                    "benefits": [
+                        "Validate pair correlation strength with cross-platform data",
+                        "Rank pairs by basis deviation sigma for better entry signals",
+                        "Filter for pairs where cross-platform data confirms mean-reversion potential",
+                    ],
+                },
+            }
+            if not bt.predictions_enabled
+            else {}
+        ),
     }
 
 

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -77,6 +77,21 @@ python3 scripts/agent.py --config config.json --backtest-file tests/fixtures/bac
 
 Set `backtest.telemetry_path` to capture JSONL replay telemetry for each decision step.
 
+## Seren Predictions Intelligence
+
+After a backtest completes, the output will suggest enabling **Seren Predictions** if it is not already active. This optional feature uses computed pair-specific endpoints to:
+
+- Validate pair correlation strength with cross-platform data
+- Rank pairs by basis deviation sigma for better entry signals
+- Filter for pairs where cross-platform data confirms mean-reversion potential
+
+Endpoints used (computed, not consensus):
+
+- `GET /api/polymarket/pairs/suggested` ($0.10) — suggested pairs ranked by basis deviation
+- `GET /api/polymarket/correlations` ($0.10) — pair correlation and basis spread statistics
+
+To enable, set `predictions_enabled: true` in the `backtest` section of your `config.json`. Estimated cost: ~$0.20 SerenBucks per backtest run.
+
 ## Disclaimer
 
 This skill can lose money. Basis spreads can persist or widen, hedge legs can slip, and liquidity can fail during volatility. Backtests are hypothetical and do not guarantee future results. This skill is software tooling and not financial advice. Use dry-run first and only trade with risk capital.

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -47,6 +47,10 @@ SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_URL_PREFIX = (
+    f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
+)
 SEREN_ALLOWED_POLYMARKET_PUBLISHERS = frozenset(
     {SEREN_POLYMARKET_DATA_PUBLISHER}
 )
@@ -106,6 +110,12 @@ class BacktestParams:
     gamma_markets_url: str = f"{SEREN_POLYMARKET_DATA_URL_PREFIX}/markets"
     clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 4
+    # Seren Predictions intelligence (costs SerenBucks per call)
+    predictions_enabled: bool = False
+    predictions_pairs_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/pairs/suggested"
+    predictions_correlations_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/correlations"
+    predictions_volatility_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/volatility"
+    predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
 def parse_args() -> argparse.Namespace:
@@ -262,6 +272,8 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
             _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 4)),
+        predictions_enabled=bool(raw.get("predictions_enabled", False)),
+        predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
     )
 
 
@@ -945,6 +957,99 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/v1/billing/balance",
+            headers={
+                "User-Agent": "liquidity-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
+    except Exception:
+        return 0.0
+
+
+def _fetch_predictions_pair_signals(
+    backtest_params: "BacktestParams",
+) -> dict[str, Any]:
+    """Fetch pair-specific intelligence from Seren Predictions computed endpoints.
+
+    Uses GET /api/polymarket/pairs/suggested and GET /api/polymarket/correlations
+    to enrich pair selection with cross-platform basis deviation and correlation data.
+    Returns dict with 'suggested_pairs' and 'correlations' keys. Costs SerenBucks.
+    """
+    if not backtest_params.predictions_enabled:
+        return {}
+
+    api_key = os.getenv("API_KEY", "").strip() or os.getenv("SEREN_API_KEY", "").strip()
+    if not api_key:
+        return {}
+
+    balance = _check_serenbucks_balance(api_key)
+    estimated_cost = 0.20  # pairs/suggested ($0.10) + correlations ($0.10)
+    if balance < estimated_cost:
+        print(
+            f"WARNING: SerenBucks balance (${balance:.2f}) may be insufficient for "
+            f"predictions intelligence (estimated ${estimated_cost:.2f}). "
+            f"Top up at https://serendb.com/billing to use Seren Predictions.",
+            file=sys.stderr,
+        )
+        if balance <= 0.0:
+            return {}
+
+    result: dict[str, Any] = {}
+
+    # Fetch suggested pairs ranked by basis deviation sigma
+    try:
+        params = urlencode({"min_r": "0.70", "min_basis_deviation_sigma": "1.0", "days": "90", "limit": "50"})
+        url = f"{backtest_params.predictions_pairs_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "liquidity-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["suggested_pairs"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["suggested_pairs"] = data
+    except Exception:
+        pass
+
+    # Fetch correlations for pair validation
+    try:
+        params = urlencode({"min_r": "0.70", "days": "90", "limit": "100"})
+        url = f"{backtest_params.predictions_correlations_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "liquidity-paired-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["correlations"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["correlations"] = data
+    except Exception:
+        pass
+
+    return result
+
+
 def run_backtest(
     config: dict[str, Any],
     backtest_days: int | None,
@@ -1074,11 +1179,31 @@ def run_backtest(
 
     write_telemetry_records(bt.telemetry_path, telemetry)
 
+    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
+    predictions = _fetch_predictions_pair_signals(backtest_params=bt)
+    predictions_pairs_count = len(predictions.get("suggested_pairs", []))
+    predictions_correlations_count = len(predictions.get("correlations", []))
+
     return {
         "status": "ok",
         "skill": "liquidity-paired-basis-maker",
         "mode": "backtest",
         "dry_run": True,
+        "predictions_intelligence": {
+            "enabled": bt.predictions_enabled,
+            "publisher": SEREN_PREDICTIONS_PUBLISHER,
+            "suggested_pairs_found": predictions_pairs_count,
+            "correlations_found": predictions_correlations_count,
+            "endpoints_used": [
+                "GET /api/polymarket/pairs/suggested ($0.10)",
+                "GET /api/polymarket/correlations ($0.10)",
+            ],
+            "note": (
+                "Seren Predictions intelligence active — costs SerenBucks per run."
+                if bt.predictions_enabled
+                else "Disabled. Set predictions_enabled: true in config to activate (costs SerenBucks)."
+            ),
+        },
         "backtest_summary": {
             "days": days,
             "days_range": {"min": bt.days_min, "max": bt.days_max},
@@ -1116,6 +1241,32 @@ def run_backtest(
         },
         "pairs": sorted(summaries, key=lambda row: row["pnl_usd"], reverse=True),
         "disclaimer": DISCLAIMER,
+        **(
+            {
+                "predictions_upgrade_prompt": {
+                    "message": (
+                        "Improve your pair selection with Seren Predictions intelligence. "
+                        "Cross-platform correlation analysis and basis deviation signals can "
+                        "identify stronger pairs and better entry timing. "
+                        "Estimated cost: ~$0.20 per backtest run."
+                    ),
+                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
+                    "publisher": "seren-polymarket-predictions",
+                    "estimated_cost_usd": 0.20,
+                    "endpoints_used": [
+                        "GET /api/polymarket/pairs/suggested ($0.10)",
+                        "GET /api/polymarket/correlations ($0.10)",
+                    ],
+                    "benefits": [
+                        "Validate pair correlation strength with cross-platform data",
+                        "Rank pairs by basis deviation sigma for better entry signals",
+                        "Filter for pairs where cross-platform data confirms mean-reversion potential",
+                    ],
+                },
+            }
+            if not bt.predictions_enabled
+            else {}
+        ),
     }
 
 

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -87,6 +87,16 @@ Each backtest market object should include:
 - optional `orderbooks` array of `{ "t": unix_ts, "best_bid": ..., "best_ask": ..., "bid_size_usd": ..., "ask_size_usd": ... }`
 - optional `rebate_bps` (number; otherwise default rebate from config)
 
+## Seren Predictions Intelligence
+
+After a backtest completes, the output will suggest enabling **Seren Predictions** if it is not already active. This optional feature uses cross-platform consensus and divergence signals from Kalshi, Manifold, Metaculus, PredictIt, and Betfair to:
+
+- Boost market selection scores for markets where Polymarket diverges from consensus
+- Add directional skew to quotes based on cross-platform price differences
+- Filter for higher-edge opportunities where platforms disagree
+
+To enable, set `predictions_enabled: true` in the `backtest` section of your `config.json`. Estimated cost: ~$0.30 SerenBucks per backtest run.
+
 ## Safety Notes
 
 - Live execution is never enabled by default.

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -1750,10 +1750,44 @@ def run_backtest(
             ),
         },
         "markets": sorted(market_summaries, key=lambda item: item["pnl_usd"], reverse=True),
+        **(
+            {
+                "predictions_upgrade_prompt": {
+                    "message": (
+                        "Improve your edge with Seren Predictions intelligence. "
+                        "Cross-platform consensus and divergence signals from Kalshi, Manifold, "
+                        "Metaculus, PredictIt, and Betfair can boost market selection and directional "
+                        "quote skew. Estimated cost: ~$0.30 per backtest run."
+                    ),
+                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
+                    "publisher": "seren-polymarket-predictions",
+                    "estimated_cost_usd": 0.30,
+                    "endpoints_used": [
+                        "POST /api/oracle/divergence/batch ($0.15)",
+                        "POST /api/oracle/consensus/batch ($0.15)",
+                    ],
+                    "benefits": [
+                        "Boost mm_score for markets with cross-platform price divergence",
+                        "Add directional skew to quotes based on consensus vs Polymarket price",
+                        "Filter for markets where other platforms disagree — higher edge potential",
+                    ],
+                },
+            }
+            if not backtest_params.predictions_enabled
+            else {}
+        ),
         "next_steps": [
             "Review negative-PnL markets and edge assumptions.",
             "Tune spread, participation, and risk caps before live mode.",
             "Run quote mode only after backtest results are acceptable.",
+            *(
+                []
+                if backtest_params.predictions_enabled
+                else [
+                    "Enable Seren Predictions intelligence for better edge detection "
+                    "(set predictions_enabled: true in config).",
+                ]
+            ),
         ],
     }
 

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -77,6 +77,21 @@ python3 scripts/agent.py --config config.json --backtest-file tests/fixtures/bac
 
 Set `backtest.telemetry_path` to capture JSONL replay telemetry for each decision step.
 
+## Seren Predictions Intelligence
+
+After a backtest completes, the output will suggest enabling **Seren Predictions** if it is not already active. This optional feature uses computed pair-specific endpoints to:
+
+- Validate pair correlation strength with cross-platform data
+- Rank pairs by basis deviation sigma for better entry signals
+- Filter for pairs where cross-platform data confirms mean-reversion potential
+
+Endpoints used (computed, not consensus):
+
+- `GET /api/polymarket/pairs/suggested` ($0.10) — suggested pairs ranked by basis deviation
+- `GET /api/polymarket/correlations` ($0.10) — pair correlation and basis spread statistics
+
+To enable, set `predictions_enabled: true` in the `backtest` section of your `config.json`. Estimated cost: ~$0.20 SerenBucks per backtest run.
+
 ## Disclaimer
 
 This skill can lose money. Basis spreads can persist or widen, hedge legs can slip, and liquidity can fail during volatility. Backtests are hypothetical and do not guarantee future results. This skill is software tooling and not financial advice. Use dry-run first and only trade with risk capital.

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -48,6 +48,10 @@ DISCLAIMER = (
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_URL_PREFIX = (
+    f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
+)
 SEREN_ALLOWED_POLYMARKET_PUBLISHER_PREFIXES = (
     SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX,
 )
@@ -99,6 +103,12 @@ class BacktestParams:
     gamma_markets_url: str = "https://api.serendb.com/publishers/polymarket-data/markets"
     clob_history_url: str = f"{POLYMARKET_CLOB_BASE_URL}/prices-history"
     history_fetch_workers: int = 12
+    # Seren Predictions intelligence (costs SerenBucks per call)
+    predictions_enabled: bool = False
+    predictions_pairs_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/pairs/suggested"
+    predictions_correlations_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/correlations"
+    predictions_volatility_url: str = f"{SEREN_PREDICTIONS_URL_PREFIX}/api/polymarket/volatility"
+    predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
 def parse_args() -> argparse.Namespace:
@@ -254,6 +264,8 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
             _safe_str(raw.get("clob_history_url"), f"{POLYMARKET_CLOB_BASE_URL}/prices-history")
         ),
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
+        predictions_enabled=bool(raw.get("predictions_enabled", False)),
+        predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
     )
 
 
@@ -884,6 +896,99 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/v1/billing/balance",
+            headers={
+                "User-Agent": "paired-market-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
+    except Exception:
+        return 0.0
+
+
+def _fetch_predictions_pair_signals(
+    backtest_params: "BacktestParams",
+) -> dict[str, Any]:
+    """Fetch pair-specific intelligence from Seren Predictions computed endpoints.
+
+    Uses GET /api/polymarket/pairs/suggested and GET /api/polymarket/correlations
+    to enrich pair selection with cross-platform basis deviation and correlation data.
+    Returns dict with 'suggested_pairs' and 'correlations' keys. Costs SerenBucks.
+    """
+    if not backtest_params.predictions_enabled:
+        return {}
+
+    api_key = os.getenv("API_KEY", "").strip() or os.getenv("SEREN_API_KEY", "").strip()
+    if not api_key:
+        return {}
+
+    balance = _check_serenbucks_balance(api_key)
+    estimated_cost = 0.20  # pairs/suggested ($0.10) + correlations ($0.10)
+    if balance < estimated_cost:
+        print(
+            f"WARNING: SerenBucks balance (${balance:.2f}) may be insufficient for "
+            f"predictions intelligence (estimated ${estimated_cost:.2f}). "
+            f"Top up at https://serendb.com/billing to use Seren Predictions.",
+            file=sys.stderr,
+        )
+        if balance <= 0.0:
+            return {}
+
+    result: dict[str, Any] = {}
+
+    # Fetch suggested pairs ranked by basis deviation sigma
+    try:
+        params = urlencode({"min_r": "0.70", "min_basis_deviation_sigma": "1.0", "days": "90", "limit": "50"})
+        url = f"{backtest_params.predictions_pairs_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "paired-market-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["suggested_pairs"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["suggested_pairs"] = data
+    except Exception:
+        pass
+
+    # Fetch correlations for pair validation
+    try:
+        params = urlencode({"min_r": "0.70", "days": "90", "limit": "100"})
+        url = f"{backtest_params.predictions_correlations_url}?{params}"
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "paired-market-basis-maker/1.1",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            if isinstance(data, dict):
+                result["correlations"] = data.get("pairs", data.get("results", []))
+            elif isinstance(data, list):
+                result["correlations"] = data
+    except Exception:
+        pass
+
+    return result
+
+
 def run_backtest(
     config: dict[str, Any],
     backtest_days: int | None,
@@ -1013,11 +1118,31 @@ def run_backtest(
 
     write_telemetry_records(bt.telemetry_path, telemetry)
 
+    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
+    predictions = _fetch_predictions_pair_signals(backtest_params=bt)
+    predictions_pairs_count = len(predictions.get("suggested_pairs", []))
+    predictions_correlations_count = len(predictions.get("correlations", []))
+
     return {
         "status": "ok",
         "skill": "paired-market-basis-maker",
         "mode": "backtest",
         "dry_run": True,
+        "predictions_intelligence": {
+            "enabled": bt.predictions_enabled,
+            "publisher": SEREN_PREDICTIONS_PUBLISHER,
+            "suggested_pairs_found": predictions_pairs_count,
+            "correlations_found": predictions_correlations_count,
+            "endpoints_used": [
+                "GET /api/polymarket/pairs/suggested ($0.10)",
+                "GET /api/polymarket/correlations ($0.10)",
+            ],
+            "note": (
+                "Seren Predictions intelligence active — costs SerenBucks per run."
+                if bt.predictions_enabled
+                else "Disabled. Set predictions_enabled: true in config to activate (costs SerenBucks)."
+            ),
+        },
         "backtest_summary": {
             "days": days,
             "days_range": {"min": bt.days_min, "max": bt.days_max},
@@ -1055,6 +1180,32 @@ def run_backtest(
         },
         "pairs": sorted(summaries, key=lambda row: row["pnl_usd"], reverse=True),
         "disclaimer": DISCLAIMER,
+        **(
+            {
+                "predictions_upgrade_prompt": {
+                    "message": (
+                        "Improve your pair selection with Seren Predictions intelligence. "
+                        "Cross-platform correlation analysis and basis deviation signals can "
+                        "identify stronger pairs and better entry timing. "
+                        "Estimated cost: ~$0.20 per backtest run."
+                    ),
+                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
+                    "publisher": "seren-polymarket-predictions",
+                    "estimated_cost_usd": 0.20,
+                    "endpoints_used": [
+                        "GET /api/polymarket/pairs/suggested ($0.10)",
+                        "GET /api/polymarket/correlations ($0.10)",
+                    ],
+                    "benefits": [
+                        "Validate pair correlation strength with cross-platform data",
+                        "Rank pairs by basis deviation sigma for better entry signals",
+                        "Filter for pairs where cross-platform data confirms mean-reversion potential",
+                    ],
+                },
+            }
+            if not bt.predictions_enabled
+            else {}
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

- **Maker-rebate-bot**: Add actionable predictions_upgrade_prompt to backtest output when predictions_enabled is false, showing estimated cost ($0.30), endpoints used, and benefits
- **Paired-basis-makers (all 3 variants)**: Integrate seren-polymarket-predictions computed endpoints (/api/polymarket/pairs/suggested, /api/polymarket/correlations) for pair-specific intelligence, plus upgrade prompt
- Updated SKILL.md for all 4 skills with new Seren Predictions Intelligence section

### Key design choice

The paired-basis-makers use **computed pair endpoints** (correlations, suggested pairs by basis deviation sigma) instead of the consensus/divergence endpoints used by the maker-rebate-bot — matching the pair-trading strategy needs.

Closes #103

## Test plan

- [ ] Run maker-rebate-bot backtest with predictions_enabled: false — verify predictions_upgrade_prompt appears
- [ ] Run maker-rebate-bot backtest with predictions_enabled: true — verify prompt absent
- [ ] Run any paired-basis-maker backtest with predictions_enabled: false — verify upgrade prompt
- [ ] Run paired-basis-maker with predictions_enabled: true — verify computed endpoints called
- [ ] Verify all 4 agent.py files pass python3 syntax check

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com