### PR TITLE
Prophet: auto-provision market seeder storage

### DIFF
--- a/prophet/prophet-market-seeder/SKILL.md
+++ b/prophet/prophet-market-seeder/SKILL.md
@@ -40,10 +40,12 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 The runtime now auto-bootstraps Prophet storage on first run:
 
-1. Resolves or creates the Seren project `prophet-market-seeder`.
+1. Resolves or creates the Seren project `prophet`.
 2. Resolves or creates the Seren database `prophet`.
 3. Applies the `prophet_market_seeder` schema and required tables.
 4. Validates the Prophet session token against the live `ViewerWalletBalance` GraphQL query.
+
+If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
 
 ## Minimal Run
 

--- a/prophet/prophet-market-seeder/config.example.json
+++ b/prophet/prophet-market-seeder/config.example.json
@@ -5,7 +5,7 @@
   "dry_run": true,
   "storage": {
     "auto_bootstrap": true,
-    "project_name": "prophet-market-seeder",
+    "project_name": "prophet",
     "database_name": "prophet",
     "schema_name": "prophet_market_seeder",
     "region": "aws-us-east-2"

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -15,12 +15,14 @@ from typing import Any, Dict, List, Optional
 
 DEFAULT_DRY_RUN = True
 DEFAULT_COMMAND = "run"
-DEFAULT_PROJECT_NAME = "prophet-market-seeder"
+DEFAULT_PROJECT_NAME = "prophet"
 DEFAULT_DATABASE_NAME = "prophet"
 DEFAULT_SCHEMA_NAME = "prophet_market_seeder"
 DEFAULT_REGION = "aws-us-east-2"
 DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
 AVAILABLE_CONNECTORS = ["storage"]
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
 VIEWER_WALLET_BALANCE_QUERY = """
 query ViewerWalletBalance {
   viewer {
@@ -317,53 +319,14 @@ def resolve_or_create_serendb_target(
 
 
 def storage_bootstrap_sql(schema_name: str) -> List[str]:
-    prefix = f"{schema_name}."
-    return [
-        f"CREATE SCHEMA IF NOT EXISTS {schema_name}",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}sessions (
-            session_id TEXT PRIMARY KEY,
-            referral_code TEXT NOT NULL,
-            command TEXT NOT NULL,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}runs (
-            run_id TEXT PRIMARY KEY,
-            session_id TEXT NOT NULL,
-            status TEXT NOT NULL,
-            dry_run BOOLEAN NOT NULL,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}events (
-            event_id BIGSERIAL PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            event_type TEXT NOT NULL,
-            payload JSONB NOT NULL DEFAULT '{{}}'::jsonb,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}market_candidates (
-            candidate_id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            title TEXT NOT NULL,
-            score DOUBLE PRECISION,
-            payload JSONB NOT NULL DEFAULT '{{}}'::jsonb,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}market_submissions (
-            submission_id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            candidate_id TEXT,
-            status TEXT NOT NULL,
-            payload JSONB NOT NULL DEFAULT '{{}}'::jsonb,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-        f"""CREATE TABLE IF NOT EXISTS {prefix}artifacts (
-            artifact_id TEXT PRIMARY KEY,
-            run_id TEXT NOT NULL,
-            artifact_type TEXT NOT NULL,
-            payload JSONB NOT NULL DEFAULT '{{}}'::jsonb,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )""",
-    ]
+    if not SCHEMA_PATH.exists():
+        raise SerenBootstrapError(f"Schema file not found: {SCHEMA_PATH}")
+    raw = SCHEMA_PATH.read_text(encoding="utf-8")
+    rendered = raw.replace("{{schema_name}}", schema_name)
+    statements = [part.strip() for part in rendered.split(";") if part.strip()]
+    if not statements:
+        raise SerenBootstrapError(f"Schema file is empty: {SCHEMA_PATH}")
+    return statements
 
 
 def psycopg_connect(dsn: str):  # pragma: no cover - exercised via tests with monkeypatch
@@ -404,7 +367,9 @@ def ensure_storage(config: dict) -> dict:
     target: Optional[SerenDbTarget] = None
     if not connection_string:
         if not api_key:
-            raise SerenBootstrapError("SEREN_API_KEY is required to auto-bootstrap Prophet storage")
+            raise SerenBootstrapError(
+                f"SEREN_API_KEY is required to auto-provision Prophet storage. Create an account at {SEREN_SKILLS_DOCS_URL}."
+            )
         target = resolve_or_create_serendb_target(
             api_key,
             project_name=project_name,
@@ -420,6 +385,7 @@ def ensure_storage(config: dict) -> dict:
         "database_name": database_name,
         "project_name": project_name,
         "statements_executed": executed,
+        "auto_provisioned": True,
     }
     if target:
         result.update(
@@ -477,12 +443,9 @@ def run_once(config: dict, dry_run: bool) -> dict:
         auth = validate_prophet_access(config)
     except ProphetSkillError as exc:
         if strict_mode or command != "setup":
-            return _error_result(
-                str(exc),
-                error_code="auth_or_bootstrap_failed",
-                dry_run=dry_run,
-                command=command,
-            )
+            error_code = "missing_seren_api_key" if SEREN_SKILLS_DOCS_URL in str(exc) else "auth_or_bootstrap_failed"
+            details = {"docs_url": SEREN_SKILLS_DOCS_URL} if error_code == "missing_seren_api_key" else None
+            return _error_result(str(exc), error_code=error_code, dry_run=dry_run, command=command, details=details)
         storage = {"status": "skipped", "reason": "setup_non_strict"}
         auth = {
             "status": "warning",

--- a/prophet/prophet-market-seeder/serendb_schema.sql
+++ b/prophet/prophet-market-seeder/serendb_schema.sql
@@ -1,0 +1,50 @@
+CREATE SCHEMA IF NOT EXISTS {{schema_name}};
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.sessions (
+    session_id TEXT PRIMARY KEY,
+    referral_code TEXT NOT NULL,
+    command TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.runs (
+    run_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    dry_run BOOLEAN NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.events (
+    event_id BIGSERIAL PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.market_candidates (
+    candidate_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    score DOUBLE PRECISION,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.market_submissions (
+    submission_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    candidate_id TEXT,
+    status TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.artifacts (
+    artifact_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    artifact_type TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/prophet/prophet-market-seeder/skill.spec.yaml
+++ b/prophet/prophet-market-seeder/skill.spec.yaml
@@ -64,6 +64,7 @@ state:
 policies:
   dry_run_default: true
   idempotency_required: true
+  auto_provision: true
 workflow:
   steps:
     - id: normalize_request

--- a/prophet/prophet-market-seeder/tests/test_smoke.py
+++ b/prophet/prophet-market-seeder/tests/test_smoke.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "agent.py"
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
 
 
 def _read_fixture(name: str) -> dict:
@@ -137,7 +138,7 @@ def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monke
         {
             "storage": {
                 "auto_bootstrap": True,
-                "project_name": "prophet-market-seeder",
+                "project_name": "prophet",
                 "database_name": "prophet",
                 "schema_name": "prophet_market_seeder",
                 "region": "aws-us-east-2",
@@ -147,7 +148,38 @@ def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monke
     )
 
     assert result["status"] == "ok"
+    assert result["project_name"] == "prophet"
+    assert result["auto_provisioned"] is True
     assert result["created_project"] is True
     assert result["created_database"] is True
     assert result["statements_executed"] >= 6
     assert any("CREATE SCHEMA IF NOT EXISTS prophet_market_seeder" in stmt for stmt in executed)
+
+
+def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
+    agent = _load_agent_module()
+
+    statements = agent.storage_bootstrap_sql("prophet_market_seeder")
+
+    assert SCHEMA_PATH.exists()
+    assert any("CREATE TABLE IF NOT EXISTS prophet_market_seeder.sessions" in stmt for stmt in statements)
+    assert any("CREATE TABLE IF NOT EXISTS prophet_market_seeder.artifacts" in stmt for stmt in statements)
+
+
+def test_setup_without_seren_api_key_points_user_to_docs(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.delenv("SEREN_API_KEY", raising=False)
+
+    result = agent.run_once(
+        {
+            "dry_run": True,
+            "inputs": {"command": "setup", "strict_mode": True},
+            "secrets": {"PROPHET_SESSION_TOKEN": "privy-jwt"},
+            "storage": {"auto_bootstrap": True},
+        },
+        dry_run=True,
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "missing_seren_api_key"
+    assert result["details"]["docs_url"] == "https://docs.serendb.com/skills.md"


### PR DESCRIPTION
Fixes #136

## What changed
- added checked-in `serendb_schema.sql` with idempotent DDL for the seeder tables
- switched the runtime to load/apply the schema file during setup/bootstrap
- changed the default Seren project target to `prophet`
- added explicit `auto_provision: true` policy metadata
- clarified the no-`SEREN_API_KEY` path with the docs URL instead of prompting for DB setup

## Verification
- `python3 -m pytest prophet/prophet-market-seeder/tests/test_smoke.py`
- `python3 -m py_compile prophet/prophet-market-seeder/scripts/agent.py`
