### PR TITLE
fix: correct wallet API response parsing in _check_serenbucks_balance

### DIFF
--- a/alphagrowth/euler-base-vault-bot/scripts/agent.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -698,7 +698,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -1842,7 +1842,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/curve/curve-gauge-yield-trader/scripts/agent.py
+++ b/curve/curve-gauge-yield-trader/scripts/agent.py
@@ -1610,7 +1610,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
+++ b/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
@@ -498,7 +498,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -800,7 +800,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -410,7 +410,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -1588,7 +1588,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/ledger/ledger-signing/scripts/agent.py
+++ b/ledger/ledger-signing/scripts/agent.py
@@ -342,7 +342,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -912,7 +912,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -973,7 +973,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -731,7 +731,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -912,7 +912,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/seren/customer-support-intake/scripts/agent.py
+++ b/seren/customer-support-intake/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/seren/job-seeker/scripts/agent.py
+++ b/seren/job-seeker/scripts/agent.py
@@ -1169,7 +1169,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/seren/seren-scheduler/scripts/agent.py
+++ b/seren/seren-scheduler/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -380,7 +380,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/wellsfargo/budget-tracker/scripts/agent.py
+++ b/wellsfargo/budget-tracker/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/wellsfargo/net-worth-tracker/scripts/agent.py
+++ b/wellsfargo/net-worth-tracker/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/wellsfargo/tax-prep/scripts/agent.py
+++ b/wellsfargo/tax-prep/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/wellsfargo/vendor-analysis/scripts/agent.py
+++ b/wellsfargo/vendor-analysis/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:

--- a/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
+++ b/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
@@ -78,7 +78,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("serenbucks") or {}
+            sb = data.get("data") or data.get("serenbucks") or {}
             raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
             return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
     except Exception as exc:


### PR DESCRIPTION
## Summary

- The `/wallet/balance` API returns `{"data": {"balance_usd": "$22.77", ...}}` but the code was parsing `data.get("serenbucks")` which doesn't exist in the response
- Changed all 22 agent.py files to use `data.get("data") or data.get("serenbucks") or {}` for forward-compatibility
- Verified: balance now correctly returns $22.77 instead of $0.00

## Root Cause

The MCP tool `get_wallet_status` reformats the raw API response into a `{"serenbucks": {...}}` structure, but the raw HTTP API returns `{"data": {...}}`. PR #106 and #109 were written against the MCP response shape, not the raw API shape.

## Test plan

- [x] All 22 files pass `ast.parse()` syntax validation
- [x] Manual test: `_check_serenbucks_balance` now returns $22.77 (was $0.00)
- [x] Parsing tries `data` key first, falls back to `serenbucks` for compatibility

Fixes #111

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com