### PR TITLE
feat(prophet): publish Prophet v1 skill family

### DIFF
--- a/prophet/prophet-adversarial-auditor/.env.example
+++ b/prophet/prophet-adversarial-auditor/.env.example
@@ -1,0 +1,4 @@
+# Generated SkillForge environment template for prophet-adversarial-auditor
+SEREN_API_KEY=
+PROPHET_SESSION_TOKEN=
+

--- a/prophet/prophet-adversarial-auditor/SKILL.md
+++ b/prophet/prophet-adversarial-auditor/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: prophet-adversarial-auditor
+description: "Inspect Prophet market creation history for rejected submissions, replayable failures, suspicious patterns, and plausible economic loss scenarios with structured findings for operators."
+---
+
+# Prophet Adversarial Auditor
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- audit Prophet market creation failures
+- review Prophet rejected submissions
+- inspect Prophet bugs and loss scenarios
+- check Prophet auditor status
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `connect_storage` uses `connector.storage.connect`
+3. `load_run_history` uses `connector.storage.query`
+4. `replay_recent_runs` uses `transform.replay_recent_runs`
+5. `detect_findings` uses `transform.detect_audit_findings`
+6. `analyze_loss_scenarios` uses `transform.analyze_loss_hypotheses`
+7. `rank_findings` uses `transform.rank_findings`
+8. `persist_audit_outputs` uses `connector.storage.upsert`
+9. `render_summary` uses `transform.render_report`

--- a/prophet/prophet-adversarial-auditor/config.example.json
+++ b/prophet/prophet-adversarial-auditor/config.example.json
@@ -1,0 +1,14 @@
+{
+  "connectors": [
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "command": "run",
+    "include_loss_hypotheses": true,
+    "json_output": false,
+    "lookback_days": 30,
+    "severity_threshold": "medium"
+  },
+  "skill": "prophet-adversarial-auditor"
+}

--- a/prophet/prophet-adversarial-auditor/requirements.txt
+++ b/prophet/prophet-adversarial-auditor/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for this generated scaffold.

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for prophet-adversarial-auditor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['storage']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prophet/prophet-adversarial-auditor/skill.spec.yaml
+++ b/prophet/prophet-adversarial-auditor/skill.spec.yaml
@@ -1,0 +1,136 @@
+skill: prophet-adversarial-auditor
+description: Inspect Prophet market creation history for rejected submissions, replayable failures, suspicious patterns, and plausible economic loss scenarios with structured findings for operators.
+triggers:
+  - audit Prophet market creation failures
+  - review Prophet rejected submissions
+  - inspect Prophet bugs and loss scenarios
+  - check Prophet auditor status
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  command:
+    type: string
+    description: Top-level skill command.
+    enum:
+      - setup
+      - run
+      - status
+    default: run
+  json_output:
+    type: boolean
+    description: Return machine-readable output when true.
+    default: false
+  lookback_days:
+    type: integer
+    description: Number of days of historical runs and submissions to inspect.
+    min: 1
+    max: 90
+    default: 30
+  severity_threshold:
+    type: string
+    description: Minimum finding severity to surface prominently.
+    enum:
+      - low
+      - medium
+      - high
+    default: medium
+  include_loss_hypotheses:
+    type: boolean
+    description: Include plausible economic leakage and loss scenarios in the report.
+    default: true
+secrets:
+  - SEREN_API_KEY
+  - PROPHET_SESSION_TOKEN
+connectors:
+  storage:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  runs:
+    kind: serendb
+    database: prophet
+    table: runs
+  audit_findings:
+    kind: serendb
+    database: prophet
+    table: audit_findings
+  loss_hypotheses:
+    kind: serendb
+    database: prophet
+    table: loss_hypotheses
+policies:
+  dry_run_default: true
+  idempotency_required: true
+workflow:
+  steps:
+    - id: normalize_request
+      use: transform.normalize_request
+      with:
+        command: "{command}"
+        json_output: "{json_output}"
+        severity_threshold: "{severity_threshold}"
+    - id: connect_storage
+      use: connector.storage.connect
+      with:
+        from_step: normalize_request
+    - id: load_run_history
+      use: connector.storage.query
+      with:
+        tables:
+          - runs
+          - events
+          - market_submissions
+          - artifacts
+        lookback_days: "{lookback_days}"
+        from_step: connect_storage
+    - id: replay_recent_runs
+      use: transform.replay_recent_runs
+      with:
+        from_step: load_run_history
+    - id: detect_findings
+      use: transform.detect_audit_findings
+      with:
+        severity_threshold: "{severity_threshold}"
+        from_step: replay_recent_runs
+    - id: analyze_loss_scenarios
+      use: transform.analyze_loss_hypotheses
+      with:
+        include_loss_hypotheses: "{include_loss_hypotheses}"
+        from_step: detect_findings
+    - id: rank_findings
+      use: transform.rank_findings
+      with:
+        severity_threshold: "{severity_threshold}"
+        from_step: analyze_loss_scenarios
+    - id: persist_audit_outputs
+      use: connector.storage.upsert
+      with:
+        tables:
+          - runs
+          - events
+          - audit_findings
+          - loss_hypotheses
+          - artifacts
+        from_step: rank_findings
+    - id: render_summary
+      use: transform.render_report
+      with:
+        json_output: "{json_output}"
+        from_step: persist_audit_outputs
+tests:
+  quick:
+    - validates_command_enum
+    - validates_lookback_window_range
+    - validates_severity_threshold_enum
+  smoke:
+    - replays_recent_runs_from_fixture
+    - ranks_findings_by_severity
+    - renders_loss_hypothesis_summary_from_fixture
+publish:
+  org: prophet
+  slug: prophet-adversarial-auditor
+metadata:
+  category: diagnostics
+  product_role: operator
+  family: prophet-v1

--- a/prophet/prophet-adversarial-auditor/tests/fixtures/connector_failure.json
+++ b/prophet/prophet-adversarial-auditor/tests/fixtures/connector_failure.json
@@ -1,0 +1,29 @@
+{
+  "status": "error",
+  "skill": "prophet-adversarial-auditor",
+  "error_code": "connector_failure",
+  "connector": "storage",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "error",
+        "connector": "storage",
+        "action": "connect",
+        "error_code": "connector_failure"
+      },
+      "query": {
+        "status": "error",
+        "connector": "storage",
+        "action": "query",
+        "error_code": "connector_failure"
+      },
+      "upsert": {
+        "status": "error",
+        "connector": "storage",
+        "action": "upsert",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/prophet/prophet-adversarial-auditor/tests/fixtures/dry_run_guard.json
+++ b/prophet/prophet-adversarial-auditor/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "prophet-adversarial-auditor",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/prophet/prophet-adversarial-auditor/tests/fixtures/happy_path.json
+++ b/prophet/prophet-adversarial-auditor/tests/fixtures/happy_path.json
@@ -1,0 +1,32 @@
+{
+  "status": "ok",
+  "skill": "prophet-adversarial-auditor",
+  "workflow_step_count": 9,
+  "dry_run": true,
+  "inputs": {
+    "command": "run",
+    "include_loss_hypotheses": true,
+    "json_output": false,
+    "lookback_days": 30,
+    "severity_threshold": "medium"
+  },
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "connect"
+      },
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/prophet/prophet-adversarial-auditor/tests/fixtures/policy_violation.json
+++ b/prophet/prophet-adversarial-auditor/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "prophet-adversarial-auditor",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/prophet/prophet-adversarial-auditor/tests/test_smoke.py
+++ b/prophet/prophet-adversarial-auditor/tests/test_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "prophet-adversarial-auditor"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"
+

--- a/prophet/prophet-growth-agent/.env.example
+++ b/prophet/prophet-growth-agent/.env.example
@@ -1,0 +1,4 @@
+# Generated SkillForge environment template for prophet-growth-agent
+SEREN_API_KEY=
+PROPHET_SESSION_TOKEN=
+

--- a/prophet/prophet-growth-agent/SKILL.md
+++ b/prophet/prophet-growth-agent/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: prophet-growth-agent
+description: "Reinforce repeat Prophet market creation with lightweight status checks, progress tracking, reminder copy, and re-engagement recommendations after first success."
+---
+
+# Prophet Growth Agent
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- check Prophet growth agent status
+- generate Prophet re-engagement reminders
+- track progress toward repeated Prophet market creation
+- run Prophet growth follow-up
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `connect_storage` uses `connector.storage.connect`
+3. `load_recent_activity` uses `connector.storage.query`
+4. `compute_progress` uses `transform.compute_repeat_creation_progress`
+5. `generate_checkin_actions` uses `transform.generate_checkin_actions`
+6. `compose_reminder_copy` uses `transform.compose_reminder_copy`
+7. `persist_growth_outputs` uses `connector.storage.upsert`
+8. `render_summary` uses `transform.render_report`

--- a/prophet/prophet-growth-agent/config.example.json
+++ b/prophet/prophet-growth-agent/config.example.json
@@ -1,0 +1,14 @@
+{
+  "connectors": [
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "command": "status",
+    "json_output": false,
+    "recent_window_days": 7,
+    "reminder_enabled": true,
+    "weekly_target_markets": 3
+  },
+  "skill": "prophet-growth-agent"
+}

--- a/prophet/prophet-growth-agent/requirements.txt
+++ b/prophet/prophet-growth-agent/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for this generated scaffold.

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for prophet-growth-agent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['storage']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prophet/prophet-growth-agent/skill.spec.yaml
+++ b/prophet/prophet-growth-agent/skill.spec.yaml
@@ -1,0 +1,130 @@
+skill: prophet-growth-agent
+description: Reinforce repeat Prophet market creation with lightweight status checks, progress tracking, reminder copy, and re-engagement recommendations after first success.
+triggers:
+  - check Prophet growth agent status
+  - generate Prophet re-engagement reminders
+  - track progress toward repeated Prophet market creation
+  - run Prophet growth follow-up
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  command:
+    type: string
+    description: Top-level skill command.
+    enum:
+      - setup
+      - run
+      - status
+    default: status
+  json_output:
+    type: boolean
+    description: Return machine-readable output when true.
+    default: false
+  recent_window_days:
+    type: integer
+    description: Lookback window used for recent creation activity and check-ins.
+    min: 1
+    max: 30
+    default: 7
+  weekly_target_markets:
+    type: integer
+    description: Target number of markets created per week.
+    min: 1
+    max: 10
+    default: 3
+  reminder_enabled:
+    type: boolean
+    description: Enable reminder and re-engagement copy generation.
+    default: true
+secrets:
+  - SEREN_API_KEY
+  - PROPHET_SESSION_TOKEN
+connectors:
+  storage:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  runs:
+    kind: serendb
+    database: prophet
+    table: runs
+  engagement_events:
+    kind: serendb
+    database: prophet
+    table: engagement_events
+  checkin_recommendations:
+    kind: serendb
+    database: prophet
+    table: checkin_recommendations
+policies:
+  dry_run_default: true
+  idempotency_required: true
+workflow:
+  steps:
+    - id: normalize_request
+      use: transform.normalize_request
+      with:
+        command: "{command}"
+        json_output: "{json_output}"
+        reminder_enabled: "{reminder_enabled}"
+    - id: connect_storage
+      use: connector.storage.connect
+      with:
+        from_step: normalize_request
+    - id: load_recent_activity
+      use: connector.storage.query
+      with:
+        tables:
+          - sessions
+          - runs
+          - market_submissions
+          - engagement_events
+        recent_window_days: "{recent_window_days}"
+        from_step: connect_storage
+    - id: compute_progress
+      use: transform.compute_repeat_creation_progress
+      with:
+        weekly_target_markets: "{weekly_target_markets}"
+        from_step: load_recent_activity
+    - id: generate_checkin_actions
+      use: transform.generate_checkin_actions
+      with:
+        command: "{command}"
+        from_step: compute_progress
+    - id: compose_reminder_copy
+      use: transform.compose_reminder_copy
+      with:
+        reminder_enabled: "{reminder_enabled}"
+        from_step: generate_checkin_actions
+    - id: persist_growth_outputs
+      use: connector.storage.upsert
+      with:
+        tables:
+          - runs
+          - events
+          - engagement_events
+          - checkin_recommendations
+          - artifacts
+        from_step: compose_reminder_copy
+    - id: render_summary
+      use: transform.render_report
+      with:
+        json_output: "{json_output}"
+        from_step: persist_growth_outputs
+tests:
+  quick:
+    - validates_command_enum
+    - validates_recent_window_range
+    - validates_weekly_target_range
+  smoke:
+    - computes_progress_toward_three_markets_per_week
+    - generates_checkin_recommendations_from_fixture
+    - renders_reengagement_summary_from_fixture
+publish:
+  org: prophet
+  slug: prophet-growth-agent
+metadata:
+  category: retention
+  product_role: secondary
+  family: prophet-v1

--- a/prophet/prophet-growth-agent/tests/fixtures/connector_failure.json
+++ b/prophet/prophet-growth-agent/tests/fixtures/connector_failure.json
@@ -1,0 +1,29 @@
+{
+  "status": "error",
+  "skill": "prophet-growth-agent",
+  "error_code": "connector_failure",
+  "connector": "storage",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "error",
+        "connector": "storage",
+        "action": "connect",
+        "error_code": "connector_failure"
+      },
+      "query": {
+        "status": "error",
+        "connector": "storage",
+        "action": "query",
+        "error_code": "connector_failure"
+      },
+      "upsert": {
+        "status": "error",
+        "connector": "storage",
+        "action": "upsert",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/prophet/prophet-growth-agent/tests/fixtures/dry_run_guard.json
+++ b/prophet/prophet-growth-agent/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "prophet-growth-agent",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/prophet/prophet-growth-agent/tests/fixtures/happy_path.json
+++ b/prophet/prophet-growth-agent/tests/fixtures/happy_path.json
@@ -1,0 +1,32 @@
+{
+  "status": "ok",
+  "skill": "prophet-growth-agent",
+  "workflow_step_count": 8,
+  "dry_run": true,
+  "inputs": {
+    "command": "status",
+    "json_output": false,
+    "recent_window_days": 7,
+    "reminder_enabled": true,
+    "weekly_target_markets": 3
+  },
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "connect"
+      },
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/prophet/prophet-growth-agent/tests/fixtures/policy_violation.json
+++ b/prophet/prophet-growth-agent/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "prophet-growth-agent",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/prophet/prophet-growth-agent/tests/test_smoke.py
+++ b/prophet/prophet-growth-agent/tests/test_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "prophet-growth-agent"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"
+

--- a/prophet/prophet-market-seeder/.env.example
+++ b/prophet/prophet-market-seeder/.env.example
@@ -1,0 +1,4 @@
+# Generated SkillForge environment template for prophet-market-seeder
+SEREN_API_KEY=
+PROPHET_SESSION_TOKEN=
+

--- a/prophet/prophet-market-seeder/SKILL.md
+++ b/prophet/prophet-market-seeder/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: prophet-market-seeder
+description: "Take referred Prophet users from setup through bounded market creation with referral-aware auth checks, candidate scoring, filtered submission, and clear run reporting."
+---
+
+# Prophet Market Seeder
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create Prophet markets from an affiliate referral flow
+- set up Prophet market seeding
+- run Prophet market candidate generation and submission
+- check Prophet market seeder status
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `validate_referral_context` uses `transform.validate_referral_context`
+3. `validate_prophet_access` uses `transform.validate_prophet_access`
+4. `connect_storage` uses `connector.storage.connect`
+5. `load_recent_context` uses `connector.storage.query`
+6. `generate_candidates` uses `transform.generate_market_candidates`
+7. `score_candidates` uses `transform.score_market_candidates`
+8. `filter_candidates` uses `transform.filter_market_candidates`
+9. `submit_candidates` uses `transform.submit_market_batch`
+10. `persist_run` uses `connector.storage.upsert`
+11. `render_summary` uses `transform.render_report`

--- a/prophet/prophet-market-seeder/config.example.json
+++ b/prophet/prophet-market-seeder/config.example.json
@@ -1,0 +1,15 @@
+{
+  "connectors": [
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "candidate_limit": 12,
+    "command": "run",
+    "json_output": false,
+    "referral_code": "AGENTACCESS",
+    "strict_mode": true,
+    "submit_limit": 3
+  },
+  "skill": "prophet-market-seeder"
+}

--- a/prophet/prophet-market-seeder/requirements.txt
+++ b/prophet/prophet-market-seeder/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for this generated scaffold.

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for prophet-market-seeder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['storage']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prophet/prophet-market-seeder/skill.spec.yaml
+++ b/prophet/prophet-market-seeder/skill.spec.yaml
@@ -1,0 +1,148 @@
+skill: prophet-market-seeder
+description: Take referred Prophet users from setup through bounded market creation with referral-aware auth checks, candidate scoring, filtered submission, and clear run reporting.
+triggers:
+  - create Prophet markets from an affiliate referral flow
+  - set up Prophet market seeding
+  - run Prophet market candidate generation and submission
+  - check Prophet market seeder status
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  command:
+    type: string
+    description: Top-level skill command.
+    enum:
+      - setup
+      - run
+      - status
+    default: run
+  json_output:
+    type: boolean
+    description: Return machine-readable output when true.
+    default: false
+  referral_code:
+    type: string
+    description: Prophet referral code used for affiliate attribution.
+    default: AGENTACCESS
+  candidate_limit:
+    type: integer
+    description: Maximum number of market candidates to generate before filtering.
+    min: 1
+    max: 25
+    default: 12
+  submit_limit:
+    type: integer
+    description: Maximum number of filtered candidates to submit in one run.
+    min: 1
+    max: 8
+    default: 3
+  strict_mode:
+    type: boolean
+    description: Block the run if quality or auth guardrails are not satisfied.
+    default: true
+secrets:
+  - SEREN_API_KEY
+  - PROPHET_SESSION_TOKEN
+connectors:
+  storage:
+    kind: seren_publisher
+    publisher: serendb
+state:
+  runs:
+    kind: serendb
+    database: prophet
+    table: runs
+  events:
+    kind: serendb
+    database: prophet
+    table: events
+  artifacts:
+    kind: serendb
+    database: prophet
+    table: artifacts
+policies:
+  dry_run_default: true
+  idempotency_required: true
+workflow:
+  steps:
+    - id: normalize_request
+      use: transform.normalize_request
+      with:
+        command: "{command}"
+        json_output: "{json_output}"
+        referral_code: "{referral_code}"
+    - id: validate_referral_context
+      use: transform.validate_referral_context
+      with:
+        strict_mode: "{strict_mode}"
+        from_step: normalize_request
+    - id: validate_prophet_access
+      use: transform.validate_prophet_access
+      with:
+        from_step: validate_referral_context
+    - id: connect_storage
+      use: connector.storage.connect
+      with:
+        from_step: validate_prophet_access
+    - id: load_recent_context
+      use: connector.storage.query
+      with:
+        tables:
+          - sessions
+          - runs
+          - market_submissions
+        from_step: connect_storage
+    - id: generate_candidates
+      use: transform.generate_market_candidates
+      with:
+        candidate_limit: "{candidate_limit}"
+        from_step: load_recent_context
+    - id: score_candidates
+      use: transform.score_market_candidates
+      with:
+        from_step: generate_candidates
+    - id: filter_candidates
+      use: transform.filter_market_candidates
+      with:
+        submit_limit: "{submit_limit}"
+        strict_mode: "{strict_mode}"
+        from_step: score_candidates
+    - id: submit_candidates
+      use: transform.submit_market_batch
+      with:
+        command: "{command}"
+        referral_code: "{referral_code}"
+        from_step: filter_candidates
+    - id: persist_run
+      use: connector.storage.upsert
+      with:
+        tables:
+          - sessions
+          - runs
+          - events
+          - market_candidates
+          - market_submissions
+          - artifacts
+        from_step: submit_candidates
+    - id: render_summary
+      use: transform.render_report
+      with:
+        json_output: "{json_output}"
+        from_step: persist_run
+tests:
+  quick:
+    - validates_command_enum
+    - defaults_referral_code_to_agentaccess
+    - bounds_candidate_and_submit_limits
+  smoke:
+    - generates_bounded_candidate_batch_from_fixture
+    - filters_candidates_before_submission
+    - renders_status_summary_from_fixture
+publish:
+  org: prophet
+  slug: prophet-market-seeder
+metadata:
+  category: market-creation
+  product_role: primary
+  family: prophet-v1

--- a/prophet/prophet-market-seeder/tests/fixtures/connector_failure.json
+++ b/prophet/prophet-market-seeder/tests/fixtures/connector_failure.json
@@ -1,0 +1,29 @@
+{
+  "status": "error",
+  "skill": "prophet-market-seeder",
+  "error_code": "connector_failure",
+  "connector": "storage",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "error",
+        "connector": "storage",
+        "action": "connect",
+        "error_code": "connector_failure"
+      },
+      "query": {
+        "status": "error",
+        "connector": "storage",
+        "action": "query",
+        "error_code": "connector_failure"
+      },
+      "upsert": {
+        "status": "error",
+        "connector": "storage",
+        "action": "upsert",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/prophet/prophet-market-seeder/tests/fixtures/dry_run_guard.json
+++ b/prophet/prophet-market-seeder/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "prophet-market-seeder",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/prophet/prophet-market-seeder/tests/fixtures/happy_path.json
+++ b/prophet/prophet-market-seeder/tests/fixtures/happy_path.json
@@ -1,0 +1,33 @@
+{
+  "status": "ok",
+  "skill": "prophet-market-seeder",
+  "workflow_step_count": 11,
+  "dry_run": true,
+  "inputs": {
+    "candidate_limit": 12,
+    "command": "run",
+    "json_output": false,
+    "referral_code": "AGENTACCESS",
+    "strict_mode": true,
+    "submit_limit": 3
+  },
+  "connectors": {
+    "storage": {
+      "connect": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "connect"
+      },
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/prophet/prophet-market-seeder/tests/fixtures/policy_violation.json
+++ b/prophet/prophet-market-seeder/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "prophet-market-seeder",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/prophet/prophet-market-seeder/tests/test_smoke.py
+++ b/prophet/prophet-market-seeder/tests/test_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "prophet-market-seeder"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"
+


### PR DESCRIPTION
## Summary
- publish the Prophet v1 three-skill family into `seren-skills/prophet`
- keep `prophet-market-seeder` as the primary entrypoint, with separate growth and auditor skills
- include generated Skillforge artifacts plus minimal `requirements.txt` files for each skill folder

## Skills
- `prophet-market-seeder`
- `prophet-growth-agent`
- `prophet-adversarial-auditor`

## Verification
- `python3 -m skillforge validate --spec artifacts/prophet/prophet-market-seeder/skill.spec.yaml`
- `python3 -m skillforge validate --spec artifacts/prophet/prophet-growth-agent/skill.spec.yaml`
- `python3 -m skillforge validate --spec artifacts/prophet/prophet-adversarial-auditor/skill.spec.yaml`
- `python3 -m skillforge generate --spec ... --out ...` for all three Prophet skills
- `python3 -m skillforge test --mode quick --spec ...` for all three Prophet skills
- `python3 -m skillforge test --mode smoke --spec ...` for all three Prophet skills
- `pytest --import-mode=importlib -q prophet/prophet-market-seeder/tests/test_smoke.py prophet/prophet-growth-agent/tests/test_smoke.py prophet/prophet-adversarial-auditor/tests/test_smoke.py`

## Tracking
Closes serenorg/seren-skillforge#24.
