### PR TITLE
fix(polymarket): use correct wallet/balance endpoint for SerenBucks check

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -900,7 +900,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
         request = Request(
-            "https://api.serendb.com/v1/billing/balance",
+            "https://api.serendb.com/wallet/balance",
             headers={
                 "User-Agent": "high-throughput-paired-basis-maker/1.1",
                 "Accept": "application/json",
@@ -909,8 +909,11 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
-    except Exception:
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0
 
 

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -961,7 +961,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
         request = Request(
-            "https://api.serendb.com/v1/billing/balance",
+            "https://api.serendb.com/wallet/balance",
             headers={
                 "User-Agent": "liquidity-paired-basis-maker/1.1",
                 "Accept": "application/json",
@@ -970,8 +970,11 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
-    except Exception:
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0
 
 

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -722,7 +722,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
         request = Request(
-            "https://api.serendb.com/v1/billing/balance",
+            "https://api.serendb.com/wallet/balance",
             headers={
                 "User-Agent": "seren-maker-rebate-bot/1.0",
                 "Accept": "application/json",
@@ -731,8 +731,11 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
-    except Exception:
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0
 
 

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -900,7 +900,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
         request = Request(
-            "https://api.serendb.com/v1/billing/balance",
+            "https://api.serendb.com/wallet/balance",
             headers={
                 "User-Agent": "paired-market-basis-maker/1.1",
                 "Accept": "application/json",
@@ -909,8 +909,11 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            return _safe_float(data.get("funded_balance_usd") or data.get("balance_usd"), 0.0)
-    except Exception:
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0
 
 


### PR DESCRIPTION
## Summary

- Fixes `_check_serenbucks_balance()` in all 4 Polymarket skill bots which always returned $0.00
- **Wrong URL**: `/v1/billing/balance` changed to `/wallet/balance` per docs
- **Missing envelope unwrap**: now reads `data["serenbucks"]["balance_usd"]` instead of top-level keys
- **Dollar-sign prefix**: strips `$` and `,` before float parsing
- **Silent failure**: bare `except` now prints a stderr warning for debuggability

Closes #105.

## Test plan

- [ ] Run maker-rebate-bot backtest — verify balance warning shows correct amount
- [ ] Confirm predictions signals fire when balance is sufficient
- [ ] Verify graceful fallback (0.0 + stderr warning) when API key is missing

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com