### PR TITLE
fix(polymarket): remove leftover polymarket-trading-serenai from maker-rebate-bot

### DIFF
--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -35,12 +35,8 @@ SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
 SEREN_POLYMARKET_PUBLISHER_PREFIX = f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}"
 SEREN_POLYMARKET_DATA_PUBLISHER = "polymarket-data"
-SEREN_POLYMARKET_TRADING_PUBLISHER = "polymarket-trading-serenai"
 SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
-)
-SEREN_POLYMARKET_TRADING_URL_PREFIX = (
-    f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}"
 )
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
@@ -263,28 +259,10 @@ def _extract_live_book(payload: dict[str, Any], mid_price: float) -> tuple[float
 
 
 def _canonicalize_history_url(url: str) -> str:
-    trimmed = url.strip()
-    if not trimmed:
-        return trimmed
-    if trimmed.startswith(SEREN_POLYMARKET_TRADING_URL_PREFIX):
-        parsed = urlparse(trimmed)
-        if parsed.path in {
-            f"{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}/prices-history",
-            f"{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_TRADING_PUBLISHER}/trades",
-        }:
-            return urlunparse(
-                parsed._replace(
-                    scheme="https",
-                    netloc="clob.polymarket.com",
-                    path="/prices-history",
-                )
-            )
-
-    parsed = urlparse(trimmed)
-    if parsed.path.endswith("/trades"):
-        path = parsed.path[: -len("/trades")] + "/prices-history"
-        return urlunparse(parsed._replace(path=path))
-    return trimmed
+    trimmed = url.rstrip("/")
+    if trimmed.endswith("/trades"):
+        return trimmed[: -len("/trades")] + "/prices-history"
+    return url
 
 
 def to_params(config: dict[str, Any]) -> StrategyParams:

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -289,13 +289,13 @@ def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
     assert backtest.get("clob_history_url", "").endswith("/prices-history")
 
 
-def test_deprecated_history_publisher_url_is_canonicalized_to_direct_clob() -> None:
+def test_legacy_trades_url_is_canonicalized_to_prices_history() -> None:
     agent = _load_agent_module()
 
-    deprecated = "https://api.serendb.com/publishers/polymarket-trading-serenai/prices-history"
-    assert agent._canonicalize_history_url(deprecated) == "https://clob.polymarket.com/prices-history"
-    assert agent._canonicalize_history_url(f"{deprecated}?market=abc&interval=max") == (
-        "https://clob.polymarket.com/prices-history?market=abc&interval=max"
+    legacy = "https://clob.polymarket.com/trades"
+    assert agent._canonicalize_history_url(legacy) == "https://clob.polymarket.com/prices-history"
+    assert agent._canonicalize_history_url("https://clob.polymarket.com/prices-history") == (
+        "https://clob.polymarket.com/prices-history"
     )
 
 


### PR DESCRIPTION
## Summary
- Removes dead `polymarket-trading-serenai` constant and URL prefix from `maker-rebate-bot/scripts/agent.py` that PR #89 missed
- Simplifies `_canonicalize_history_url` to match the already-fixed peer skills (simple `/trades` → `/prices-history` rewrite)
- Updates test to validate the simplified canonicalization instead of the removed publisher URL rewrite

## Test plan
- [x] `pytest polymarket/maker-rebate-bot/tests/test_smoke.py` — 13/13 passed
- [x] `grep -r polymarket-trading-serenai polymarket/` — zero matches

Closes #126

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com