### PR TITLE
fix(polymarket): rename seren-polymarket-predictions to seren-polymarket-intelligence

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -48,7 +48,7 @@ DISCLAIMER = (
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
-SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-intelligence"
 SEREN_PREDICTIONS_URL_PREFIX = (
     f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
 )
@@ -1196,7 +1196,7 @@ def run_backtest(
                         "Estimated cost: ~$0.20 per backtest run."
                     ),
                     "action": 'Set "predictions_enabled": true in your config.json backtest section.',
-                    "publisher": "seren-polymarket-predictions",
+                    "publisher": "seren-polymarket-intelligence",
                     "estimated_cost_usd": 0.20,
                     "endpoints_used": [
                         "GET /api/polymarket/pairs/suggested ($0.10)",

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -47,7 +47,7 @@ SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
-SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-intelligence"
 SEREN_PREDICTIONS_URL_PREFIX = (
     f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
 )
@@ -1257,7 +1257,7 @@ def run_backtest(
                         "Estimated cost: ~$0.20 per backtest run."
                     ),
                     "action": 'Set "predictions_enabled": true in your config.json backtest section.',
-                    "publisher": "seren-polymarket-predictions",
+                    "publisher": "seren-polymarket-intelligence",
                     "estimated_cost_usd": 0.20,
                     "endpoints_used": [
                         "GET /api/polymarket/pairs/suggested ($0.10)",

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -39,7 +39,7 @@ SEREN_POLYMARKET_DATA_URL_PREFIX = (
     f"https://{SEREN_POLYMARKET_PUBLISHER_HOST}{SEREN_PUBLISHERS_PREFIX}{SEREN_POLYMARKET_DATA_PUBLISHER}"
 )
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
-SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-intelligence"
 SEREN_PREDICTIONS_URL_PREFIX = (
     f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
 )
@@ -1765,7 +1765,7 @@ def run_backtest(
                         "quote skew. Estimated cost: ~$0.30 per backtest run."
                     ),
                     "action": 'Set "predictions_enabled": true in your config.json backtest section.',
-                    "publisher": "seren-polymarket-predictions",
+                    "publisher": "seren-polymarket-intelligence",
                     "estimated_cost_usd": 0.30,
                     "endpoints_used": [
                         "POST /api/oracle/divergence/batch ($0.15)",

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -48,7 +48,7 @@ DISCLAIMER = (
 SEREN_POLYMARKET_PUBLISHER_PREFIX = "https://api.serendb.com/publishers/"
 SEREN_POLYMARKET_DATA_PUBLISHER_PREFIX = f"{SEREN_POLYMARKET_PUBLISHER_PREFIX}polymarket-data/"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
-SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-predictions"
+SEREN_PREDICTIONS_PUBLISHER = "seren-polymarket-intelligence"
 SEREN_PREDICTIONS_URL_PREFIX = (
     f"https://api.serendb.com/publishers/{SEREN_PREDICTIONS_PUBLISHER}"
 )
@@ -1196,7 +1196,7 @@ def run_backtest(
                         "Estimated cost: ~$0.20 per backtest run."
                     ),
                     "action": 'Set "predictions_enabled": true in your config.json backtest section.',
-                    "publisher": "seren-polymarket-predictions",
+                    "publisher": "seren-polymarket-intelligence",
                     "estimated_cost_usd": 0.20,
                     "endpoints_used": [
                         "GET /api/polymarket/pairs/suggested ($0.10)",


### PR DESCRIPTION
## Summary
- Renames publisher slug from `seren-polymarket-predictions` to `seren-polymarket-intelligence` across all 4 Polymarket backtest skills
- 8 occurrences replaced (2 per skill: constant declaration + upsell prompt string)

## Test plan
- [x] `pytest polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py` — 6/6 passed
- [x] `pytest polymarket/paired-market-basis-maker/tests/test_smoke.py` — 7/7 passed
- [x] `pytest polymarket/liquidity-paired-basis-maker/tests/test_smoke.py` — 6/6 passed
- [x] `pytest polymarket/maker-rebate-bot/tests/test_smoke.py` — 13/13 passed
- [x] `grep -r seren-polymarket-predictions polymarket/` — zero matches

Closes #132

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com