### PR TITLE
fix(polymarket/bot): set skill name to polymarket-bot for slash-command routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# macOS
+.DS_Store
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/
+
+# Credentials & local config
+.env
+config.json
+
+# Claude Code
+.claude/
+
+# Runtime artifacts
+logs/
+*.log
+
+# Test fixtures (local/generated)
+**/tests/fixtures/live_backtest.json

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bot
+name: polymarket-bot
 display-name: Polymarket Bot
 description: "Autonomous trading agent for Polymarket prediction markets using Seren ecosystem"
 ---


### PR DESCRIPTION
## Summary
- Changes SKILL.md frontmatter `name: bot` to `name: polymarket-bot` so `/polymarket-bot` resolves correctly
- Adds root `.gitignore` to suppress .DS_Store, __pycache__, .env, config.json, logs, and .claude/

## Test plan
- [ ] Verify `/polymarket-bot` resolves in Seren Desktop after skill registry refresh

Closes #130

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com