### PR TITLE
fix(polymarket): remove placeholder market IDs that break backtests

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -44,7 +44,7 @@ Live execution requires both:
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
-- `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
+- `config.example.json` - strategy parameters and live backtest defaults
 - `.env.example` - environment template for API credentials
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
@@ -62,6 +62,10 @@ python3 scripts/agent.py --config config.json
 ```
 
 If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
+
+> **Live market data only.** Always leave `"markets": []` and `"state": {"leg_exposure": {}}` empty in your config.json.
+> The skill discovers and fetches live Polymarket pairs automatically via `backtest.gamma_markets_url`.
+> Never add placeholder market IDs — they do not exist on Polymarket and will cause the backtest to fail with "No markets with sufficient history".
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -52,35 +52,8 @@
     "max_leg_notional_usd": 900
   },
   "state": {
-    "leg_exposure": {
-      "US-RECESSION-2026": 40,
-      "US-GDP-CONTRACTION-2026": -34
-    }
+    "_note": "Leave leg_exposure empty. The skill populates this from live position state.",
+    "leg_exposure": {}
   },
-  "markets": [
-    {
-      "market_id": "US-RECESSION-2026",
-      "pair_market_id": "US-GDP-CONTRACTION-2026",
-      "mid_price": 0.44,
-      "pair_mid_price": 0.39,
-      "seconds_to_resolution": 345600,
-      "basis_volatility_bps": 88
-    },
-    {
-      "market_id": "US-CPI-HOTTER-THAN-4",
-      "pair_market_id": "US-INFLATION-STICKY-4",
-      "mid_price": 0.36,
-      "pair_mid_price": 0.355,
-      "seconds_to_resolution": 259200,
-      "basis_volatility_bps": 41
-    },
-    {
-      "market_id": "FED-CUT-BEFORE-JULY",
-      "pair_market_id": "FED-HOLD-THROUGH-JULY",
-      "mid_price": 0.52,
-      "pair_mid_price": 0.47,
-      "seconds_to_resolution": 432000,
-      "basis_volatility_bps": 77
-    }
-  ]
+  "markets": []
 }

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -44,7 +44,7 @@ Live execution requires both:
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
-- `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
+- `config.example.json` - strategy parameters and live backtest defaults
 - `.env.example` - optional fallback auth/env template (`SEREN_API_KEY` only if runtime auth is unavailable)
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
@@ -62,6 +62,10 @@ python3 scripts/agent.py --config config.json
 ```
 
 If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
+
+> **Live market data only.** Always leave `"markets": []` and `"state": {"leg_exposure": {}}` empty in your config.json.
+> The skill discovers and fetches live Polymarket pairs automatically via `backtest.gamma_markets_url`.
+> Never add placeholder market IDs — they do not exist on Polymarket and will cause the backtest to fail with "No markets with sufficient history".
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -52,35 +52,8 @@
     "max_leg_notional_usd": 800
   },
   "state": {
-    "leg_exposure": {
-      "US-RECESSION-2026": 40,
-      "US-GDP-CONTRACTION-2026": -34
-    }
+    "_note": "Leave leg_exposure empty. The skill populates this from live position state.",
+    "leg_exposure": {}
   },
-  "markets": [
-    {
-      "market_id": "US-RECESSION-2026",
-      "pair_market_id": "US-GDP-CONTRACTION-2026",
-      "mid_price": 0.44,
-      "pair_mid_price": 0.39,
-      "seconds_to_resolution": 345600,
-      "basis_volatility_bps": 88
-    },
-    {
-      "market_id": "US-CPI-HOTTER-THAN-4",
-      "pair_market_id": "US-INFLATION-STICKY-4",
-      "mid_price": 0.36,
-      "pair_mid_price": 0.355,
-      "seconds_to_resolution": 259200,
-      "basis_volatility_bps": 41
-    },
-    {
-      "market_id": "FED-CUT-BEFORE-JULY",
-      "pair_market_id": "FED-HOLD-THROUGH-JULY",
-      "mid_price": 0.52,
-      "pair_mid_price": 0.47,
-      "seconds_to_resolution": 432000,
-      "basis_volatility_bps": 77
-    }
-  ]
+  "markets": []
 }

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -60,6 +60,10 @@ python3 scripts/agent.py --config config.json
 This runs the default 90-day backtest and returns a decision hint to keep paper-only or proceed to quote mode.
 If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
 
+> **Live market data only.** Always leave `"markets": []` and `"state": {"inventory": {}}` empty in your config.json.
+> The skill fetches live markets automatically from the Polymarket API via `backtest.gamma_markets_url`.
+> Never add placeholder or example market IDs (e.g. `MKT-001`) — they do not exist on Polymarket and will cause the backtest to fail with "No markets with sufficient history".
+
 ## Run Quote Mode (After Backtest Review)
 
 ```bash

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -47,28 +47,8 @@
     "inventory_skew_strength_bps": 25
   },
   "state": {
-    "inventory": {
-      "MKT-001": 15,
-      "MKT-002": -8
-    }
+    "_note": "Leave inventory empty. The skill populates this from live order/position state.",
+    "inventory": {}
   },
-  "markets": [
-    {
-      "market_id": "MKT-001",
-      "mid_price": 0.48,
-      "best_bid": 0.47,
-      "best_ask": 0.49,
-      "seconds_to_resolution": 86400,
-      "volatility_bps": 80
-    },
-    {
-      "market_id": "MKT-002",
-      "mid_price": 0.62,
-      "best_bid": 0.61,
-      "best_ask": 0.63,
-      "seconds_to_resolution": 43200,
-      "volatility_bps": 55,
-      "rebate_bps": 2
-    }
-  ]
+  "markets": []
 }

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -44,7 +44,7 @@ Live execution requires both:
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime
-- `config.example.json` - strategy parameters, live backtest defaults, and trade-mode sample markets
+- `config.example.json` - strategy parameters and live backtest defaults
 - `.env.example` - environment template for API credentials
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
@@ -62,6 +62,10 @@ python3 scripts/agent.py --config config.json
 ```
 
 If you are already running inside Seren Desktop, the runtime can use injected auth automatically.
+
+> **Live market data only.** Always leave `"markets": []` and `"state": {"leg_exposure": {}}` empty in your config.json.
+> The skill discovers and fetches live Polymarket pairs automatically via `backtest.gamma_markets_url`.
+> Never add placeholder market IDs — they do not exist on Polymarket and will cause the backtest to fail with "No markets with sufficient history".
 
 ## Run Trade Mode (Backtest-First)
 

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -52,35 +52,8 @@
     "max_leg_notional_usd": 800
   },
   "state": {
-    "leg_exposure": {
-      "US-RECESSION-2026": 40,
-      "US-GDP-CONTRACTION-2026": -34
-    }
+    "_note": "Leave leg_exposure empty. The skill populates this from live position state.",
+    "leg_exposure": {}
   },
-  "markets": [
-    {
-      "market_id": "US-RECESSION-2026",
-      "pair_market_id": "US-GDP-CONTRACTION-2026",
-      "mid_price": 0.44,
-      "pair_mid_price": 0.39,
-      "seconds_to_resolution": 345600,
-      "basis_volatility_bps": 88
-    },
-    {
-      "market_id": "US-CPI-HOTTER-THAN-4",
-      "pair_market_id": "US-INFLATION-STICKY-4",
-      "mid_price": 0.36,
-      "pair_mid_price": 0.355,
-      "seconds_to_resolution": 259200,
-      "basis_volatility_bps": 41
-    },
-    {
-      "market_id": "FED-CUT-BEFORE-JULY",
-      "pair_market_id": "FED-HOLD-THROUGH-JULY",
-      "mid_price": 0.52,
-      "pair_mid_price": 0.47,
-      "seconds_to_resolution": 432000,
-      "basis_volatility_bps": 77
-    }
-  ]
+  "markets": []
 }


### PR DESCRIPTION
## Summary

Fixes #118.

Removes fake placeholder market IDs from all 4 Polymarket trading skill `config.example.json` files that caused backtests to fail with **"No markets with sufficient history were available for backtest"**.

## Root Cause

`config.example.json` files contained illustrative sample data in the `markets` array and `state` object:
- **maker-rebate-bot**: `MKT-001`, `MKT-002` in `markets[]` and `state.inventory`
- **basis makers (3x)**: `US-RECESSION-2026`, `FED-CUT-BEFORE-JULY`, etc. in `markets[]` and `state.leg_exposure`

When users followed the Quick Start (`cp config.example.json config.json`), the fake IDs were loaded. The agent tried to fetch history for non-existent markets → found nothing → aborted.

The backtest API endpoint (`backtest.gamma_markets_url`) already points to live Polymarket data. The fix ensures nothing in `config.json` overrides it with fake data.

## Changes

**config.example.json (4 files):**
- `markets: []` — empty, skill auto-discovers live markets
- `state.inventory: {}` / `state.leg_exposure: {}` — empty, skill loads from live state
- `_note` field added explaining markets must stay empty

**SKILL.md (4 files):**
- Added live-data-only warning block in Quick Start sections
- Fixed misleading "trade-mode sample markets" description in Runtime Files

## Test Plan

- [ ] Copy `config.example.json` to `config.json` and run backtest — should fetch live markets
- [ ] Confirm no placeholder IDs (MKT-001, US-RECESSION-2026, etc.) appear in any config.example.json
- [ ] Backtest completes without "No markets with sufficient history" error

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com