### PR TITLE
fix: migrate deprecated maker backtest history url

### DIFF
--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -35,8 +35,12 @@ SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
 SEREN_POLYMARKET_PUBLISHER_PREFIX = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}"
 SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
+SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
 SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
+)
+SEREN_POLYMARKET_TRADING_URL_PREFIX = (
+    f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
 )
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
@@ -259,11 +263,28 @@ def _extract_live_book(payload: dict[str, Any], mid_price: float) -> tuple[float
 
 
 def _canonicalize_history_url(url: str) -> str:
-    parsed = urlparse(url)
+    trimmed = url.strip()
+    if not trimmed:
+        return trimmed
+    if trimmed.startswith(SEREN_POLYMARKET_TRADING_URL_PREFIX):
+        parsed = urlparse(trimmed)
+        if parsed.path in {
+            f"{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}/prices-history",
+            f"{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}/trades",
+        }:
+            return urlunparse(
+                parsed._replace(
+                    scheme="https",
+                    netloc="clob.polymarket.com",
+                    path="/prices-history",
+                )
+            )
+
+    parsed = urlparse(trimmed)
     if parsed.path.endswith("/trades"):
         path = parsed.path[: -len("/trades")] + "/prices-history"
         return urlunparse(parsed._replace(path=path))
-    return url
+    return trimmed
 
 
 def to_params(config: dict[str, Any]) -> StrategyParams:

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -289,6 +289,16 @@ def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
     assert backtest.get("clob_history_url", "").endswith("/prices-history")
 
 
+def test_deprecated_history_publisher_url_is_canonicalized_to_direct_clob() -> None:
+    agent = _load_agent_module()
+
+    deprecated = "https://api.serendb.com/publishers/polymarket-trading-serenai/prices-history"
+    assert agent._canonicalize_history_url(deprecated) == "https://clob.polymarket.com/prices-history"
+    assert agent._canonicalize_history_url(f"{deprecated}?market=abc&interval=max") == (
+        "https://clob.polymarket.com/prices-history?market=abc&interval=max"
+    )
+
+
 def test_backtest_rejects_non_seren_polymarket_data_source(tmp_path: Path) -> None:
     bad_gamma_url = "https://gamma" + "-api." + "polymarket.com/markets"
     bad_clob_url = "https://evil." + "example.com/prices-history"


### PR DESCRIPTION
Fixes #114

## Summary
- migrate deprecated `polymarket-trading-serenai/prices-history` history URLs to direct CLOB history
- preserve existing query strings during migration
- add a regression test so stale installed configs keep working after the history-source move

## Why
The current repo `main` backtests successfully, but older installed skill copies and copied configs can still point at the deprecated history source and fail in practice. This change makes the runtime tolerate that older config shape instead of depending on manual user edits.

## Validation
- `pytest -q polymarket/maker-rebate-bot/tests/test_smoke.py`
- `python3 -u scripts/agent.py --config config.example.json` from `polymarket/maker-rebate-bot`
