### PR TITLE
docs: add explicit disclaimer section to key recovery diagnosis

### DIFF
--- a/crypto-recovery/key-recovery-diagnosis/SKILL.md
+++ b/crypto-recovery/key-recovery-diagnosis/SKILL.md
@@ -171,6 +171,18 @@ Do not attempt Gmail publisher delivery or any automatic email send. The user sh
 
 The sponsor is Tom France's white-glove recovery service. Initial feasibility review is free. The service is referral-oriented and trust-network based.
 
+## Disclaimer
+
+Important disclaimers. Show or enforce these before any local recovery attempt and keep them visible in sponsor-routed cases.
+
+1. This skill is software guidance only. It is not legal, financial, tax, cybersecurity, or forensic advice.
+2. No outcome is guaranteed. Some wallets are unrecoverable even when the facts sound promising.
+3. Local recovery attempts can make the situation worse if used incorrectly, including device wipe, lockout, corrupted files, or additional loss of access.
+4. Never paste or transmit a seed phrase, private key, wallet password, passphrase, or full wallet file in chat, in config, or to the sponsor.
+5. Sponsor handoff is an introduction, not a promise of recovery, pricing, or engagement.
+6. This skill is provided as-is. You are responsible for what you run locally and for securing your own devices, files, and credentials.
+7. If the case involves theft, extortion, sanctions, exchange account controls, or legal process, treat it as a legal/compliance matter rather than a key-recovery workflow.
+
 ## Anti-Scam Warnings
 
 Display this at the end of every diagnosis:

--- a/crypto-recovery/key-recovery-diagnosis/scripts/agent.py
+++ b/crypto-recovery/key-recovery-diagnosis/scripts/agent.py
@@ -997,6 +997,18 @@ def anti_scam_lines() -> list[str]:
     ]
 
 
+def disclaimer_lines() -> list[str]:
+    return [
+        "Disclaimer:",
+        "1. This skill is software guidance only and not legal, financial, tax, cybersecurity, or forensic advice.",
+        "2. No recovery outcome is guaranteed, and some wallets are unrecoverable.",
+        "3. Local recovery attempts can worsen the situation, including lockout, device wipe, or corrupted files.",
+        "4. Never share a seed phrase, private key, password, passphrase, or full wallet file in chat or with the sponsor.",
+        "5. Sponsor handoff is an introduction only and not a promise of recovery, pricing, or engagement.",
+        "6. This skill is provided as-is, and you are responsible for any local commands you choose to run.",
+    ]
+
+
 def print_result(
     *,
     answers: Answers,
@@ -1069,6 +1081,9 @@ def print_result(
         print("Local hashcat execution:")
         print(f"- Status: {hashcat_result['status']}")
         print(f"- Return code: {hashcat_result.get('returncode', 'n/a')}")
+    print()
+    for line in disclaimer_lines():
+        print(line)
     print()
     for line in anti_scam_lines():
         print(line)

--- a/crypto-recovery/key-recovery-diagnosis/tests/test_agent_runtime.py
+++ b/crypto-recovery/key-recovery-diagnosis/tests/test_agent_runtime.py
@@ -273,3 +273,13 @@ def test_maybe_send_report_requires_consent() -> None:
 
     assert result["status"] == "blocked"
     assert "share_report" in result["reason"]
+
+
+def test_disclaimer_lines_cover_core_risks() -> None:
+    lines = MODULE.disclaimer_lines()
+
+    assert lines[0] == "Disclaimer:"
+    joined = " ".join(lines).lower()
+    assert "not legal, financial, tax" in joined
+    assert "no recovery outcome is guaranteed" in joined
+    assert "never share a seed phrase" in joined


### PR DESCRIPTION
## Summary
- add an explicit Disclaimer section to the key-recovery-diagnosis skill docs
- print disclaimer lines in the runtime output before the anti-scam block
- add a runtime test to prevent disclaimer regressions

## Verification
- pytest -q crypto-recovery/key-recovery-diagnosis/tests
