### PR TITLE
fix(prophet): harden remaining Prophet skills

### DIFF
--- a/prophet/prophet-adversarial-auditor/SKILL.md
+++ b/prophet/prophet-adversarial-auditor/SKILL.md
@@ -19,11 +19,40 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 ## Workflow Summary
 
 1. `normalize_request` uses `transform.normalize_request`
-2. `connect_storage` uses `connector.storage.connect`
-3. `load_run_history` uses `connector.storage.query`
-4. `replay_recent_runs` uses `transform.replay_recent_runs`
-5. `detect_findings` uses `transform.detect_audit_findings`
-6. `analyze_loss_scenarios` uses `transform.analyze_loss_hypotheses`
-7. `rank_findings` uses `transform.rank_findings`
-8. `persist_audit_outputs` uses `connector.storage.upsert`
-9. `render_summary` uses `transform.render_report`
+2. `validate_prophet_access` uses `transform.validate_prophet_access`
+3. `connect_storage` uses `connector.storage.connect`
+4. `load_run_history` uses `connector.storage.query`
+5. `replay_recent_runs` uses `transform.replay_recent_runs`
+6. `detect_findings` uses `transform.detect_audit_findings`
+7. `analyze_loss_scenarios` uses `transform.analyze_loss_hypotheses`
+8. `rank_findings` uses `transform.rank_findings`
+9. `persist_audit_outputs` uses `connector.storage.upsert`
+10. `render_summary` uses `transform.render_report`
+
+## Auth Contract
+
+- Prophet backend requests must include `Authorization: Bearer <PROPHET_SESSION_TOKEN>`.
+- The correct token source is `localStorage["privy:token"]` from an authenticated `app.prophetmarket.ai` browser session.
+- The `privy-session` cookie by itself is not sufficient for authenticated GraphQL access.
+
+## First-Run Setup
+
+The runtime now auto-bootstraps Prophet storage on first run:
+
+1. Resolves or creates the Seren project `prophet`.
+2. Resolves or creates the Seren database `prophet`.
+3. Applies the `prophet_adversarial_auditor` schema and required tables.
+4. Validates the Prophet session token against the live `ViewerWalletBalance` GraphQL query.
+
+If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
+
+## Minimal Run
+
+```bash
+cd prophet/prophet-adversarial-auditor
+python3 -m pip install -r requirements.txt
+cp config.example.json config.json
+export SEREN_API_KEY=...
+export PROPHET_SESSION_TOKEN='eyJ...'
+python3 scripts/agent.py --config config.json
+```

--- a/prophet/prophet-adversarial-auditor/config.example.json
+++ b/prophet/prophet-adversarial-auditor/config.example.json
@@ -3,12 +3,20 @@
     "storage"
   ],
   "dry_run": true,
+  "storage": {
+    "auto_bootstrap": true,
+    "project_name": "prophet",
+    "database_name": "prophet",
+    "schema_name": "prophet_adversarial_auditor",
+    "region": "aws-us-east-2"
+  },
   "inputs": {
     "command": "run",
     "include_loss_hypotheses": true,
     "json_output": false,
     "lookback_days": 30,
-    "severity_threshold": "medium"
+    "severity_threshold": "medium",
+    "strict_mode": true
   },
   "skill": "prophet-adversarial-auditor"
 }

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -1,19 +1,70 @@
 #!/usr/bin/env python3
-"""Generated SkillForge runtime for prophet-adversarial-auditor."""
+"""Runtime for prophet-adversarial-auditor with explicit Prophet auth and storage bootstrap."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 
 DEFAULT_DRY_RUN = True
-AVAILABLE_CONNECTORS = ['storage']
+DEFAULT_COMMAND = "run"
+DEFAULT_PROJECT_NAME = "prophet"
+DEFAULT_DATABASE_NAME = "prophet"
+DEFAULT_SCHEMA_NAME = "prophet_adversarial_auditor"
+DEFAULT_REGION = "aws-us-east-2"
+DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
+AVAILABLE_CONNECTORS = ["storage"]
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
+VIEWER_WALLET_BALANCE_QUERY = """
+query ViewerWalletBalance {
+  viewer {
+    walletBalance {
+      availableCents
+      totalCents
+      safeAddress
+      safeDeployed
+      __typename
+    }
+    __typename
+  }
+}
+""".strip()
+
+
+class ProphetSkillError(RuntimeError):
+    """Base error for runtime failures."""
+
+
+class ProphetAuthError(ProphetSkillError):
+    """Raised when Prophet auth cannot be validated."""
+
+
+class SerenBootstrapError(ProphetSkillError):
+    """Raised when Seren storage bootstrap fails."""
+
+
+@dataclass
+class SerenDbTarget:
+    project_id: str
+    branch_id: str
+    database_name: str
+    connection_string: str
+    project_name: str
+    branch_name: str
+    created_project: bool = False
+    created_database: bool = False
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser = argparse.ArgumentParser(description="Run prophet-adversarial-auditor.")
     parser.add_argument(
         "--config",
         default="config.json",
@@ -29,22 +80,412 @@ def load_config(config_path: str) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def run_once(config: dict, dry_run: bool) -> dict:
+def _bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _normalize_command(value: Any) -> str:
+    command = str(value or DEFAULT_COMMAND).strip().lower()
+    if command not in {"setup", "run", "status"}:
+        raise ProphetSkillError(f"Unsupported command: {command}")
+    return command
+
+
+def _config_inputs(config: dict) -> dict:
+    return config.get("inputs", {}) if isinstance(config.get("inputs"), dict) else {}
+
+
+def resolve_secret(config: dict, name: str) -> Optional[str]:
+    secret_block = config.get("secrets")
+    if isinstance(secret_block, dict):
+        value = secret_block.get(name)
+        if value:
+            return str(value)
+    value = os.getenv(name)
+    if value:
+        return value
+    return None
+
+
+def _error_result(message: str, *, error_code: str, dry_run: bool, command: str, details: Optional[dict] = None) -> dict:
+    payload = {
+        "status": "error",
+        "error_code": error_code,
+        "message": message,
+        "dry_run": dry_run,
+        "command": command,
+    }
+    if details:
+        payload["details"] = details
+    return payload
+
+
+class ProphetApi:
+    def __init__(self, session_token: str, base_url: Optional[str] = None):
+        if not session_token:
+            raise ValueError("PROPHET_SESSION_TOKEN is required")
+        self.session_token = session_token
+        self.base_url = (base_url or os.getenv("PROPHET_BASE_URL") or DEFAULT_PROPHET_BASE_URL).rstrip("/")
+
+    def _request(self, query: str, operation_name: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/api/graphql"
+        body = {"query": query, "operationName": operation_name}
+        req = urllib.request.Request(
+            url=url,
+            method="POST",
+            data=json.dumps(body).encode("utf-8"),
+        )
+        req.add_header("Authorization", f"Bearer {self.session_token}")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                payload = resp.read().decode("utf-8")
+        except Exception as exc:
+            raise ProphetAuthError(f"Prophet auth probe failed: {exc}") from exc
+
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError as exc:
+            raise ProphetAuthError("Prophet auth probe returned invalid JSON") from exc
+
+    def viewer_wallet_balance(self) -> dict:
+        payload = self._request(VIEWER_WALLET_BALANCE_QUERY, "ViewerWalletBalance")
+        viewer = payload.get("data", {}).get("viewer")
+        if not viewer:
+            raise ProphetAuthError(
+                "Prophet session token was accepted by the endpoint but did not resolve an authenticated viewer"
+            )
+        return viewer
+
+
+class SerenApi:
+    def __init__(self, api_key: str, api_base: Optional[str] = None):
+        if not api_key:
+            raise ValueError("SEREN_API_KEY is required")
+        self.api_key = api_key
+        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com").rstrip("/")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: Optional[Dict[str, Any]] = None,
+        query: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.api_base}{path}"
+        if query:
+            url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+
+        req = urllib.request.Request(url=url, method=method)
+        req.add_header("Authorization", f"Bearer {self.api_key}")
+        req.add_header("Content-Type", "application/json")
+        raw = json.dumps(body).encode("utf-8") if body is not None else None
+
+        try:
+            with urllib.request.urlopen(req, data=raw, timeout=30) as resp:
+                payload = resp.read().decode("utf-8")
+        except Exception as exc:
+            raise SerenBootstrapError(f"Seren API request failed ({method} {path}): {exc}") from exc
+
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError as exc:
+            raise SerenBootstrapError(f"Seren API returned invalid JSON for {method} {path}") from exc
+
+    @staticmethod
+    def _as_list(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if isinstance(payload, list):
+            return payload
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("items", "projects", "branches", "databases"):
+                items = data.get(key)
+                if isinstance(items, list):
+                    return items
+        return []
+
+    def list_projects(self) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", "/projects"))
+
+    def create_project(self, name: str, region: str) -> Dict[str, Any]:
+        payload = self._request("POST", "/projects", body={"name": name, "region": region})
+        data = payload.get("data")
+        return data if isinstance(data, dict) else payload
+
+    def list_branches(self, project_id: str) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", f"/projects/{project_id}/branches"))
+
+    def list_databases(self, project_id: str, branch_id: str) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases"))
+
+    def create_database(self, project_id: str, branch_id: str, name: str) -> Dict[str, Any]:
+        payload = self._request(
+            "POST",
+            f"/projects/{project_id}/branches/{branch_id}/databases",
+            body={"name": name},
+        )
+        data = payload.get("data")
+        return data if isinstance(data, dict) else payload
+
+    def get_connection_string(self, project_id: str, branch_id: str, role: str = "serendb_owner") -> str:
+        payload = self._request(
+            "GET",
+            f"/projects/{project_id}/branches/{branch_id}/connection-string",
+            query={"role": role, "pooled": "false"},
+        )
+        data = payload.get("data")
+        if isinstance(data, dict) and data.get("connection_string"):
+            return str(data["connection_string"])
+        if payload.get("connection_string"):
+            return str(payload["connection_string"])
+        raise SerenBootstrapError("Could not resolve connection string from Seren API")
+
+
+def _patch_database(connection_string: str, database_name: str) -> str:
+    parsed = urllib.parse.urlparse(connection_string)
+    return urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, f"/{database_name}", parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def resolve_or_create_serendb_target(
+    api_key: str,
+    *,
+    project_name: str,
+    database_name: str,
+    region: str,
+) -> SerenDbTarget:
+    api = SerenApi(api_key=api_key)
+
+    projects = api.list_projects()
+    project = next((p for p in projects if str(p.get("name", "")).lower() == project_name.lower()), None)
+    created_project = False
+    if not project:
+        project = api.create_project(name=project_name, region=region)
+        created_project = True
+
+    project_id = str(project.get("id") or "")
+    if not project_id:
+        raise SerenBootstrapError("Unable to determine Prophet storage project_id")
+
+    branches = api.list_branches(project_id)
+    if not branches:
+        raise SerenBootstrapError(f"No branches available for Prophet storage project {project_id}")
+
+    default_branch_id = project.get("default_branch_id") if isinstance(project, dict) else None
+    branch = None
+    if default_branch_id:
+        branch = next((b for b in branches if str(b.get("id")) == str(default_branch_id)), None)
+    if not branch:
+        branch = next((b for b in branches if str(b.get("name", "")).lower() in {"main", "production"}), None)
+    if not branch:
+        branch = branches[0]
+
+    branch_id = str(branch.get("id") or "")
+    branch_name = str(branch.get("name") or "main")
+    if not branch_id:
+        raise SerenBootstrapError("Unable to determine Prophet storage branch_id")
+
+    databases = api.list_databases(project_id, branch_id)
+    db_names = {str(d.get("name")) for d in databases if d.get("name")}
+    created_database = False
+    if database_name not in db_names:
+        api.create_database(project_id=project_id, branch_id=branch_id, name=database_name)
+        created_database = True
+
+    conn = _patch_database(api.get_connection_string(project_id=project_id, branch_id=branch_id), database_name)
+    return SerenDbTarget(
+        project_id=project_id,
+        branch_id=branch_id,
+        database_name=database_name,
+        connection_string=conn,
+        project_name=str(project.get("name") or project_name),
+        branch_name=branch_name,
+        created_project=created_project,
+        created_database=created_database,
+    )
+
+
+def storage_bootstrap_sql(schema_name: str) -> List[str]:
+    if not SCHEMA_PATH.exists():
+        raise SerenBootstrapError(f"Schema file not found: {SCHEMA_PATH}")
+    raw = SCHEMA_PATH.read_text(encoding="utf-8")
+    rendered = raw.replace("{{schema_name}}", schema_name)
+    statements = [part.strip() for part in rendered.split(";") if part.strip()]
+    if not statements:
+        raise SerenBootstrapError(f"Schema file is empty: {SCHEMA_PATH}")
+    return statements
+
+
+def psycopg_connect(dsn: str):  # pragma: no cover - exercised via tests with monkeypatch
+    import psycopg
+
+    return psycopg.connect(dsn)
+
+
+def apply_storage_bootstrap(connection_string: str, schema_name: str) -> int:
+    statements = storage_bootstrap_sql(schema_name)
+    try:
+        with psycopg_connect(connection_string) as conn:
+            with conn.cursor() as cur:
+                for statement in statements:
+                    cur.execute(statement)
+            conn.commit()
+    except Exception as exc:
+        raise SerenBootstrapError(f"Failed to apply Prophet storage bootstrap: {exc}") from exc
+    return len(statements)
+
+
+def ensure_storage(config: dict) -> dict:
+    storage_cfg = config.get("storage") if isinstance(config.get("storage"), dict) else {}
+    if not _bool(storage_cfg.get("auto_bootstrap"), True):
+        return {
+            "status": "skipped",
+            "reason": "auto_bootstrap_disabled",
+            "schema_name": str(storage_cfg.get("schema_name") or DEFAULT_SCHEMA_NAME),
+        }
+
+    project_name = str(storage_cfg.get("project_name") or DEFAULT_PROJECT_NAME)
+    database_name = str(storage_cfg.get("database_name") or DEFAULT_DATABASE_NAME)
+    schema_name = str(storage_cfg.get("schema_name") or DEFAULT_SCHEMA_NAME)
+    region = str(storage_cfg.get("region") or DEFAULT_REGION)
+    connection_string = storage_cfg.get("connection_string") or os.getenv("SERENDB_URL")
+    api_key = resolve_secret(config, "SEREN_API_KEY")
+
+    target: Optional[SerenDbTarget] = None
+    if not connection_string:
+        if not api_key:
+            raise SerenBootstrapError(
+                f"SEREN_API_KEY is required to auto-provision Prophet storage. Create an account at {SEREN_SKILLS_DOCS_URL}."
+            )
+        target = resolve_or_create_serendb_target(
+            api_key,
+            project_name=project_name,
+            database_name=database_name,
+            region=region,
+        )
+        connection_string = target.connection_string
+
+    executed = apply_storage_bootstrap(connection_string, schema_name)
+    result = {
+        "status": "ok",
+        "schema_name": schema_name,
+        "database_name": database_name,
+        "project_name": project_name,
+        "statements_executed": executed,
+        "auto_provisioned": True,
+    }
+    if target:
+        result.update(
+            {
+                "project_id": target.project_id,
+                "branch_id": target.branch_id,
+                "branch_name": target.branch_name,
+                "created_project": bool(getattr(target, "created_project", False)),
+                "created_database": bool(getattr(target, "created_database", False)),
+            }
+        )
+    return result
+
+
+def validate_prophet_access(config: dict) -> dict:
+    token = resolve_secret(config, "PROPHET_SESSION_TOKEN")
+    if not token:
+        raise ProphetAuthError(
+            "Missing PROPHET_SESSION_TOKEN. Use the Privy JWT from localStorage['privy:token'] and send it as Authorization: Bearer <token>."
+        )
+    viewer = ProphetApi(token).viewer_wallet_balance()
+    wallet_balance = viewer.get("walletBalance") or {}
     return {
         "status": "ok",
+        "required_header": "Authorization: Bearer <PROPHET_SESSION_TOKEN>",
+        "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
+        "viewer": {
+            "wallet_balance_total_cents": wallet_balance.get("totalCents"),
+            "wallet_balance_available_cents": wallet_balance.get("availableCents"),
+            "safe_address": wallet_balance.get("safeAddress"),
+            "safe_deployed": wallet_balance.get("safeDeployed"),
+        },
+    }
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    inputs = _config_inputs(config)
+    command = _normalize_command(inputs.get("command"))
+    strict_mode = _bool(inputs.get("strict_mode"), True)
+    lookback_days = int(inputs.get("lookback_days") or 30)
+    severity_threshold = str(inputs.get("severity_threshold") or "medium").strip().lower()
+    include_loss_hypotheses = _bool(inputs.get("include_loss_hypotheses"), True)
+
+    if lookback_days < 1 or lookback_days > 90:
+        return _error_result(
+            "Invalid lookback_days value",
+            error_code="invalid_lookback_days",
+            dry_run=dry_run,
+            command=command,
+            details={"lookback_days": lookback_days},
+        )
+    if severity_threshold not in {"low", "medium", "high"}:
+        return _error_result(
+            "Invalid severity_threshold value",
+            error_code="invalid_severity_threshold",
+            dry_run=dry_run,
+            command=command,
+            details={"severity_threshold": severity_threshold},
+        )
+
+    try:
+        storage = ensure_storage(config) if command in {"setup", "run"} else {"status": "not_run"}
+        auth = validate_prophet_access(config)
+    except ProphetSkillError as exc:
+        if strict_mode or command != "setup":
+            error_code = "missing_seren_api_key" if SEREN_SKILLS_DOCS_URL in str(exc) else "auth_or_bootstrap_failed"
+            details = {"docs_url": SEREN_SKILLS_DOCS_URL} if error_code == "missing_seren_api_key" else None
+            return _error_result(str(exc), error_code=error_code, dry_run=dry_run, command=command, details=details)
+        storage = {"status": "skipped", "reason": "setup_non_strict"}
+        auth = {
+            "status": "warning",
+            "message": str(exc),
+            "required_header": "Authorization: Bearer <PROPHET_SESSION_TOKEN>",
+            "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
+        }
+
+    result = {
+        "status": "ok",
+        "skill": "prophet-adversarial-auditor",
+        "command": command,
         "dry_run": dry_run,
         "connectors": AVAILABLE_CONNECTORS,
-        "input_keys": sorted(config.get("inputs", {}).keys()),
+        "input_keys": sorted(inputs.keys()),
+        "auth": auth,
+        "storage": storage,
+        "analysis_window_days": lookback_days,
+        "severity_threshold": severity_threshold,
+        "include_loss_hypotheses": include_loss_hypotheses,
     }
+    if command == "run":
+        result["analysis_mode"] = "dry-run" if dry_run else "live"
+    return result
 
 
 def main() -> int:
     args = parse_args()
     config = load_config(args.config)
-    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    dry_run = _bool(config.get("dry_run"), DEFAULT_DRY_RUN)
     result = run_once(config=config, dry_run=dry_run)
     print(json.dumps(result))
-    return 0
+    return 0 if result.get("status") == "ok" else 1
 
 
 if __name__ == "__main__":

--- a/prophet/prophet-adversarial-auditor/serendb_schema.sql
+++ b/prophet/prophet-adversarial-auditor/serendb_schema.sql
@@ -1,0 +1,51 @@
+CREATE SCHEMA IF NOT EXISTS {{schema_name}};
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.sessions (
+  session_id TEXT PRIMARY KEY,
+  command TEXT NOT NULL,
+  severity_threshold TEXT NOT NULL,
+  lookback_days INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.runs (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT REFERENCES {{schema_name}}.sessions(session_id),
+  status TEXT NOT NULL,
+  findings_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.events (
+  event_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.audit_findings (
+  finding_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  severity TEXT NOT NULL,
+  title TEXT NOT NULL,
+  details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.loss_hypotheses (
+  hypothesis_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  impact_level TEXT NOT NULL,
+  hypothesis TEXT NOT NULL,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.artifacts (
+  artifact_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  artifact_type TEXT NOT NULL,
+  artifact_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/prophet/prophet-adversarial-auditor/skill.spec.yaml
+++ b/prophet/prophet-adversarial-auditor/skill.spec.yaml
@@ -39,6 +39,10 @@ inputs:
     type: boolean
     description: Include plausible economic leakage and loss scenarios in the report.
     default: true
+  strict_mode:
+    type: boolean
+    description: Block the run if Prophet auth or storage bootstrap guardrails fail.
+    default: true
 secrets:
   - SEREN_API_KEY
   - PROPHET_SESSION_TOKEN
@@ -62,6 +66,7 @@ state:
 policies:
   dry_run_default: true
   idempotency_required: true
+  auto_provision: true
 workflow:
   steps:
     - id: normalize_request
@@ -70,10 +75,14 @@ workflow:
         command: "{command}"
         json_output: "{json_output}"
         severity_threshold: "{severity_threshold}"
+    - id: validate_prophet_access
+      use: transform.validate_prophet_access
+      with:
+        from_step: normalize_request
     - id: connect_storage
       use: connector.storage.connect
       with:
-        from_step: normalize_request
+        from_step: validate_prophet_access
     - id: load_run_history
       use: connector.storage.query
       with:

--- a/prophet/prophet-adversarial-auditor/tests/test_smoke.py
+++ b/prophet/prophet-adversarial-auditor/tests/test_smoke.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "agent.py"
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
 
 
 def _read_fixture(name: str) -> dict:
     return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _load_agent_module():
+    spec = importlib.util.spec_from_file_location("prophet_adversarial_auditor_agent", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_happy_path_fixture_is_successful() -> None:
@@ -34,3 +49,116 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
     assert payload["dry_run"] is True
     assert payload["blocked_action"] == "live_execution"
 
+
+def test_validate_prophet_access_requires_bearer_token_header(monkeypatch) -> None:
+    agent = _load_agent_module()
+    captured = {}
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "data": {
+                        "viewer": {
+                            "walletBalance": {
+                                "availableCents": 0,
+                                "totalCents": 0,
+                                "safeAddress": "0xabc",
+                                "safeDeployed": False,
+                            }
+                        }
+                    }
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request, timeout=30):
+        captured["authorization"] = request.get_header("Authorization")
+        return DummyResponse()
+
+    monkeypatch.setattr(agent.urllib.request, "urlopen", fake_urlopen)
+    result = agent.validate_prophet_access({"secrets": {"PROPHET_SESSION_TOKEN": "privy-jwt"}})
+
+    assert captured["authorization"] == "Bearer privy-jwt"
+    assert result["status"] == "ok"
+    assert result["required_header"] == "Authorization: Bearer <PROPHET_SESSION_TOKEN>"
+
+
+def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monkeypatch) -> None:
+    agent = _load_agent_module()
+    executed = []
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, statement):
+            executed.append(statement)
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+        def commit(self):
+            executed.append("COMMIT")
+
+    monkeypatch.setattr(
+        agent,
+        "resolve_or_create_serendb_target",
+        lambda api_key, project_name, database_name, region: SimpleNamespace(
+            project_id="proj_123",
+            branch_id="branch_123",
+            branch_name="main",
+            database_name=database_name,
+            connection_string="postgresql://example/prophet",
+            project_name=project_name,
+            created_project=True,
+            created_database=True,
+        ),
+    )
+    monkeypatch.setattr(agent, "psycopg_connect", lambda dsn: FakeConnection())
+
+    result = agent.ensure_storage(
+        {
+            "storage": {
+                "auto_bootstrap": True,
+                "project_name": "prophet",
+                "database_name": "prophet",
+                "schema_name": "prophet_adversarial_auditor",
+                "region": "aws-us-east-2",
+            },
+            "secrets": {"SEREN_API_KEY": "sb_test"},
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["project_name"] == "prophet"
+    assert result["auto_provisioned"] is True
+    assert result["created_project"] is True
+    assert result["created_database"] is True
+    assert result["statements_executed"] >= 6
+    assert any("CREATE SCHEMA IF NOT EXISTS prophet_adversarial_auditor" in stmt for stmt in executed)
+
+
+def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
+    agent = _load_agent_module()
+
+    statements = agent.storage_bootstrap_sql("prophet_adversarial_auditor")
+
+    assert SCHEMA_PATH.exists()
+    assert any("CREATE TABLE IF NOT EXISTS prophet_adversarial_auditor.audit_findings" in stmt for stmt in statements)
+    assert any("CREATE TABLE IF NOT EXISTS prophet_adversarial_auditor.loss_hypotheses" in stmt for stmt in statements)

--- a/prophet/prophet-growth-agent/SKILL.md
+++ b/prophet/prophet-growth-agent/SKILL.md
@@ -19,10 +19,39 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 ## Workflow Summary
 
 1. `normalize_request` uses `transform.normalize_request`
-2. `connect_storage` uses `connector.storage.connect`
-3. `load_recent_activity` uses `connector.storage.query`
-4. `compute_progress` uses `transform.compute_repeat_creation_progress`
-5. `generate_checkin_actions` uses `transform.generate_checkin_actions`
-6. `compose_reminder_copy` uses `transform.compose_reminder_copy`
-7. `persist_growth_outputs` uses `connector.storage.upsert`
-8. `render_summary` uses `transform.render_report`
+2. `validate_prophet_access` uses `transform.validate_prophet_access`
+3. `connect_storage` uses `connector.storage.connect`
+4. `load_recent_activity` uses `connector.storage.query`
+5. `compute_progress` uses `transform.compute_repeat_creation_progress`
+6. `generate_checkin_actions` uses `transform.generate_checkin_actions`
+7. `compose_reminder_copy` uses `transform.compose_reminder_copy`
+8. `persist_growth_outputs` uses `connector.storage.upsert`
+9. `render_summary` uses `transform.render_report`
+
+## Auth Contract
+
+- Prophet backend requests must include `Authorization: Bearer <PROPHET_SESSION_TOKEN>`.
+- The correct token source is `localStorage["privy:token"]` from an authenticated `app.prophetmarket.ai` browser session.
+- The `privy-session` cookie by itself is not sufficient for authenticated GraphQL access.
+
+## First-Run Setup
+
+The runtime now auto-bootstraps Prophet storage on first run:
+
+1. Resolves or creates the Seren project `prophet`.
+2. Resolves or creates the Seren database `prophet`.
+3. Applies the `prophet_growth_agent` schema and required tables.
+4. Validates the Prophet session token against the live `ViewerWalletBalance` GraphQL query.
+
+If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
+
+## Minimal Run
+
+```bash
+cd prophet/prophet-growth-agent
+python3 -m pip install -r requirements.txt
+cp config.example.json config.json
+export SEREN_API_KEY=...
+export PROPHET_SESSION_TOKEN='eyJ...'
+python3 scripts/agent.py --config config.json
+```

--- a/prophet/prophet-growth-agent/config.example.json
+++ b/prophet/prophet-growth-agent/config.example.json
@@ -3,11 +3,19 @@
     "storage"
   ],
   "dry_run": true,
+  "storage": {
+    "auto_bootstrap": true,
+    "project_name": "prophet",
+    "database_name": "prophet",
+    "schema_name": "prophet_growth_agent",
+    "region": "aws-us-east-2"
+  },
   "inputs": {
     "command": "status",
     "json_output": false,
     "recent_window_days": 7,
     "reminder_enabled": true,
+    "strict_mode": true,
     "weekly_target_markets": 3
   },
   "skill": "prophet-growth-agent"

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -1,19 +1,70 @@
 #!/usr/bin/env python3
-"""Generated SkillForge runtime for prophet-growth-agent."""
+"""Runtime for prophet-growth-agent with explicit Prophet auth and storage bootstrap."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 
 DEFAULT_DRY_RUN = True
-AVAILABLE_CONNECTORS = ['storage']
+DEFAULT_COMMAND = "status"
+DEFAULT_PROJECT_NAME = "prophet"
+DEFAULT_DATABASE_NAME = "prophet"
+DEFAULT_SCHEMA_NAME = "prophet_growth_agent"
+DEFAULT_REGION = "aws-us-east-2"
+DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
+AVAILABLE_CONNECTORS = ["storage"]
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
+VIEWER_WALLET_BALANCE_QUERY = """
+query ViewerWalletBalance {
+  viewer {
+    walletBalance {
+      availableCents
+      totalCents
+      safeAddress
+      safeDeployed
+      __typename
+    }
+    __typename
+  }
+}
+""".strip()
+
+
+class ProphetSkillError(RuntimeError):
+    """Base error for runtime failures."""
+
+
+class ProphetAuthError(ProphetSkillError):
+    """Raised when Prophet auth cannot be validated."""
+
+
+class SerenBootstrapError(ProphetSkillError):
+    """Raised when Seren storage bootstrap fails."""
+
+
+@dataclass
+class SerenDbTarget:
+    project_id: str
+    branch_id: str
+    database_name: str
+    connection_string: str
+    project_name: str
+    branch_name: str
+    created_project: bool = False
+    created_database: bool = False
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser = argparse.ArgumentParser(description="Run prophet-growth-agent.")
     parser.add_argument(
         "--config",
         default="config.json",
@@ -29,22 +80,412 @@ def load_config(config_path: str) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def run_once(config: dict, dry_run: bool) -> dict:
+def _bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _normalize_command(value: Any) -> str:
+    command = str(value or DEFAULT_COMMAND).strip().lower()
+    if command not in {"setup", "run", "status"}:
+        raise ProphetSkillError(f"Unsupported command: {command}")
+    return command
+
+
+def _config_inputs(config: dict) -> dict:
+    return config.get("inputs", {}) if isinstance(config.get("inputs"), dict) else {}
+
+
+def resolve_secret(config: dict, name: str) -> Optional[str]:
+    secret_block = config.get("secrets")
+    if isinstance(secret_block, dict):
+        value = secret_block.get(name)
+        if value:
+            return str(value)
+    value = os.getenv(name)
+    if value:
+        return value
+    return None
+
+
+def _error_result(message: str, *, error_code: str, dry_run: bool, command: str, details: Optional[dict] = None) -> dict:
+    payload = {
+        "status": "error",
+        "error_code": error_code,
+        "message": message,
+        "dry_run": dry_run,
+        "command": command,
+    }
+    if details:
+        payload["details"] = details
+    return payload
+
+
+class ProphetApi:
+    def __init__(self, session_token: str, base_url: Optional[str] = None):
+        if not session_token:
+            raise ValueError("PROPHET_SESSION_TOKEN is required")
+        self.session_token = session_token
+        self.base_url = (base_url or os.getenv("PROPHET_BASE_URL") or DEFAULT_PROPHET_BASE_URL).rstrip("/")
+
+    def _request(self, query: str, operation_name: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/api/graphql"
+        body = {"query": query, "operationName": operation_name}
+        req = urllib.request.Request(
+            url=url,
+            method="POST",
+            data=json.dumps(body).encode("utf-8"),
+        )
+        req.add_header("Authorization", f"Bearer {self.session_token}")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                payload = resp.read().decode("utf-8")
+        except Exception as exc:
+            raise ProphetAuthError(f"Prophet auth probe failed: {exc}") from exc
+
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError as exc:
+            raise ProphetAuthError("Prophet auth probe returned invalid JSON") from exc
+
+    def viewer_wallet_balance(self) -> dict:
+        payload = self._request(VIEWER_WALLET_BALANCE_QUERY, "ViewerWalletBalance")
+        viewer = payload.get("data", {}).get("viewer")
+        if not viewer:
+            raise ProphetAuthError(
+                "Prophet session token was accepted by the endpoint but did not resolve an authenticated viewer"
+            )
+        return viewer
+
+
+class SerenApi:
+    def __init__(self, api_key: str, api_base: Optional[str] = None):
+        if not api_key:
+            raise ValueError("SEREN_API_KEY is required")
+        self.api_key = api_key
+        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com").rstrip("/")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: Optional[Dict[str, Any]] = None,
+        query: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.api_base}{path}"
+        if query:
+            url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+
+        req = urllib.request.Request(url=url, method=method)
+        req.add_header("Authorization", f"Bearer {self.api_key}")
+        req.add_header("Content-Type", "application/json")
+        raw = json.dumps(body).encode("utf-8") if body is not None else None
+
+        try:
+            with urllib.request.urlopen(req, data=raw, timeout=30) as resp:
+                payload = resp.read().decode("utf-8")
+        except Exception as exc:
+            raise SerenBootstrapError(f"Seren API request failed ({method} {path}): {exc}") from exc
+
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError as exc:
+            raise SerenBootstrapError(f"Seren API returned invalid JSON for {method} {path}") from exc
+
+    @staticmethod
+    def _as_list(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if isinstance(payload, list):
+            return payload
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("items", "projects", "branches", "databases"):
+                items = data.get(key)
+                if isinstance(items, list):
+                    return items
+        return []
+
+    def list_projects(self) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", "/projects"))
+
+    def create_project(self, name: str, region: str) -> Dict[str, Any]:
+        payload = self._request("POST", "/projects", body={"name": name, "region": region})
+        data = payload.get("data")
+        return data if isinstance(data, dict) else payload
+
+    def list_branches(self, project_id: str) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", f"/projects/{project_id}/branches"))
+
+    def list_databases(self, project_id: str, branch_id: str) -> List[Dict[str, Any]]:
+        return self._as_list(self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases"))
+
+    def create_database(self, project_id: str, branch_id: str, name: str) -> Dict[str, Any]:
+        payload = self._request(
+            "POST",
+            f"/projects/{project_id}/branches/{branch_id}/databases",
+            body={"name": name},
+        )
+        data = payload.get("data")
+        return data if isinstance(data, dict) else payload
+
+    def get_connection_string(self, project_id: str, branch_id: str, role: str = "serendb_owner") -> str:
+        payload = self._request(
+            "GET",
+            f"/projects/{project_id}/branches/{branch_id}/connection-string",
+            query={"role": role, "pooled": "false"},
+        )
+        data = payload.get("data")
+        if isinstance(data, dict) and data.get("connection_string"):
+            return str(data["connection_string"])
+        if payload.get("connection_string"):
+            return str(payload["connection_string"])
+        raise SerenBootstrapError("Could not resolve connection string from Seren API")
+
+
+def _patch_database(connection_string: str, database_name: str) -> str:
+    parsed = urllib.parse.urlparse(connection_string)
+    return urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, f"/{database_name}", parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def resolve_or_create_serendb_target(
+    api_key: str,
+    *,
+    project_name: str,
+    database_name: str,
+    region: str,
+) -> SerenDbTarget:
+    api = SerenApi(api_key=api_key)
+
+    projects = api.list_projects()
+    project = next((p for p in projects if str(p.get("name", "")).lower() == project_name.lower()), None)
+    created_project = False
+    if not project:
+        project = api.create_project(name=project_name, region=region)
+        created_project = True
+
+    project_id = str(project.get("id") or "")
+    if not project_id:
+        raise SerenBootstrapError("Unable to determine Prophet storage project_id")
+
+    branches = api.list_branches(project_id)
+    if not branches:
+        raise SerenBootstrapError(f"No branches available for Prophet storage project {project_id}")
+
+    default_branch_id = project.get("default_branch_id") if isinstance(project, dict) else None
+    branch = None
+    if default_branch_id:
+        branch = next((b for b in branches if str(b.get("id")) == str(default_branch_id)), None)
+    if not branch:
+        branch = next((b for b in branches if str(b.get("name", "")).lower() in {"main", "production"}), None)
+    if not branch:
+        branch = branches[0]
+
+    branch_id = str(branch.get("id") or "")
+    branch_name = str(branch.get("name") or "main")
+    if not branch_id:
+        raise SerenBootstrapError("Unable to determine Prophet storage branch_id")
+
+    databases = api.list_databases(project_id, branch_id)
+    db_names = {str(d.get("name")) for d in databases if d.get("name")}
+    created_database = False
+    if database_name not in db_names:
+        api.create_database(project_id=project_id, branch_id=branch_id, name=database_name)
+        created_database = True
+
+    conn = _patch_database(api.get_connection_string(project_id=project_id, branch_id=branch_id), database_name)
+    return SerenDbTarget(
+        project_id=project_id,
+        branch_id=branch_id,
+        database_name=database_name,
+        connection_string=conn,
+        project_name=str(project.get("name") or project_name),
+        branch_name=branch_name,
+        created_project=created_project,
+        created_database=created_database,
+    )
+
+
+def storage_bootstrap_sql(schema_name: str) -> List[str]:
+    if not SCHEMA_PATH.exists():
+        raise SerenBootstrapError(f"Schema file not found: {SCHEMA_PATH}")
+    raw = SCHEMA_PATH.read_text(encoding="utf-8")
+    rendered = raw.replace("{{schema_name}}", schema_name)
+    statements = [part.strip() for part in rendered.split(";") if part.strip()]
+    if not statements:
+        raise SerenBootstrapError(f"Schema file is empty: {SCHEMA_PATH}")
+    return statements
+
+
+def psycopg_connect(dsn: str):  # pragma: no cover - exercised via tests with monkeypatch
+    import psycopg
+
+    return psycopg.connect(dsn)
+
+
+def apply_storage_bootstrap(connection_string: str, schema_name: str) -> int:
+    statements = storage_bootstrap_sql(schema_name)
+    try:
+        with psycopg_connect(connection_string) as conn:
+            with conn.cursor() as cur:
+                for statement in statements:
+                    cur.execute(statement)
+            conn.commit()
+    except Exception as exc:
+        raise SerenBootstrapError(f"Failed to apply Prophet storage bootstrap: {exc}") from exc
+    return len(statements)
+
+
+def ensure_storage(config: dict) -> dict:
+    storage_cfg = config.get("storage") if isinstance(config.get("storage"), dict) else {}
+    if not _bool(storage_cfg.get("auto_bootstrap"), True):
+        return {
+            "status": "skipped",
+            "reason": "auto_bootstrap_disabled",
+            "schema_name": str(storage_cfg.get("schema_name") or DEFAULT_SCHEMA_NAME),
+        }
+
+    project_name = str(storage_cfg.get("project_name") or DEFAULT_PROJECT_NAME)
+    database_name = str(storage_cfg.get("database_name") or DEFAULT_DATABASE_NAME)
+    schema_name = str(storage_cfg.get("schema_name") or DEFAULT_SCHEMA_NAME)
+    region = str(storage_cfg.get("region") or DEFAULT_REGION)
+    connection_string = storage_cfg.get("connection_string") or os.getenv("SERENDB_URL")
+    api_key = resolve_secret(config, "SEREN_API_KEY")
+
+    target: Optional[SerenDbTarget] = None
+    if not connection_string:
+        if not api_key:
+            raise SerenBootstrapError(
+                f"SEREN_API_KEY is required to auto-provision Prophet storage. Create an account at {SEREN_SKILLS_DOCS_URL}."
+            )
+        target = resolve_or_create_serendb_target(
+            api_key,
+            project_name=project_name,
+            database_name=database_name,
+            region=region,
+        )
+        connection_string = target.connection_string
+
+    executed = apply_storage_bootstrap(connection_string, schema_name)
+    result = {
+        "status": "ok",
+        "schema_name": schema_name,
+        "database_name": database_name,
+        "project_name": project_name,
+        "statements_executed": executed,
+        "auto_provisioned": True,
+    }
+    if target:
+        result.update(
+            {
+                "project_id": target.project_id,
+                "branch_id": target.branch_id,
+                "branch_name": target.branch_name,
+                "created_project": bool(getattr(target, "created_project", False)),
+                "created_database": bool(getattr(target, "created_database", False)),
+            }
+        )
+    return result
+
+
+def validate_prophet_access(config: dict) -> dict:
+    token = resolve_secret(config, "PROPHET_SESSION_TOKEN")
+    if not token:
+        raise ProphetAuthError(
+            "Missing PROPHET_SESSION_TOKEN. Use the Privy JWT from localStorage['privy:token'] and send it as Authorization: Bearer <token>."
+        )
+    viewer = ProphetApi(token).viewer_wallet_balance()
+    wallet_balance = viewer.get("walletBalance") or {}
     return {
         "status": "ok",
+        "required_header": "Authorization: Bearer <PROPHET_SESSION_TOKEN>",
+        "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
+        "viewer": {
+            "wallet_balance_total_cents": wallet_balance.get("totalCents"),
+            "wallet_balance_available_cents": wallet_balance.get("availableCents"),
+            "safe_address": wallet_balance.get("safeAddress"),
+            "safe_deployed": wallet_balance.get("safeDeployed"),
+        },
+    }
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    inputs = _config_inputs(config)
+    command = _normalize_command(inputs.get("command"))
+    strict_mode = _bool(inputs.get("strict_mode"), True)
+    recent_window_days = int(inputs.get("recent_window_days") or 7)
+    weekly_target_markets = int(inputs.get("weekly_target_markets") or 3)
+    reminder_enabled = _bool(inputs.get("reminder_enabled"), True)
+
+    if recent_window_days < 1 or recent_window_days > 30:
+        return _error_result(
+            "Invalid recent_window_days value",
+            error_code="invalid_recent_window_days",
+            dry_run=dry_run,
+            command=command,
+            details={"recent_window_days": recent_window_days},
+        )
+    if weekly_target_markets < 1 or weekly_target_markets > 10:
+        return _error_result(
+            "Invalid weekly_target_markets value",
+            error_code="invalid_weekly_target_markets",
+            dry_run=dry_run,
+            command=command,
+            details={"weekly_target_markets": weekly_target_markets},
+        )
+
+    try:
+        storage = ensure_storage(config) if command in {"setup", "run"} else {"status": "not_run"}
+        auth = validate_prophet_access(config)
+    except ProphetSkillError as exc:
+        if strict_mode or command != "setup":
+            error_code = "missing_seren_api_key" if SEREN_SKILLS_DOCS_URL in str(exc) else "auth_or_bootstrap_failed"
+            details = {"docs_url": SEREN_SKILLS_DOCS_URL} if error_code == "missing_seren_api_key" else None
+            return _error_result(str(exc), error_code=error_code, dry_run=dry_run, command=command, details=details)
+        storage = {"status": "skipped", "reason": "setup_non_strict"}
+        auth = {
+            "status": "warning",
+            "message": str(exc),
+            "required_header": "Authorization: Bearer <PROPHET_SESSION_TOKEN>",
+            "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
+        }
+
+    result = {
+        "status": "ok",
+        "skill": "prophet-growth-agent",
+        "command": command,
         "dry_run": dry_run,
         "connectors": AVAILABLE_CONNECTORS,
-        "input_keys": sorted(config.get("inputs", {}).keys()),
+        "input_keys": sorted(inputs.keys()),
+        "auth": auth,
+        "storage": storage,
+        "recent_window_days": recent_window_days,
+        "weekly_target_markets": weekly_target_markets,
+        "reminder_enabled": reminder_enabled,
     }
+    if command == "run":
+        result["follow_up_mode"] = "dry-run" if dry_run else "live"
+    return result
 
 
 def main() -> int:
     args = parse_args()
     config = load_config(args.config)
-    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    dry_run = _bool(config.get("dry_run"), DEFAULT_DRY_RUN)
     result = run_once(config=config, dry_run=dry_run)
     print(json.dumps(result))
-    return 0
+    return 0 if result.get("status") == "ok" else 1
 
 
 if __name__ == "__main__":

--- a/prophet/prophet-growth-agent/serendb_schema.sql
+++ b/prophet/prophet-growth-agent/serendb_schema.sql
@@ -1,0 +1,49 @@
+CREATE SCHEMA IF NOT EXISTS {{schema_name}};
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.sessions (
+  session_id TEXT PRIMARY KEY,
+  command TEXT NOT NULL,
+  recent_window_days INTEGER NOT NULL,
+  weekly_target_markets INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.runs (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT REFERENCES {{schema_name}}.sessions(session_id),
+  status TEXT NOT NULL,
+  reminder_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.events (
+  event_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.engagement_events (
+  engagement_event_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  engagement_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.checkin_recommendations (
+  recommendation_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  recommendation TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.artifacts (
+  artifact_id TEXT PRIMARY KEY,
+  run_id TEXT REFERENCES {{schema_name}}.runs(run_id),
+  artifact_type TEXT NOT NULL,
+  artifact_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/prophet/prophet-growth-agent/skill.spec.yaml
+++ b/prophet/prophet-growth-agent/skill.spec.yaml
@@ -37,6 +37,10 @@ inputs:
     type: boolean
     description: Enable reminder and re-engagement copy generation.
     default: true
+  strict_mode:
+    type: boolean
+    description: Block the run if Prophet auth or storage bootstrap guardrails fail.
+    default: true
 secrets:
   - SEREN_API_KEY
   - PROPHET_SESSION_TOKEN
@@ -60,6 +64,7 @@ state:
 policies:
   dry_run_default: true
   idempotency_required: true
+  auto_provision: true
 workflow:
   steps:
     - id: normalize_request
@@ -68,10 +73,14 @@ workflow:
         command: "{command}"
         json_output: "{json_output}"
         reminder_enabled: "{reminder_enabled}"
+    - id: validate_prophet_access
+      use: transform.validate_prophet_access
+      with:
+        from_step: normalize_request
     - id: connect_storage
       use: connector.storage.connect
       with:
-        from_step: normalize_request
+        from_step: validate_prophet_access
     - id: load_recent_activity
       use: connector.storage.query
       with:

--- a/prophet/prophet-growth-agent/tests/test_smoke.py
+++ b/prophet/prophet-growth-agent/tests/test_smoke.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "agent.py"
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
 
 
 def _read_fixture(name: str) -> dict:
     return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _load_agent_module():
+    spec = importlib.util.spec_from_file_location("prophet_growth_agent", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_happy_path_fixture_is_successful() -> None:
@@ -34,3 +49,116 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
     assert payload["dry_run"] is True
     assert payload["blocked_action"] == "live_execution"
 
+
+def test_validate_prophet_access_requires_bearer_token_header(monkeypatch) -> None:
+    agent = _load_agent_module()
+    captured = {}
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "data": {
+                        "viewer": {
+                            "walletBalance": {
+                                "availableCents": 0,
+                                "totalCents": 0,
+                                "safeAddress": "0xabc",
+                                "safeDeployed": False,
+                            }
+                        }
+                    }
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request, timeout=30):
+        captured["authorization"] = request.get_header("Authorization")
+        return DummyResponse()
+
+    monkeypatch.setattr(agent.urllib.request, "urlopen", fake_urlopen)
+    result = agent.validate_prophet_access({"secrets": {"PROPHET_SESSION_TOKEN": "privy-jwt"}})
+
+    assert captured["authorization"] == "Bearer privy-jwt"
+    assert result["status"] == "ok"
+    assert result["required_header"] == "Authorization: Bearer <PROPHET_SESSION_TOKEN>"
+
+
+def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monkeypatch) -> None:
+    agent = _load_agent_module()
+    executed = []
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, statement):
+            executed.append(statement)
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+        def commit(self):
+            executed.append("COMMIT")
+
+    monkeypatch.setattr(
+        agent,
+        "resolve_or_create_serendb_target",
+        lambda api_key, project_name, database_name, region: SimpleNamespace(
+            project_id="proj_123",
+            branch_id="branch_123",
+            branch_name="main",
+            database_name=database_name,
+            connection_string="postgresql://example/prophet",
+            project_name=project_name,
+            created_project=True,
+            created_database=True,
+        ),
+    )
+    monkeypatch.setattr(agent, "psycopg_connect", lambda dsn: FakeConnection())
+
+    result = agent.ensure_storage(
+        {
+            "storage": {
+                "auto_bootstrap": True,
+                "project_name": "prophet",
+                "database_name": "prophet",
+                "schema_name": "prophet_growth_agent",
+                "region": "aws-us-east-2",
+            },
+            "secrets": {"SEREN_API_KEY": "sb_test"},
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["project_name"] == "prophet"
+    assert result["auto_provisioned"] is True
+    assert result["created_project"] is True
+    assert result["created_database"] is True
+    assert result["statements_executed"] >= 6
+    assert any("CREATE SCHEMA IF NOT EXISTS prophet_growth_agent" in stmt for stmt in executed)
+
+
+def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
+    agent = _load_agent_module()
+
+    statements = agent.storage_bootstrap_sql("prophet_growth_agent")
+
+    assert SCHEMA_PATH.exists()
+    assert any("CREATE TABLE IF NOT EXISTS prophet_growth_agent.engagement_events" in stmt for stmt in statements)
+    assert any("CREATE TABLE IF NOT EXISTS prophet_growth_agent.checkin_recommendations" in stmt for stmt in statements)


### PR DESCRIPTION
## Summary
- apply the Prophet bearer-auth and Seren auto-bootstrap contract to `prophet-adversarial-auditor` and `prophet-growth-agent`
- add checked-in schema files for both skills and wire runtime bootstrap to use them
- update skill docs/config/spec entries and add focused auth/bootstrap smoke coverage

Closes #140

## Testing
- `pytest --import-mode=importlib prophet/prophet-adversarial-auditor/tests/test_smoke.py prophet/prophet-growth-agent/tests/test_smoke.py prophet/prophet-market-seeder/tests/test_smoke.py`
- `python3 -m py_compile prophet/prophet-adversarial-auditor/scripts/agent.py prophet/prophet-growth-agent/scripts/agent.py prophet/prophet-market-seeder/scripts/agent.py`
