### PR TITLE
docs: update SKILL.md files for wallet balance check

### DIFF
--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -882,7 +882,6 @@ def calculate_position_size(fair_value, market_price, bankroll, max_kelly=0.06):
 - Web dashboard (command-line only)
 - Email/webhook notifications (file logs only)
 - Backtesting with historical data
-- Real-time Polymarket balance checking (placeholder returns $0.00)
 
 ---
 

--- a/seren/api/SKILL.md
+++ b/seren/api/SKILL.md
@@ -158,6 +158,31 @@ curl -sS -X GET "https://api.serendb.com/wallet/balance" \
   -H "Authorization: Bearer $SEREN_API_KEY"
 ```
 
+**Response:**
+
+```json
+{
+  "data": {
+    "wallet_address": "0x...",
+    "balance_atomic": 22771925,
+    "balance_usd": "$22.77",
+    "funded_balance_atomic": 22171925,
+    "funded_balance_usd": "$22.17",
+    "promotional_balance_atomic": 600000,
+    "promotional_balance_usd": "$0.60",
+    "by_source": [],
+    "total_purchases_cents": 12500,
+    "total_purchases_usd": "$125.00",
+    "has_recovery": true
+  }
+}
+```
+
+> **Note:** The raw HTTP API wraps the payload in a `"data"` key. The Seren MCP
+> tool `get_wallet_status` reformats this into `{"serenbucks": {...}}`. Code that
+> calls the HTTP API directly should use `data.get("data")` to extract the balance
+> fields. See [seren-core#103](https://github.com/serenorg/seren-core/issues/103).
+
 ### POST `/wallet/deposit`
 
 ```bash


### PR DESCRIPTION
## Summary

- Remove stale placeholder-returns-0 line from polymarket/bot/SKILL.md — _check_serenbucks_balance is now implemented (PRs #109, #112)
- Add the actual GET /wallet/balance JSON response shape to seren/api/SKILL.md with a note explaining the data envelope vs the MCP tool serenbucks format
- References seren-core#103 (upstream envelope issue)

## Test plan

- [ ] Verify polymarket/bot/SKILL.md no longer lists balance checking as Not Implemented
- [ ] Verify seren/api/SKILL.md documents the data response envelope

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com