### PR TITLE
fix(prophet): API paths + email OTP auth for growth-agent and adversarial-auditor

### DIFF
--- a/prophet/prophet-adversarial-auditor/SKILL.md
+++ b/prophet/prophet-adversarial-auditor/SKILL.md
@@ -31,9 +31,24 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 ## Auth Contract
 
-- Prophet backend requests must include `Authorization: Bearer <PROPHET_SESSION_TOKEN>`.
-- The correct token source is `localStorage["privy:token"]` from an authenticated `app.prophetmarket.ai` browser session.
-- The `privy-session` cookie by itself is not sufficient for authenticated GraphQL access.
+The skill acquires the Prophet session token automatically via Playwright using the email OTP flow:
+
+1. Navigate to `https://app.prophetmarket.ai`
+2. Click the "Connect" button to open the Privy auth modal
+3. Check `localStorage["privy:token"]` — if already set, use it directly
+4. If not authenticated:
+   a. Prompt user for their Prophet email (or read from config `inputs.prophet_email`)
+   b. Fill `#email-input` and click `button:has-text("Submit")`
+   c. Privy sends a 6-digit OTP to the user's email
+   d. Prompt user for the 6-digit code
+   e. Fill `input[name="code-0"]` through `input[name="code-5"]`
+   f. Poll `localStorage["privy:token"]` until non-null (with 60s timeout)
+5. Extract the JWT and pass it as `PROPHET_SESSION_TOKEN`
+
+**Important:**
+- Always use the email OTP path (wallet connect and Google OAuth do not work in Playwright)
+- The token is a JWT starting with `eyJ...` and expires after ~1 hour
+- The `privy-session` cookie alone is not sufficient for authenticated GraphQL access
 
 ## First-Run Setup
 

--- a/prophet/prophet-adversarial-auditor/config.example.json
+++ b/prophet/prophet-adversarial-auditor/config.example.json
@@ -14,6 +14,7 @@
     "command": "run",
     "include_loss_hypotheses": true,
     "json_output": false,
+    "prophet_email": "",
     "lookback_days": 30,
     "severity_threshold": "medium",
     "strict_mode": true

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -171,7 +171,7 @@ class SerenApi:
         if not api_key:
             raise ValueError("SEREN_API_KEY is required")
         self.api_key = api_key
-        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com").rstrip("/")
+        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com/publishers/seren-db").rstrip("/")
 
     def _request(
         self,

--- a/prophet/prophet-growth-agent/SKILL.md
+++ b/prophet/prophet-growth-agent/SKILL.md
@@ -30,9 +30,24 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 ## Auth Contract
 
-- Prophet backend requests must include `Authorization: Bearer <PROPHET_SESSION_TOKEN>`.
-- The correct token source is `localStorage["privy:token"]` from an authenticated `app.prophetmarket.ai` browser session.
-- The `privy-session` cookie by itself is not sufficient for authenticated GraphQL access.
+The skill acquires the Prophet session token automatically via Playwright using the email OTP flow:
+
+1. Navigate to `https://app.prophetmarket.ai`
+2. Click the "Connect" button to open the Privy auth modal
+3. Check `localStorage["privy:token"]` — if already set, use it directly
+4. If not authenticated:
+   a. Prompt user for their Prophet email (or read from config `inputs.prophet_email`)
+   b. Fill `#email-input` and click `button:has-text("Submit")`
+   c. Privy sends a 6-digit OTP to the user's email
+   d. Prompt user for the 6-digit code
+   e. Fill `input[name="code-0"]` through `input[name="code-5"]`
+   f. Poll `localStorage["privy:token"]` until non-null (with 60s timeout)
+5. Extract the JWT and pass it as `PROPHET_SESSION_TOKEN`
+
+**Important:**
+- Always use the email OTP path (wallet connect and Google OAuth do not work in Playwright)
+- The token is a JWT starting with `eyJ...` and expires after ~1 hour
+- The `privy-session` cookie alone is not sufficient for authenticated GraphQL access
 
 ## First-Run Setup
 

--- a/prophet/prophet-growth-agent/config.example.json
+++ b/prophet/prophet-growth-agent/config.example.json
@@ -13,6 +13,7 @@
   "inputs": {
     "command": "status",
     "json_output": false,
+    "prophet_email": "",
     "recent_window_days": 7,
     "reminder_enabled": true,
     "strict_mode": true,

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -171,7 +171,7 @@ class SerenApi:
         if not api_key:
             raise ValueError("SEREN_API_KEY is required")
         self.api_key = api_key
-        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com").rstrip("/")
+        self.api_base = (api_base or os.getenv("SEREN_API_BASE") or "https://api.serendb.com/publishers/seren-db").rstrip("/")
 
     def _request(
         self,


### PR DESCRIPTION
## Summary
- Fix API base URL default from `https://api.serendb.com` to `https://api.serendb.com/publishers/seren-db` in `prophet-growth-agent` and `prophet-adversarial-auditor`
- Replace Auth Contract sections in both SKILL.md files with the Playwright email OTP flow (matching prophet-market-seeder)
- Add `prophet_email` to `config.example.json` inputs for both skills

## Test plan
- [ ] Verify `agent.py` in both skills defaults to the correct `/publishers/seren-db` API path
- [ ] Confirm SKILL.md Auth Contract matches prophet-market-seeder
- [ ] Confirm config.example.json includes `prophet_email` field

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com