### PR TITLE
fix: cap backtest max drawdown at bankroll across all trading bots

### DIFF
--- a/alpaca/saas-short-trader/scripts/strategy_engine.py
+++ b/alpaca/saas-short-trader/scripts/strategy_engine.py
@@ -482,7 +482,7 @@ class StrategyEngine:
         series = self.storage.get_pnl_series(mode=mode) + [current_net]
         if not series:
             return 0.0
-        peak = -10**18
+        peak = 0.0
         max_dd = 0.0
         for v in series:
             peak = max(peak, v)
@@ -941,7 +941,7 @@ class StrategyEngine:
         net5 = sum(p5)
         net10 = sum(p10)
         net20 = sum(p20)
-        max_dd = max(0.0, abs(min(0.0, min(p5)))) + (0.10 * gross / 100.0)
+        max_dd = max(0.0, abs(min(0.0, min(p5))))
 
         return {
             "net_pnl_5d": round(net5, 6),

--- a/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
@@ -529,7 +529,7 @@ class StrategyEngine:
         series = self.storage.get_pnl_series(mode=mode) + [current_net]
         if not series:
             return 0.0
-        peak = -10**18
+        peak = 0.0
         max_dd = 0.0
         for v in series:
             peak = max(peak, v)
@@ -1046,7 +1046,7 @@ class StrategyEngine:
         net5 = sum(p5)
         net10 = sum(p10)
         net20 = sum(p20)
-        max_dd = max(0.0, abs(min(0.0, min(p5)))) + (0.10 * gross / 100.0)
+        max_dd = max(0.0, abs(min(0.0, min(p5))))
 
         return {
             "net_pnl_5d": round(net5, 6),

--- a/polymarket/_shared/pair_stateful_replay.py
+++ b/polymarket/_shared/pair_stateful_replay.py
@@ -374,14 +374,14 @@ def simulate_pair_backtest(
             record["reason"] = "missing_orderbook_snapshot"
             telemetry.append(record)
             equity_curve.append(
-                _pair_equity(
+                max(0.0, _pair_equity(
                     cash_usd=cash_usd,
                     primary_shares=primary_position_shares,
                     pair_shares=pair_position_shares,
                     primary_price=next_primary_mid,
                     pair_price=next_pair_mid,
                     unwind_cost_bps=params.expected_unwind_cost_bps,
-                )
+                ))
             )
             continue
 
@@ -392,14 +392,14 @@ def simulate_pair_backtest(
             record["reason"] = "near_resolution"
             telemetry.append(record)
             equity_curve.append(
-                _pair_equity(
+                max(0.0, _pair_equity(
                     cash_usd=cash_usd,
                     primary_shares=primary_position_shares,
                     pair_shares=pair_position_shares,
                     primary_price=next_primary_mid,
                     pair_price=next_pair_mid,
                     unwind_cost_bps=params.expected_unwind_cost_bps,
-                )
+                ))
             )
             continue
 
@@ -409,14 +409,14 @@ def simulate_pair_backtest(
             record["reason"] = "invalid_mid_prices"
             telemetry.append(record)
             equity_curve.append(
-                _pair_equity(
+                max(0.0, _pair_equity(
                     cash_usd=cash_usd,
                     primary_shares=primary_position_shares,
                     pair_shares=pair_position_shares,
                     primary_price=next_primary_mid,
                     pair_price=next_pair_mid,
                     unwind_cost_bps=params.expected_unwind_cost_bps,
-                )
+                ))
             )
             continue
 
@@ -504,14 +504,14 @@ def simulate_pair_backtest(
             )
             telemetry.append(record)
             equity_curve.append(
-                _pair_equity(
+                max(0.0, _pair_equity(
                     cash_usd=cash_usd,
                     primary_shares=primary_position_shares,
                     pair_shares=pair_position_shares,
                     primary_price=next_primary_mid,
                     pair_price=next_pair_mid,
                     unwind_cost_bps=params.expected_unwind_cost_bps,
-                )
+                ))
             )
             continue
 
@@ -637,6 +637,7 @@ def simulate_pair_backtest(
         pair_price=aligned_pair[-1][1],
         unwind_cost_bps=params.expected_unwind_cost_bps,
     )
+    ending_equity = max(0.0, ending_equity)
     if not equity_curve or ending_equity != equity_curve[-1]:
         equity_curve.append(ending_equity)
 

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -839,6 +839,9 @@ def _load_backtest_markets(
 
 
 def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
+    if not equity_curve:
+        return 0.0, 0.0
+    bankroll = equity_curve[0]
     peak = float("-inf")
     max_dd_usd = 0.0
     max_dd_pct = 0.0
@@ -849,7 +852,7 @@ def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
         drawdown_pct = (drawdown / peak) * 100.0 if peak > 0 else 0.0
         max_dd_usd = max(max_dd_usd, drawdown)
         max_dd_pct = max(max_dd_pct, drawdown_pct)
-    return max_dd_usd, max_dd_pct
+    return min(max_dd_usd, bankroll), min(max_dd_pct, 100.0)
 
 
 def _annualized_return_pct(starting: float, ending: float, days: int) -> float:
@@ -1082,7 +1085,7 @@ def run_backtest(
     equity_curve = [p.bankroll_usd]
     equity = p.bankroll_usd
     for event_pnl in event_pnls:
-        equity += event_pnl
+        equity = max(0.0, equity + event_pnl)
         equity_curve.append(equity)
 
     total_pnl = equity - p.bankroll_usd

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -900,6 +900,9 @@ def _load_backtest_markets(
 
 
 def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
+    if not equity_curve:
+        return 0.0, 0.0
+    bankroll = equity_curve[0]
     peak = float("-inf")
     max_dd_usd = 0.0
     max_dd_pct = 0.0
@@ -910,7 +913,7 @@ def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
         drawdown_pct = (drawdown / peak) * 100.0 if peak > 0 else 0.0
         max_dd_usd = max(max_dd_usd, drawdown)
         max_dd_pct = max(max_dd_pct, drawdown_pct)
-    return max_dd_usd, max_dd_pct
+    return min(max_dd_usd, bankroll), min(max_dd_pct, 100.0)
 
 
 def _annualized_return_pct(starting: float, ending: float, days: int) -> float:
@@ -1143,7 +1146,7 @@ def run_backtest(
     equity_curve = [p.bankroll_usd]
     equity = p.bankroll_usd
     for event_pnl in event_pnls:
-        equity += event_pnl
+        equity = max(0.0, equity + event_pnl)
         equity_curve.append(equity)
 
     total_pnl = equity - p.bankroll_usd

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -1186,13 +1186,16 @@ def _fetch_live_quote_markets(config: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _max_drawdown(equity_curve: list[float]) -> float:
+    if not equity_curve:
+        return 0.0
+    bankroll = equity_curve[0]
     peak = float("-inf")
     max_dd = 0.0
     for value in equity_curve:
         if value > peak:
             peak = value
         max_dd = max(max_dd, peak - value)
-    return max_dd
+    return min(max_dd, bankroll)
 
 
 def _build_quote_plan(
@@ -1482,12 +1485,12 @@ def _simulate_market_backtest(
             skipped += 1
             telemetry.append(record)
             equity_curve.append(
-                _liquidation_equity(
+                max(0.0, _liquidation_equity(
                     cash_usd=cash_usd,
                     position_shares=position_shares,
                     mark_price=next_price,
                     unwind_cost_bps=strategy_params.expected_unwind_cost_bps,
-                )
+                ))
             )
             continue
 
@@ -1571,12 +1574,12 @@ def _simulate_market_backtest(
         if equity_after <= 0.0:
             break
 
-    ending_equity = _liquidation_equity(
+    ending_equity = max(0.0, _liquidation_equity(
         cash_usd=cash_usd,
         position_shares=position_shares,
         mark_price=history[-1][1],
         unwind_cost_bps=strategy_params.expected_unwind_cost_bps,
-    )
+    ))
     if not equity_curve or ending_equity != equity_curve[-1]:
         equity_curve.append(ending_equity)
     return {

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -839,6 +839,9 @@ def _load_backtest_markets(
 
 
 def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
+    if not equity_curve:
+        return 0.0, 0.0
+    bankroll = equity_curve[0]
     peak = float("-inf")
     max_dd_usd = 0.0
     max_dd_pct = 0.0
@@ -849,7 +852,7 @@ def _max_drawdown_stats(equity_curve: list[float]) -> tuple[float, float]:
         drawdown_pct = (drawdown / peak) * 100.0 if peak > 0 else 0.0
         max_dd_usd = max(max_dd_usd, drawdown)
         max_dd_pct = max(max_dd_pct, drawdown_pct)
-    return max_dd_usd, max_dd_pct
+    return min(max_dd_usd, bankroll), min(max_dd_pct, 100.0)
 
 
 def _annualized_return_pct(starting: float, ending: float, days: int) -> float:
@@ -1082,7 +1085,7 @@ def run_backtest(
     equity_curve = [p.bankroll_usd]
     equity = p.bankroll_usd
     for event_pnl in event_pnls:
-        equity += event_pnl
+        equity = max(0.0, equity + event_pnl)
         equity_curve.append(equity)
 
     total_pnl = equity - p.bankroll_usd


### PR DESCRIPTION
## Summary
- Clamp equity curve values at 0 so equity never goes negative (cannot lose more than bankroll)
- Cap _max_drawdown / _max_drawdown_stats return values at the bankroll
- Fix Alpaca compute_drawdown peak initialisation from -10**18 to 0
- Remove artificial drawdown inflation (+ 0.10 * gross / 100.0) in Alpaca stress-test calculations

## Affected Files (7)
- polymarket/maker-rebate-bot/scripts/agent.py
- polymarket/liquidity-paired-basis-maker/scripts/agent.py
- polymarket/high-throughput-paired-basis-maker/scripts/agent.py
- polymarket/paired-market-basis-maker/scripts/agent.py
- polymarket/_shared/pair_stateful_replay.py
- alpaca/saas-short-trader/scripts/strategy_engine.py
- alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py

## Test plan
- Run 90-day backtest on maker-rebate-bot and verify max_drawdown_usd <= bankroll_usd
- Run backtests on paired-basis bots and verify drawdown clamping
- Verify Alpaca strategy engine compile and drawdown values are realistic

Closes #108

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com