### PR TITLE
feat: add _check_serenbucks_balance to all 18 non-Polymarket skills

### DIFF
--- a/alphagrowth/euler-base-vault-bot/scripts/agent.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-euler-base-vault-bot/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -26,6 +26,7 @@ from position_tracker import PositionTracker
 from logger import GridTraderLogger
 from serendb_store import SerenDBStore
 import pair_selector
+from urllib.request import Request, urlopen
 
 
 def _get_seren_api_key() -> str | None:
@@ -660,6 +661,49 @@ class CoinbaseGridTrader:
 
         print("\n✓ Trading stopped\n")
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-grid-trader/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main():
     """CLI entry point"""

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -23,6 +23,8 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+import sys
+from urllib.request import Request, urlopen
 
 try:
     from dotenv import load_dotenv
@@ -1803,6 +1805,49 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--accept-risk-disclaimer", action="store_true")
     return parser.parse_args()
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-smart-dca-bot/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/curve/curve-gauge-yield-trader/scripts/agent.py
+++ b/curve/curve-gauge-yield-trader/scripts/agent.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+import sys
 
 DEFAULT_DRY_RUN = True
 DEFAULT_API_BASE = "https://api.serendb.com"
@@ -1572,6 +1573,49 @@ def run_once(config: dict[str, Any], *, yes_live: bool, ledger_address: str) -> 
         "live_execution": live_execution,
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-curve-gauge-yield-trader/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
+++ b/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
@@ -26,6 +26,8 @@ from report_generator import generate_reconciliation_outputs
 from seren_api_client import SerenAPIError, SerenAPIKeyManager
 from serendb_store import SerenDBStore
 from transfer_tracker import reconcile_transfers
+import sys
+from urllib.request import Request, urlopen
 
 SKILL_NAME = "carf-dac8-crypto-asset-reporting"
 DEFAULT_CONFIG_PATH = "config.json"
@@ -459,6 +461,49 @@ def run_once(
     finally:
         store.close()
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-carf-dac8-crypto-asset-reporting/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="CARF/DAC8 crypto reconciliation")

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -27,6 +27,7 @@ from position_tracker import PositionTracker
 from logger import GridTraderLogger
 from serendb_store import SerenDBStore
 import pair_selector
+from urllib.request import Request, urlopen
 
 
 def _get_seren_api_key() -> str | None:
@@ -761,6 +762,50 @@ class KrakenGridTrader:
 
         print("\n✓ Trading stopped\n")
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-kraken-grid-trader/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main():
     """CLI entry point"""

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -17,6 +17,7 @@ from dotenv import load_dotenv
 from kraken_client import KrakenClient
 from mode_engine import ModeEngine
 from serendb_store import SerenDBStore
+from urllib.request import Request, urlopen
 
 
 QUESTION_SET: List[Dict[str, Any]] = [
@@ -372,6 +373,49 @@ def build_parser() -> argparse.ArgumentParser:
 
     return parser
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-money-mode-router/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     parser = build_parser()

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -23,6 +23,8 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+import sys
+from urllib.request import Request, urlopen
 
 try:
     from dotenv import load_dotenv
@@ -1549,6 +1551,49 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--accept-risk-disclaimer", action="store_true")
     return parser.parse_args()
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-kraken-smart-dca-bot/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/ledger/ledger-signing/scripts/agent.py
+++ b/ledger/ledger-signing/scripts/agent.py
@@ -7,6 +7,9 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -302,6 +305,49 @@ def run_once(config: dict, dry_run: bool, execute: bool) -> dict:
 
     return _execute_hid_sign(inputs)
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-ledger-signing/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/seren/customer-support-intake/scripts/agent.py
+++ b/seren/customer-support-intake/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-customer-support-intake/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/seren/job-seeker/scripts/agent.py
+++ b/seren/job-seeker/scripts/agent.py
@@ -35,6 +35,7 @@ import sys
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 from pathlib import Path
+from urllib.request import Request, urlopen
 
 # Import our modules
 from seren_client import SerenClient
@@ -1131,6 +1132,49 @@ Keep it professional, enthusiastic, and under 200 words. Focus on why they're a 
 
 
 # ========== CLI ==========
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-job-seeker/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main():
     """Main CLI entry point"""

--- a/seren/seren-scheduler/scripts/agent.py
+++ b/seren/seren-scheduler/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-seren-scheduler/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -339,6 +342,50 @@ def run_once(config: dict) -> dict:
         "inputs": inputs,
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-spectra-pt-yield-trader/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/wellsfargo/budget-tracker/scripts/agent.py
+++ b/wellsfargo/budget-tracker/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = False
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-budget-tracker/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/wellsfargo/net-worth-tracker/scripts/agent.py
+++ b/wellsfargo/net-worth-tracker/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = False
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-net-worth-tracker/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/wellsfargo/tax-prep/scripts/agent.py
+++ b/wellsfargo/tax-prep/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = False
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-tax-prep/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/wellsfargo/vendor-analysis/scripts/agent.py
+++ b/wellsfargo/vendor-analysis/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = False
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-vendor-analysis/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()

--- a/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
+++ b/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import os
+import sys
+from urllib.request import Request, urlopen
 
 
 DEFAULT_DRY_RUN = True
@@ -37,6 +40,50 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "input_keys": sorted(config.get("inputs", {}).keys()),
     }
 
+
+
+# ---------------------------------------------------------------------------
+# SerenBucks balance helpers
+# ---------------------------------------------------------------------------
+
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_api_key() -> str:
+    """Return the Seren API key from environment (Desktop or .env)."""
+    for env_name in ("API_KEY", "SEREN_API_KEY"):
+        token = (os.getenv(env_name) or "").strip()
+        if token:
+            return token
+    return ""
+
+
+def _check_serenbucks_balance(api_key: str) -> float:
+    """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
+    try:
+        request = Request(
+            "https://api.serendb.com/wallet/balance",
+            headers={
+                "User-Agent": "seren-peer-to-peer-payments-exchange/1.0",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+        )
+        with urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            sb = data.get("serenbucks") or {}
+            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
+            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+    except Exception as exc:
+        print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
+        return 0.0
 
 def main() -> int:
     args = parse_args()


### PR DESCRIPTION
## Summary

- Adds `_check_serenbucks_balance`, `_runtime_api_key`, and `_safe_float` to all 18 non-Polymarket skills that have `scripts/agent.py`
- Uses the corrected wallet endpoint (`GET /wallet/balance`) and response parsing from PR #106
- Each skill has a unique User-Agent header for traceability
- Errors are logged to stderr instead of being silently swallowed

### Skills updated (18 total)

| Org | Skills |
|-----|--------|
| alphagrowth | euler-base-vault-bot |
| coinbase | smart-dca-bot, grid-trader |
| curve | curve-gauge-yield-trader |
| kraken | smart-dca-bot, grid-trader, money-mode-router, carf-dac8-crypto-asset-reporting |
| ledger | ledger-signing |
| seren | job-seeker, seren-scheduler, customer-support-intake |
| spectra | spectra-pt-yield-trader |
| wellsfargo | tax-prep, budget-tracker, net-worth-tracker, vendor-analysis |
| zkp2p | peer-to-peer-payments-exchange |

## Test plan

- [x] All 18 files pass `ast.parse()` syntax validation
- [x] All 18 files contain `_check_serenbucks_balance`, `_runtime_api_key`, and `_safe_float`
- [x] All use correct endpoint `api.serendb.com/wallet/balance`
- [x] All strip `$` and `,` from balance strings
- [x] All log warnings to stderr on failure
- [ ] seren-SkillsForge template update (separate repo — tracked in #107)

Closes #107

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com