### PR TITLE
fix(prophet-market-seeder): fix API paths + email OTP auth (#142, #144)

### DIFF
--- a/prophet/prophet-market-seeder/SKILL.md
+++ b/prophet/prophet-market-seeder/SKILL.md
@@ -32,9 +32,24 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 ## Auth Contract
 
-- Prophet backend requests must include `Authorization: Bearer <PROPHET_SESSION_TOKEN>`.
-- The correct token source is `localStorage["privy:token"]` from an authenticated `app.prophetmarket.ai` browser session.
-- The `privy-session` cookie by itself is not sufficient for authenticated GraphQL access.
+The skill acquires the Prophet session token automatically via Playwright using the email OTP flow:
+
+1. Navigate to `https://app.prophetmarket.ai`
+2. Click the "Connect" button to open the Privy auth modal
+3. Check `localStorage["privy:token"]` — if already set, use it directly
+4. If not authenticated:
+   a. Prompt user for their Prophet email (or read from config `inputs.prophet_email`)
+   b. Fill `#email-input` and click `button:has-text("Submit")`
+   c. Privy sends a 6-digit OTP to the user's email
+   d. Prompt user for the 6-digit code
+   e. Fill `input[name="code-0"]` through `input[name="code-5"]`
+   f. Poll `localStorage["privy:token"]` until non-null (with 60s timeout)
+5. Extract the JWT and pass it as `PROPHET_SESSION_TOKEN`
+
+**Important:**
+- Always use the email OTP path (wallet connect and Google OAuth do not work in Playwright)
+- The token is a JWT starting with `eyJ...` and expires after ~1 hour
+- The `privy-session` cookie alone is not sufficient for authenticated GraphQL access
 
 ## First-Run Setup
 

--- a/prophet/prophet-market-seeder/config.example.json
+++ b/prophet/prophet-market-seeder/config.example.json
@@ -14,6 +14,7 @@
     "candidate_limit": 12,
     "command": "run",
     "json_output": false,
+    "prophet_email": "",
     "referral_code": "AGENTACCESS",
     "strict_mode": true,
     "submit_limit": 3

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -171,7 +171,7 @@ class SerenApi:
         if not api_key:
             raise ValueError("SEREN_API_KEY is required")
         self.api_key = api_key
-        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com").rstrip("/")
+        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com/publishers/seren-db").rstrip("/")
 
     def _request(
         self,


### PR DESCRIPTION
## Summary

- **Fix #144**: Changed `SerenApi` default `api_base` from `https://api.serendb.com` to `https://api.serendb.com/publishers/seren-db` so all API method paths resolve correctly.
- **Fix #142**: Replaced the Auth Contract section in `SKILL.md` with full documentation of the Playwright email OTP flow for acquiring the Prophet session token automatically.
- Added `prophet_email` field to `config.example.json` inputs.

Closes #142, closes #144

## Test plan

- [ ] Verify `SerenApi` calls hit `/publishers/seren-db/projects` (not `/projects`) by running with `--dry-run`
- [ ] Confirm `SKILL.md` Auth Contract section renders correctly and describes the email OTP steps
- [ ] Confirm `config.example.json` parses as valid JSON and includes `prophet_email`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com