### PR TITLE
feat(polymarket): auto-tune invocation backtests

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -38,6 +38,11 @@
     "history_interval": "max",
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 12,
+    "optimization": {
+      "enabled": true,
+      "target_return_pct": 25.0,
+      "max_iterations": 8
+    },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"
   },

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -115,6 +115,13 @@ class BacktestParams:
     predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
+@dataclass(frozen=True)
+class OptimizationParams:
+    enabled: bool = True
+    target_return_pct: float = 25.0
+    max_iterations: int = 8
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run paired-market basis maker strategy.")
     parser.add_argument("--config", default="config.json", help="Config file path.")
@@ -196,6 +203,22 @@ def load_config(config_path: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _clone_config(config: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(config))
+
+
+def _write_config(config_path: str, config: dict[str, Any]) -> None:
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def _apply_config_updates_in_place(config: dict[str, Any], updates: dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
+
+
 def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
     if not isinstance(state, dict) or not state:
         return
@@ -270,6 +293,18 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
         predictions_enabled=bool(raw.get("predictions_enabled", False)),
         predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
+    )
+
+
+def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
+    backtest_raw = config.get("backtest", {})
+    raw = backtest_raw.get("optimization", {}) if isinstance(backtest_raw, dict) else {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return OptimizationParams(
+        enabled=_safe_bool(raw.get("enabled"), True),
+        target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
     )
 
 
@@ -903,6 +938,143 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _pair_target_descriptors(markets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "market_id": _safe_str(market.get("market_id"), "unknown"),
+            "pair_market_id": _safe_str(market.get("pair_market_id"), "unknown"),
+            "question": _safe_str(market.get("question"), ""),
+            "pair_question": _safe_str(market.get("pair_question"), ""),
+        }
+        for market in markets
+    ]
+
+
+def _diff_section(original: dict[str, Any], updated: dict[str, Any]) -> dict[str, Any]:
+    diff: dict[str, Any] = {}
+    for key, value in updated.items():
+        if original.get(key) != value:
+            diff[key] = value
+    return diff
+
+
+def _rank_pair_markets(markets: list[dict[str, Any]], result: dict[str, Any]) -> list[dict[str, Any]]:
+    pnl_by_pair: dict[tuple[str, str], float] = {}
+    for row in result.get("pairs", []):
+        if not isinstance(row, dict):
+            continue
+        key = (
+            _safe_str(row.get("market_id"), "unknown"),
+            _safe_str(row.get("pair_market_id"), "unknown"),
+        )
+        pnl_by_pair[key] = _safe_float(row.get("pnl_usd"), 0.0)
+    return sorted(
+        markets,
+        key=lambda market: (
+            pnl_by_pair.get(
+                (
+                    _safe_str(market.get("market_id"), "unknown"),
+                    _safe_str(market.get("pair_market_id"), "unknown"),
+                ),
+                float("-inf"),
+            ),
+            _safe_float(market.get("rebate_bps"), 0.0),
+        ),
+        reverse=True,
+    )
+
+
+def _optimization_attempt_summary(
+    *,
+    name: str,
+    result: dict[str, Any],
+    strategy_updates: dict[str, Any],
+    backtest_updates: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": _safe_str(result.get("status"), "error"),
+        "return_pct": round(_safe_float(result.get("results", {}).get("return_pct"), 0.0), 4),
+        "total_pnl_usd": round(_safe_float(result.get("results", {}).get("total_pnl_usd"), 0.0), 4),
+        "target_market_count": len(targets),
+        "target_market_ids": [target["market_id"] for target in targets],
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+
+
+def _is_better_backtest_result(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
+    if candidate.get("status") != "ok":
+        return False
+    if current.get("status") != "ok":
+        return True
+    candidate_return = _safe_float(candidate.get("results", {}).get("return_pct"), float("-inf"))
+    current_return = _safe_float(current.get("results", {}).get("return_pct"), float("-inf"))
+    if candidate_return != current_return:
+        return candidate_return > current_return
+    candidate_pnl = _safe_float(candidate.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    current_pnl = _safe_float(current.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    return candidate_pnl > current_pnl
+
+
+def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) -> list[dict[str, Any]]:
+    p = to_strategy_params(config)
+    base_pairs = max(2, min(total_markets, p.pairs_max))
+    focus_pairs = max(2, min(total_markets, max(2, int(round(base_pairs * 0.6)))))
+    broad_pairs = max(2, min(total_markets, max(base_pairs, int(round(total_markets * 0.75)))))
+    return [
+        {
+            "name": "focus-lower-entry",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.1, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "focus-higher-capacity",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.75), 4),
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.75), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.15, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.15, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.15, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.15, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-tighter-exit",
+            "subset_size": base_pairs,
+            "strategy": {
+                "pairs_max": base_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.05, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-higher-capacity",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.1, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.2, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+    ]
+
+
 def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
@@ -999,56 +1171,18 @@ def _fetch_predictions_pair_signals(
     return result
 
 
-def run_backtest(
+def _evaluate_backtest(
+    *,
     config: dict[str, Any],
-    backtest_days: int | None,
-    backtest_file: str | None = None,
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
-    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
-    configured_backtest_file = ""
-    if isinstance(config.get("backtest"), dict):
-        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
-    selected_backtest_file = backtest_file or configured_backtest_file or None
-
-    end_ts = int(time.time())
-    start_ts = end_ts - (days * 24 * 60 * 60)
-
-    try:
-        if selected_backtest_file:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-                backtest_file=selected_backtest_file,
-            )
-        else:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-            )
-    except Exception as exc:
-        return {
-            "status": "error",
-            "error_code": "backtest_data_load_failed",
-            "message": str(exc),
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
-    if not markets:
-        return {
-            "status": "error",
-            "error_code": "no_backtest_markets",
-            "message": "No paired historical markets were available for backtest.",
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0
@@ -1058,8 +1192,7 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
-    num_pairs = len(markets)
-    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
+    capital_per_pair = p.bankroll_usd / max(1, len(markets))
 
     for market in markets:
         result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
@@ -1095,7 +1228,6 @@ def run_backtest(
     total_pnl = equity - p.bankroll_usd
     total_return_pct = (total_pnl / p.bankroll_usd) * 100.0
     max_drawdown_usd, max_drawdown_pct = _max_drawdown_stats(equity_curve)
-    # UI-facing percentages should not report losses below -100% or drawdowns above 100%.
     display_total_return_pct = max(total_return_pct, -100.0)
     display_max_drawdown_pct = min(max_drawdown_pct, 100.0)
     events = len(event_pnls)
@@ -1127,15 +1259,13 @@ def run_backtest(
         }
 
     write_telemetry_records(bt.telemetry_path, telemetry)
-
-    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
     predictions = _fetch_predictions_pair_signals(backtest_params=bt)
     predictions_pairs_count = len(predictions.get("suggested_pairs", []))
     predictions_correlations_count = len(predictions.get("correlations", []))
 
     return {
         "status": "ok",
-        "skill": "high-throughput-paired-basis-maker",
+        "skill": skill_name,
         "mode": "backtest",
         "dry_run": True,
         "predictions_intelligence": {
@@ -1217,6 +1347,168 @@ def run_backtest(
             else {}
         ),
     }
+
+
+def _optimize_backtest(
+    *,
+    config: dict[str, Any],
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
+) -> dict[str, Any]:
+    baseline = _evaluate_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name=skill_name,
+    )
+    if baseline.get("status") != "ok":
+        return baseline
+
+    optimization = to_optimization_params(config)
+    ranked_markets = _rank_pair_markets(markets, baseline)
+    best_result = baseline
+    best_config = _clone_config(config)
+    best_targets = _pair_target_descriptors(ranked_markets)
+    attempts = [
+        _optimization_attempt_summary(
+            name="baseline",
+            result=baseline,
+            strategy_updates={},
+            backtest_updates={},
+            targets=best_targets,
+        )
+    ]
+
+    if optimization.enabled:
+        max_attempts = max(1, optimization.max_iterations)
+        for candidate in _pair_optimization_candidates(config, len(ranked_markets))[: max(0, max_attempts - 1)]:
+            if _safe_float(best_result.get("results", {}).get("return_pct"), 0.0) >= optimization.target_return_pct:
+                break
+            subset_size = max(2, min(len(ranked_markets), _safe_int(candidate.get("subset_size"), len(ranked_markets))))
+            candidate_markets = ranked_markets[:subset_size]
+            candidate_config = _clone_config(config)
+            candidate_config.setdefault("strategy", {}).update(candidate.get("strategy", {}))
+            candidate_config.setdefault("backtest", {}).update(candidate.get("backtest", {}))
+            candidate_result = _evaluate_backtest(
+                config=candidate_config,
+                markets=candidate_markets,
+                source=f"{source}|optimized:{candidate['name']}",
+                days=days,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                skill_name=skill_name,
+            )
+            candidate_targets = _pair_target_descriptors(candidate_markets)
+            attempts.append(
+                _optimization_attempt_summary(
+                    name=_safe_str(candidate.get("name"), "candidate"),
+                    result=candidate_result,
+                    strategy_updates=_diff_section(config.get("strategy", {}), candidate_config.get("strategy", {})),
+                    backtest_updates=_diff_section(config.get("backtest", {}), candidate_config.get("backtest", {})),
+                    targets=candidate_targets,
+                )
+            )
+            if _is_better_backtest_result(candidate_result, best_result):
+                best_result = candidate_result
+                best_config = candidate_config
+                best_targets = candidate_targets
+
+    strategy_updates = _diff_section(config.get("strategy", {}), best_config.get("strategy", {}))
+    backtest_updates = _diff_section(config.get("backtest", {}), best_config.get("backtest", {}))
+    best_return_pct = _safe_float(best_result.get("results", {}).get("return_pct"), 0.0)
+    optimization_state = {
+        "enabled": optimization.enabled,
+        "target_return_pct": round(optimization.target_return_pct, 4),
+        "target_met": best_return_pct >= optimization.target_return_pct,
+        "selected_attempt": next(
+            (attempt["name"] for attempt in attempts if attempt["return_pct"] == round(best_return_pct, 4)),
+            attempts[0]["name"],
+        ),
+        "best_return_pct": round(best_return_pct, 4),
+        "attempt_count": len(attempts),
+        "target_pairs": best_targets,
+        "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    best_result["optimization_summary"] = {
+        **optimization_state,
+        "attempts": attempts,
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+    best_result["config_updates"] = {
+        "strategy": strategy_updates,
+        "backtest": backtest_updates,
+        "state": {"backtest_optimizer": optimization_state},
+    }
+    return best_result
+
+
+def run_backtest(
+    config: dict[str, Any],
+    backtest_days: int | None,
+    backtest_file: str | None = None,
+) -> dict[str, Any]:
+    p = to_strategy_params(config)
+    bt = to_backtest_params(config)
+    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
+    configured_backtest_file = ""
+    if isinstance(config.get("backtest"), dict):
+        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
+    selected_backtest_file = backtest_file or configured_backtest_file or None
+
+    end_ts = int(time.time())
+    start_ts = end_ts - (days * 24 * 60 * 60)
+
+    try:
+        if selected_backtest_file:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                backtest_file=selected_backtest_file,
+            )
+        else:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "error_code": "backtest_data_load_failed",
+            "message": str(exc),
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    if not markets:
+        return {
+            "status": "error",
+            "error_code": "no_backtest_markets",
+            "message": "No paired historical markets were available for backtest.",
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    return _optimize_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name="high-throughput-paired-basis-maker",
+    )
 
 
 def _extract_live_mid_price(payload: dict[str, Any]) -> float:
@@ -1695,6 +1987,13 @@ def main() -> int:
     if backtest.get("status") != "ok":
         print(json.dumps(backtest, sort_keys=True))
         return 1
+
+    if isinstance(backtest.get("config_updates"), dict):
+        _apply_config_updates_in_place(config, backtest["config_updates"])
+        try:
+            _write_config(args.config, config)
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            backtest["config_writeback_warning"] = str(exc)
 
     if args.run_type == "backtest":
         print(json.dumps(backtest, sort_keys=True))

--- a/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import json
 import sys
@@ -155,3 +156,92 @@ def test_trade_mode_fetches_live_pairs_when_config_markets_is_empty(monkeypatch)
     assert result["pair_trades"][0]["market_id"] == "LIVE-HT-1A"
     assert result["pair_trades"][0]["pair_market_id"] == "LIVE-HT-1B"
     assert any("/publishers/polymarket-data/markets?" in url for url in fetched_urls)
+
+
+def test_backtest_optimizer_selects_targeted_pair_subset_and_tuned_config(monkeypatch) -> None:
+    module = _load_agent_module()
+    now_ts = int(time.time())
+    config = {
+        "strategy": {"bankroll_usd": 1000, "pairs_max": 3, "basis_entry_bps": 35, "base_pair_notional_usd": 600},
+        "backtest": {"days": 90, "min_events": 1, "telemetry_path": "", "optimization": {"target_return_pct": 25.0}},
+    }
+    markets = [
+        {"market_id": "M0", "pair_market_id": "P0", "question": "A", "pair_question": "B", "history": [], "pair_history": [], "rebate_bps": 2.3},
+        {"market_id": "M1", "pair_market_id": "P1", "question": "C", "pair_question": "D", "history": [], "pair_history": [], "rebate_bps": 2.3},
+        {"market_id": "M2", "pair_market_id": "P2", "question": "E", "pair_question": "F", "history": [], "pair_history": [], "rebate_bps": 2.3},
+    ]
+
+    def fake_load_backtest_markets(p, bt, start_ts, end_ts):
+        return markets, "synthetic"
+
+    def fake_simulate_pair(market, p, bt, allocated_capital=0.0):
+        aggressive = p.base_pair_notional_usd > 650 and p.basis_entry_bps < 30
+        pnl = 140.0 if aggressive and market["market_id"] in {"M0", "M1"} else (8.0 if market["market_id"] in {"M0", "M1"} else -2.0)
+        return {
+            "market_id": market["market_id"],
+            "pair_market_id": market["pair_market_id"],
+            "considered_points": 10,
+            "quoted_points": 6,
+            "traded_points": 6,
+            "skipped_points": 0,
+            "fill_events": 1,
+            "filled_notional_usd": 100.0,
+            "pnl_usd": pnl,
+            "event_pnls": [pnl],
+            "orderbook_mode": "synthetic",
+            "telemetry": [],
+        }
+
+    monkeypatch.setattr(module, "_load_backtest_markets", fake_load_backtest_markets)
+    monkeypatch.setattr(module, "_simulate_pair", fake_simulate_pair)
+    monkeypatch.setattr(module, "write_telemetry_records", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_fetch_predictions_pair_signals", lambda backtest_params: {})
+
+    output = module.run_backtest(config, None)
+
+    assert output["status"] == "ok"
+    assert output["results"]["return_pct"] >= 25.0
+    assert output["optimization_summary"]["target_met"] is True
+    assert output["config_updates"]["strategy"]["base_pair_notional_usd"] > 600
+    assert [target["market_id"] for target in output["optimization_summary"]["target_pairs"]] == ["M0", "M1"]
+
+
+def test_main_applies_backtest_config_updates_before_trade(monkeypatch, tmp_path: Path) -> None:
+    module = _load_agent_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"execution": {"require_positive_backtest": True}, "strategy": {"basis_entry_bps": 35}}), encoding="utf-8")
+    seen: dict[str, float] = {}
+
+    monkeypatch.setattr(
+        module,
+        "parse_args",
+        lambda: argparse.Namespace(
+            config=str(config_path),
+            run_type="trade",
+            markets_file=None,
+            backtest_file=None,
+            backtest_days=None,
+            allow_negative_backtest=False,
+            yes_live=False,
+        ),
+    )
+    monkeypatch.setattr(module, "load_config", lambda path: json.loads(config_path.read_text(encoding="utf-8")))
+    monkeypatch.setattr(
+        module,
+        "run_backtest",
+        lambda config, backtest_days, backtest_file=None: {
+            "status": "ok",
+            "results": {"return_pct": 30.0},
+            "config_updates": {"strategy": {"basis_entry_bps": 12.0}, "state": {"backtest_optimizer": {"target_met": True}}},
+        },
+    )
+    def fake_run_trade(config, markets_file, yes_live):
+        seen["basis_entry_bps"] = config["strategy"]["basis_entry_bps"]
+        return {"status": "ok"}
+
+    monkeypatch.setattr(module, "run_trade", fake_run_trade)
+
+    assert module.main() == 0
+    assert seen["basis_entry_bps"] == 12.0
+    persisted = json.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted["strategy"]["basis_entry_bps"] == 12.0

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -38,6 +38,11 @@
     "history_interval": "max",
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 4,
+    "optimization": {
+      "enabled": true,
+      "target_return_pct": 25.0,
+      "max_iterations": 8
+    },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"
   },

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -122,6 +122,13 @@ class BacktestParams:
     predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
+@dataclass(frozen=True)
+class OptimizationParams:
+    enabled: bool = True
+    target_return_pct: float = 25.0
+    max_iterations: int = 8
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run liquidity-filtered paired-market basis maker strategy.")
     parser.add_argument("--config", default="config.json", help="Config file path.")
@@ -204,6 +211,22 @@ def load_config(config_path: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _clone_config(config: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(config))
+
+
+def _write_config(config_path: str, config: dict[str, Any]) -> None:
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def _apply_config_updates_in_place(config: dict[str, Any], updates: dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
+
+
 def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
     if not isinstance(state, dict) or not state:
         return
@@ -278,6 +301,18 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 4)),
         predictions_enabled=bool(raw.get("predictions_enabled", False)),
         predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
+    )
+
+
+def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
+    backtest_raw = config.get("backtest", {})
+    raw = backtest_raw.get("optimization", {}) if isinstance(backtest_raw, dict) else {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return OptimizationParams(
+        enabled=_safe_bool(raw.get("enabled"), True),
+        target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
     )
 
 
@@ -964,6 +999,143 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _pair_target_descriptors(markets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "market_id": _safe_str(market.get("market_id"), "unknown"),
+            "pair_market_id": _safe_str(market.get("pair_market_id"), "unknown"),
+            "question": _safe_str(market.get("question"), ""),
+            "pair_question": _safe_str(market.get("pair_question"), ""),
+        }
+        for market in markets
+    ]
+
+
+def _diff_section(original: dict[str, Any], updated: dict[str, Any]) -> dict[str, Any]:
+    diff: dict[str, Any] = {}
+    for key, value in updated.items():
+        if original.get(key) != value:
+            diff[key] = value
+    return diff
+
+
+def _rank_pair_markets(markets: list[dict[str, Any]], result: dict[str, Any]) -> list[dict[str, Any]]:
+    pnl_by_pair: dict[tuple[str, str], float] = {}
+    for row in result.get("pairs", []):
+        if not isinstance(row, dict):
+            continue
+        key = (
+            _safe_str(row.get("market_id"), "unknown"),
+            _safe_str(row.get("pair_market_id"), "unknown"),
+        )
+        pnl_by_pair[key] = _safe_float(row.get("pnl_usd"), 0.0)
+    return sorted(
+        markets,
+        key=lambda market: (
+            pnl_by_pair.get(
+                (
+                    _safe_str(market.get("market_id"), "unknown"),
+                    _safe_str(market.get("pair_market_id"), "unknown"),
+                ),
+                float("-inf"),
+            ),
+            _safe_float(market.get("rebate_bps"), 0.0),
+        ),
+        reverse=True,
+    )
+
+
+def _optimization_attempt_summary(
+    *,
+    name: str,
+    result: dict[str, Any],
+    strategy_updates: dict[str, Any],
+    backtest_updates: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": _safe_str(result.get("status"), "error"),
+        "return_pct": round(_safe_float(result.get("results", {}).get("return_pct"), 0.0), 4),
+        "total_pnl_usd": round(_safe_float(result.get("results", {}).get("total_pnl_usd"), 0.0), 4),
+        "target_market_count": len(targets),
+        "target_market_ids": [target["market_id"] for target in targets],
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+
+
+def _is_better_backtest_result(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
+    if candidate.get("status") != "ok":
+        return False
+    if current.get("status") != "ok":
+        return True
+    candidate_return = _safe_float(candidate.get("results", {}).get("return_pct"), float("-inf"))
+    current_return = _safe_float(current.get("results", {}).get("return_pct"), float("-inf"))
+    if candidate_return != current_return:
+        return candidate_return > current_return
+    candidate_pnl = _safe_float(candidate.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    current_pnl = _safe_float(current.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    return candidate_pnl > current_pnl
+
+
+def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) -> list[dict[str, Any]]:
+    p = to_strategy_params(config)
+    base_pairs = max(2, min(total_markets, p.pairs_max))
+    focus_pairs = max(2, min(total_markets, max(2, int(round(base_pairs * 0.6)))))
+    broad_pairs = max(2, min(total_markets, max(base_pairs, int(round(total_markets * 0.75)))))
+    return [
+        {
+            "name": "focus-lower-entry",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.1, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "focus-higher-capacity",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.75), 4),
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.75), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.15, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.15, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.15, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.15, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-tighter-exit",
+            "subset_size": base_pairs,
+            "strategy": {
+                "pairs_max": base_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.05, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-higher-capacity",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.1, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.2, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+    ]
+
+
 def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
@@ -1060,56 +1232,18 @@ def _fetch_predictions_pair_signals(
     return result
 
 
-def run_backtest(
+def _evaluate_backtest(
+    *,
     config: dict[str, Any],
-    backtest_days: int | None,
-    backtest_file: str | None = None,
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
-    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
-    configured_backtest_file = ""
-    if isinstance(config.get("backtest"), dict):
-        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
-    selected_backtest_file = backtest_file or configured_backtest_file or None
-
-    end_ts = int(time.time())
-    start_ts = end_ts - (days * 24 * 60 * 60)
-
-    try:
-        if selected_backtest_file:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-                backtest_file=selected_backtest_file,
-            )
-        else:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-            )
-    except Exception as exc:
-        return {
-            "status": "error",
-            "error_code": "backtest_data_load_failed",
-            "message": str(exc),
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
-    if not markets:
-        return {
-            "status": "error",
-            "error_code": "no_backtest_markets",
-            "message": "No paired historical markets were available for backtest.",
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0
@@ -1119,8 +1253,7 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
-    num_pairs = len(markets)
-    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
+    capital_per_pair = p.bankroll_usd / max(1, len(markets))
 
     for market in markets:
         result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
@@ -1156,7 +1289,6 @@ def run_backtest(
     total_pnl = equity - p.bankroll_usd
     total_return_pct = (total_pnl / p.bankroll_usd) * 100.0
     max_drawdown_usd, max_drawdown_pct = _max_drawdown_stats(equity_curve)
-    # UI-facing percentages should not report losses below -100% or drawdowns above 100%.
     display_total_return_pct = max(total_return_pct, -100.0)
     display_max_drawdown_pct = min(max_drawdown_pct, 100.0)
     events = len(event_pnls)
@@ -1188,15 +1320,13 @@ def run_backtest(
         }
 
     write_telemetry_records(bt.telemetry_path, telemetry)
-
-    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
     predictions = _fetch_predictions_pair_signals(backtest_params=bt)
     predictions_pairs_count = len(predictions.get("suggested_pairs", []))
     predictions_correlations_count = len(predictions.get("correlations", []))
 
     return {
         "status": "ok",
-        "skill": "liquidity-paired-basis-maker",
+        "skill": skill_name,
         "mode": "backtest",
         "dry_run": True,
         "predictions_intelligence": {
@@ -1278,6 +1408,168 @@ def run_backtest(
             else {}
         ),
     }
+
+
+def _optimize_backtest(
+    *,
+    config: dict[str, Any],
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
+) -> dict[str, Any]:
+    baseline = _evaluate_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name=skill_name,
+    )
+    if baseline.get("status") != "ok":
+        return baseline
+
+    optimization = to_optimization_params(config)
+    ranked_markets = _rank_pair_markets(markets, baseline)
+    best_result = baseline
+    best_config = _clone_config(config)
+    best_targets = _pair_target_descriptors(ranked_markets)
+    attempts = [
+        _optimization_attempt_summary(
+            name="baseline",
+            result=baseline,
+            strategy_updates={},
+            backtest_updates={},
+            targets=best_targets,
+        )
+    ]
+
+    if optimization.enabled:
+        max_attempts = max(1, optimization.max_iterations)
+        for candidate in _pair_optimization_candidates(config, len(ranked_markets))[: max(0, max_attempts - 1)]:
+            if _safe_float(best_result.get("results", {}).get("return_pct"), 0.0) >= optimization.target_return_pct:
+                break
+            subset_size = max(2, min(len(ranked_markets), _safe_int(candidate.get("subset_size"), len(ranked_markets))))
+            candidate_markets = ranked_markets[:subset_size]
+            candidate_config = _clone_config(config)
+            candidate_config.setdefault("strategy", {}).update(candidate.get("strategy", {}))
+            candidate_config.setdefault("backtest", {}).update(candidate.get("backtest", {}))
+            candidate_result = _evaluate_backtest(
+                config=candidate_config,
+                markets=candidate_markets,
+                source=f"{source}|optimized:{candidate['name']}",
+                days=days,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                skill_name=skill_name,
+            )
+            candidate_targets = _pair_target_descriptors(candidate_markets)
+            attempts.append(
+                _optimization_attempt_summary(
+                    name=_safe_str(candidate.get("name"), "candidate"),
+                    result=candidate_result,
+                    strategy_updates=_diff_section(config.get("strategy", {}), candidate_config.get("strategy", {})),
+                    backtest_updates=_diff_section(config.get("backtest", {}), candidate_config.get("backtest", {})),
+                    targets=candidate_targets,
+                )
+            )
+            if _is_better_backtest_result(candidate_result, best_result):
+                best_result = candidate_result
+                best_config = candidate_config
+                best_targets = candidate_targets
+
+    strategy_updates = _diff_section(config.get("strategy", {}), best_config.get("strategy", {}))
+    backtest_updates = _diff_section(config.get("backtest", {}), best_config.get("backtest", {}))
+    best_return_pct = _safe_float(best_result.get("results", {}).get("return_pct"), 0.0)
+    optimization_state = {
+        "enabled": optimization.enabled,
+        "target_return_pct": round(optimization.target_return_pct, 4),
+        "target_met": best_return_pct >= optimization.target_return_pct,
+        "selected_attempt": next(
+            (attempt["name"] for attempt in attempts if attempt["return_pct"] == round(best_return_pct, 4)),
+            attempts[0]["name"],
+        ),
+        "best_return_pct": round(best_return_pct, 4),
+        "attempt_count": len(attempts),
+        "target_pairs": best_targets,
+        "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    best_result["optimization_summary"] = {
+        **optimization_state,
+        "attempts": attempts,
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+    best_result["config_updates"] = {
+        "strategy": strategy_updates,
+        "backtest": backtest_updates,
+        "state": {"backtest_optimizer": optimization_state},
+    }
+    return best_result
+
+
+def run_backtest(
+    config: dict[str, Any],
+    backtest_days: int | None,
+    backtest_file: str | None = None,
+) -> dict[str, Any]:
+    p = to_strategy_params(config)
+    bt = to_backtest_params(config)
+    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
+    configured_backtest_file = ""
+    if isinstance(config.get("backtest"), dict):
+        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
+    selected_backtest_file = backtest_file or configured_backtest_file or None
+
+    end_ts = int(time.time())
+    start_ts = end_ts - (days * 24 * 60 * 60)
+
+    try:
+        if selected_backtest_file:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                backtest_file=selected_backtest_file,
+            )
+        else:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "error_code": "backtest_data_load_failed",
+            "message": str(exc),
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    if not markets:
+        return {
+            "status": "error",
+            "error_code": "no_backtest_markets",
+            "message": "No paired historical markets were available for backtest.",
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    return _optimize_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name="liquidity-paired-basis-maker",
+    )
 
 
 def _extract_live_mid_price(payload: dict[str, Any]) -> float:
@@ -1756,6 +2048,13 @@ def main() -> int:
     if backtest.get("status") != "ok":
         print(json.dumps(backtest, sort_keys=True))
         return 1
+
+    if isinstance(backtest.get("config_updates"), dict):
+        _apply_config_updates_in_place(config, backtest["config_updates"])
+        try:
+            _write_config(args.config, config)
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            backtest["config_writeback_warning"] = str(exc)
 
     if args.run_type == "backtest":
         print(json.dumps(backtest, sort_keys=True))

--- a/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
@@ -102,7 +102,9 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
     assert output["results"]["starting_bankroll_usd"] == 1000
     assert output["results"]["fill_events"] > 0
     assert output["backtest_summary"]["quoted_points"] > 0
-    assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(synthetic_markets)
+    assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(
+        output["optimization_summary"]["target_pairs"]
+    )
     assert output["results"]["return_pct"] >= -100.0
     assert output["pairs"][0]["orderbook_mode"] in output["backtest_summary"]["orderbook_modes"]
 

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -31,6 +31,11 @@
     "telemetry_path": "logs/polymarket-maker-rebate-backtest-telemetry.jsonl",
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history",
+    "optimization": {
+      "enabled": true,
+      "target_return_pct": 25.0,
+      "max_iterations": 8
+    },
     "predictions_enabled": false,
     "predictions_skew_strength_bps": 15,
     "predictions_score_boost": 0.3

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -103,6 +103,13 @@ class BacktestParams:
 
 
 @dataclass(frozen=True)
+class OptimizationParams:
+    enabled: bool = True
+    target_return_pct: float = 25.0
+    max_iterations: int = 8
+
+
+@dataclass(frozen=True)
 class OrderBookSnapshot:
     t: int
     best_bid: float
@@ -167,6 +174,22 @@ def load_json_file(path: Path) -> dict[str, Any]:
 
 def load_config(config_path: str) -> dict[str, Any]:
     return load_json_file(Path(config_path))
+
+
+def _clone_config(config: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(config))
+
+
+def _write_config(config_path: str, config: dict[str, Any]) -> None:
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def _apply_config_updates_in_place(config: dict[str, Any], updates: dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
 
 
 def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
@@ -348,6 +371,18 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         predictions_score_boost=clamp(
             _safe_float(backtest.get("predictions_score_boost"), 0.3), 0.0, 1.0
         ),
+    )
+
+
+def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
+    backtest = config.get("backtest", {})
+    raw = backtest.get("optimization", {}) if isinstance(backtest, dict) else {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return OptimizationParams(
+        enabled=bool(raw.get("enabled", True)),
+        target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
     )
 
 
@@ -1600,6 +1635,376 @@ def _simulate_market_backtest(
     }
 
 
+def _market_target_descriptors(markets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "market_id": _safe_str(market.get("market_id"), "unknown"),
+            "question": _safe_str(market.get("question"), ""),
+        }
+        for market in markets
+    ]
+
+
+def _diff_section(original: dict[str, Any], updated: dict[str, Any]) -> dict[str, Any]:
+    diff: dict[str, Any] = {}
+    for key, value in updated.items():
+        if original.get(key) != value:
+            diff[key] = value
+    return diff
+
+
+def _rank_markets_for_optimization(markets: list[dict[str, Any]], result: dict[str, Any]) -> list[dict[str, Any]]:
+    pnl_by_market = {
+        _safe_str(row.get("market_id"), "unknown"): _safe_float(row.get("pnl_usd"), 0.0)
+        for row in result.get("markets", [])
+        if isinstance(row, dict)
+    }
+    return sorted(
+        markets,
+        key=lambda market: (
+            pnl_by_market.get(_safe_str(market.get("market_id"), "unknown"), float("-inf")),
+            _safe_float(market.get("rebate_bps"), 0.0),
+        ),
+        reverse=True,
+    )
+
+
+def _optimization_attempt_summary(
+    *,
+    name: str,
+    result: dict[str, Any],
+    strategy_updates: dict[str, Any],
+    backtest_updates: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": _safe_str(result.get("status"), "error"),
+        "return_pct": round(_safe_float(result.get("results", {}).get("return_pct"), 0.0), 4),
+        "total_pnl_usd": round(_safe_float(result.get("results", {}).get("total_pnl_usd"), 0.0), 4),
+        "target_market_count": len(targets),
+        "target_market_ids": [target["market_id"] for target in targets],
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+
+
+def _is_better_backtest_result(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
+    if candidate.get("status") != "ok":
+        return False
+    if current.get("status") != "ok":
+        return True
+    candidate_return = _safe_float(candidate.get("results", {}).get("return_pct"), float("-inf"))
+    current_return = _safe_float(current.get("results", {}).get("return_pct"), float("-inf"))
+    if candidate_return != current_return:
+        return candidate_return > current_return
+    candidate_pnl = _safe_float(candidate.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    current_pnl = _safe_float(current.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    return candidate_pnl > current_pnl
+
+
+def _maker_optimization_candidates(config: dict[str, Any], total_markets: int) -> list[dict[str, Any]]:
+    p = to_params(config)
+    bt = to_backtest_params(config)
+    base_markets = max(1, min(total_markets, p.markets_max))
+    focus_markets = max(1, min(total_markets, max(1, int(round(base_markets * 0.5)))))
+    broad_markets = max(1, min(total_markets, max(base_markets, int(round(total_markets * 0.75)))))
+    return [
+        {
+            "name": "focus-higher-participation",
+            "subset_size": focus_markets,
+            "strategy": {
+                "markets_max": focus_markets,
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.15, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.1, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.15, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "focus-tighter-spread",
+            "subset_size": focus_markets,
+            "strategy": {
+                "markets_max": focus_markets,
+                "min_spread_bps": round(max(5.0, p.min_spread_bps * 0.85), 4),
+                "max_spread_bps": round(max(p.min_spread_bps, p.max_spread_bps * 0.9), 4),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.1, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.1, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "high-conviction",
+            "subset_size": focus_markets,
+            "strategy": {
+                "markets_max": focus_markets,
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.75), 4),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.25, 4),
+                "max_notional_per_market_usd": round(p.max_notional_per_market_usd * 1.2, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.15, 4),
+                "max_position_notional_usd": round(p.max_position_notional_usd * 1.15, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.2, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "broader-scan",
+            "subset_size": broad_markets,
+            "strategy": {
+                "markets_max": broad_markets,
+                "min_spread_bps": round(max(5.0, p.min_spread_bps * 0.9), 4),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.05, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.05, 0.0, 1.0), 4)},
+        },
+    ]
+
+
+def _evaluate_backtest(
+    *,
+    config: dict[str, Any],
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+) -> dict[str, Any]:
+    strategy_params = to_params(config)
+    backtest_params = to_backtest_params(config)
+    market_summaries: list[dict[str, Any]] = []
+    equity_curve = [strategy_params.bankroll_usd]
+    total_considered = 0
+    total_quoted = 0
+    total_notional = 0.0
+    total_fill_events = 0
+    telemetry_records: list[dict[str, Any]] = []
+    orderbook_modes: set[str] = set()
+
+    selected_markets = markets[: strategy_params.markets_max]
+    capital_per_market = strategy_params.bankroll_usd / max(1, len(selected_markets))
+
+    for market in selected_markets:
+        summary = _simulate_market_backtest(
+            market=market,
+            strategy_params=strategy_params,
+            backtest_params=backtest_params,
+            allocated_capital=capital_per_market,
+        )
+        market_summaries.append(
+            {
+                "market_id": summary["market_id"],
+                "question": summary["question"],
+                "considered_points": summary["considered_points"],
+                "quoted_points": summary["quoted_points"],
+                "skipped_points": summary["skipped_points"],
+                "fill_events": summary["fill_events"],
+                "filled_notional_usd": summary["filled_notional_usd"],
+                "pnl_usd": summary["pnl_usd"],
+                "orderbook_mode": summary["orderbook_mode"],
+            }
+        )
+        total_considered += int(summary["considered_points"])
+        total_quoted += int(summary["quoted_points"])
+        total_notional += float(summary["filled_notional_usd"])
+        total_fill_events += int(summary["fill_events"])
+        telemetry_records.extend(summary["telemetry"])
+        orderbook_modes.add(_safe_str(summary.get("orderbook_mode"), "unknown"))
+
+        market_equity_curve = summary["equity_curve"]
+        if len(market_equity_curve) > len(equity_curve):
+            equity_curve.extend([equity_curve[-1]] * (len(market_equity_curve) - len(equity_curve)))
+        for idx, value in enumerate(market_equity_curve):
+            if idx < len(equity_curve):
+                equity_curve[idx] += value - capital_per_market
+
+    ending_equity = equity_curve[-1]
+    total_pnl = ending_equity - strategy_params.bankroll_usd
+    return_pct = (total_pnl / strategy_params.bankroll_usd) * 100.0
+    max_drawdown = _max_drawdown(equity_curve)
+    decision = "consider_live_guarded" if total_pnl > 0 else "paper_only_or_tune"
+    _write_telemetry_records(backtest_params.telemetry_path, telemetry_records)
+
+    return {
+        "status": "ok",
+        "skill": "polymarket-maker-rebate-bot",
+        "mode": "backtest",
+        "dry_run": True,
+        "predictions_intelligence": {
+            "enabled": backtest_params.predictions_enabled,
+            "markets_with_signals": sum(1 for m in selected_markets if m.get("prediction_signal")),
+            "skew_strength_bps": backtest_params.predictions_skew_strength_bps,
+            "score_boost": backtest_params.predictions_score_boost,
+            "note": (
+                "Seren Predictions intelligence active — costs SerenBucks per batch call."
+                if backtest_params.predictions_enabled
+                else "Disabled. Set predictions_enabled: true in config to activate (costs SerenBucks)."
+            ),
+        },
+        "backtest_summary": {
+            "days": days,
+            "source": source,
+            "start_utc": datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat(),
+            "end_utc": datetime.fromtimestamp(end_ts, tz=timezone.utc).isoformat(),
+            "markets_selected": len(market_summaries),
+            "considered_points": total_considered,
+            "quoted_points": total_quoted,
+            "fill_events": total_fill_events,
+            "orderbook_mode": ",".join(sorted(orderbook_modes)),
+            "quote_rate_pct": round(
+                (total_quoted / total_considered) * 100.0 if total_considered else 0.0,
+                4,
+            ),
+        },
+        "results": {
+            "starting_bankroll_usd": round(strategy_params.bankroll_usd, 4),
+            "ending_bankroll_usd": round(ending_equity, 4),
+            "total_pnl_usd": round(total_pnl, 4),
+            "return_pct": round(return_pct, 4),
+            "filled_notional_usd": round(total_notional, 4),
+            "events": total_fill_events,
+            "max_drawdown_usd": round(max_drawdown, 4),
+            "telemetry_path": backtest_params.telemetry_path or None,
+            "decision_hint": decision,
+            "disclaimer": "Backtests are estimates and do not guarantee future performance.",
+        },
+        "markets": sorted(market_summaries, key=lambda item: item["pnl_usd"], reverse=True),
+        **(
+            {
+                "predictions_upgrade_prompt": {
+                    "message": (
+                        "Improve your edge with Seren Predictions intelligence. "
+                        "Cross-platform consensus and divergence signals from Kalshi, Manifold, "
+                        "Metaculus, PredictIt, and Betfair can boost market selection and directional "
+                        "quote skew. Estimated cost: ~$0.30 per backtest run."
+                    ),
+                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
+                    "publisher": "seren-polymarket-intelligence",
+                    "estimated_cost_usd": 0.30,
+                    "endpoints_used": [
+                        "POST /api/oracle/divergence/batch ($0.15)",
+                        "POST /api/oracle/consensus/batch ($0.15)",
+                    ],
+                    "benefits": [
+                        "Boost mm_score for markets with cross-platform price divergence",
+                        "Add directional skew to quotes based on consensus vs Polymarket price",
+                        "Filter for markets where other platforms disagree — higher edge potential",
+                    ],
+                },
+            }
+            if not backtest_params.predictions_enabled
+            else {}
+        ),
+        "next_steps": [
+            "Review negative-PnL markets and edge assumptions.",
+            "Tune spread, participation, and risk caps before live mode.",
+            "Run quote mode only after backtest results are acceptable.",
+            *(
+                []
+                if backtest_params.predictions_enabled
+                else [
+                    "Enable Seren Predictions intelligence for better edge detection "
+                    "(set predictions_enabled: true in config).",
+                ]
+            ),
+        ],
+    }
+
+
+def _optimize_backtest(
+    *,
+    config: dict[str, Any],
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+) -> dict[str, Any]:
+    baseline = _evaluate_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+    if baseline.get("status") != "ok":
+        return baseline
+
+    optimization = to_optimization_params(config)
+    ranked_markets = _rank_markets_for_optimization(markets, baseline)
+    best_result = baseline
+    best_config = _clone_config(config)
+    best_targets = _market_target_descriptors(ranked_markets[: to_params(config).markets_max])
+    attempts = [
+        _optimization_attempt_summary(
+            name="baseline",
+            result=baseline,
+            strategy_updates={},
+            backtest_updates={},
+            targets=best_targets,
+        )
+    ]
+
+    if optimization.enabled:
+        max_attempts = max(1, optimization.max_iterations)
+        for candidate in _maker_optimization_candidates(config, len(ranked_markets))[: max(0, max_attempts - 1)]:
+            if _safe_float(best_result.get("results", {}).get("return_pct"), 0.0) >= optimization.target_return_pct:
+                break
+            subset_size = max(1, min(len(ranked_markets), _safe_int(candidate.get("subset_size"), len(ranked_markets))))
+            candidate_markets = ranked_markets[:subset_size]
+            candidate_config = _clone_config(config)
+            candidate_config.setdefault("strategy", {}).update(candidate.get("strategy", {}))
+            candidate_config.setdefault("backtest", {}).update(candidate.get("backtest", {}))
+            candidate_result = _evaluate_backtest(
+                config=candidate_config,
+                markets=candidate_markets,
+                source=f"{source}|optimized:{candidate['name']}",
+                days=days,
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+            candidate_targets = _market_target_descriptors(candidate_markets[: to_params(candidate_config).markets_max])
+            attempts.append(
+                _optimization_attempt_summary(
+                    name=_safe_str(candidate.get("name"), "candidate"),
+                    result=candidate_result,
+                    strategy_updates=_diff_section(config.get("strategy", {}), candidate_config.get("strategy", {})),
+                    backtest_updates=_diff_section(config.get("backtest", {}), candidate_config.get("backtest", {})),
+                    targets=candidate_targets,
+                )
+            )
+            if _is_better_backtest_result(candidate_result, best_result):
+                best_result = candidate_result
+                best_config = candidate_config
+                best_targets = candidate_targets
+
+    strategy_updates = _diff_section(config.get("strategy", {}), best_config.get("strategy", {}))
+    backtest_updates = _diff_section(config.get("backtest", {}), best_config.get("backtest", {}))
+    best_return_pct = _safe_float(best_result.get("results", {}).get("return_pct"), 0.0)
+    optimization_state = {
+        "enabled": optimization.enabled,
+        "target_return_pct": round(optimization.target_return_pct, 4),
+        "target_met": best_return_pct >= optimization.target_return_pct,
+        "selected_attempt": next(
+            (attempt["name"] for attempt in attempts if attempt["return_pct"] == round(best_return_pct, 4)),
+            attempts[0]["name"],
+        ),
+        "best_return_pct": round(best_return_pct, 4),
+        "attempt_count": len(attempts),
+        "target_markets": best_targets,
+        "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    best_result["optimization_summary"] = {
+        **optimization_state,
+        "attempts": attempts,
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+    best_result["config_updates"] = {
+        "strategy": strategy_updates,
+        "backtest": backtest_updates,
+        "state": {"backtest_optimizer": optimization_state},
+    }
+    return best_result
+
+
 def run_backtest(
     config: dict[str, Any],
     backtest_file: str | None,
@@ -1657,148 +2062,14 @@ def run_backtest(
             "dry_run": True,
         }
 
-    market_summaries: list[dict[str, Any]] = []
-    equity_curve = [strategy_params.bankroll_usd]
-    total_considered = 0
-    total_quoted = 0
-    total_notional = 0.0
-    total_fill_events = 0
-    telemetry_records: list[dict[str, Any]] = []
-    orderbook_modes: set[str] = set()
-
-    selected_markets = markets[: strategy_params.markets_max]
-    num_markets = len(selected_markets)
-    capital_per_market = strategy_params.bankroll_usd / max(1, num_markets)
-
-    for market in selected_markets:
-        summary = _simulate_market_backtest(
-            market=market,
-            strategy_params=strategy_params,
-            backtest_params=backtest_params,
-            allocated_capital=capital_per_market,
-        )
-        market_summaries.append(
-            {
-                "market_id": summary["market_id"],
-                "question": summary["question"],
-                "considered_points": summary["considered_points"],
-                "quoted_points": summary["quoted_points"],
-                "skipped_points": summary["skipped_points"],
-                "fill_events": summary["fill_events"],
-                "filled_notional_usd": summary["filled_notional_usd"],
-                "pnl_usd": summary["pnl_usd"],
-                "orderbook_mode": summary["orderbook_mode"],
-            }
-        )
-        total_considered += int(summary["considered_points"])
-        total_quoted += int(summary["quoted_points"])
-        total_notional += float(summary["filled_notional_usd"])
-        total_fill_events += int(summary["fill_events"])
-        telemetry_records.extend(summary["telemetry"])
-        orderbook_modes.add(_safe_str(summary.get("orderbook_mode"), "unknown"))
-
-        market_equity_curve = summary["equity_curve"]
-        if len(market_equity_curve) > len(equity_curve):
-            equity_curve.extend([equity_curve[-1]] * (len(market_equity_curve) - len(equity_curve)))
-        for idx, value in enumerate(market_equity_curve):
-            if idx < len(equity_curve):
-                equity_curve[idx] += value - capital_per_market
-
-    ending_equity = equity_curve[-1]
-    total_pnl = ending_equity - strategy_params.bankroll_usd
-    return_pct = (total_pnl / strategy_params.bankroll_usd) * 100.0
-    max_drawdown = _max_drawdown(equity_curve)
-    decision = "consider_live_guarded" if total_pnl > 0 else "paper_only_or_tune"
-    _write_telemetry_records(backtest_params.telemetry_path, telemetry_records)
-
-    return {
-        "status": "ok",
-        "skill": "polymarket-maker-rebate-bot",
-        "mode": "backtest",
-        "dry_run": True,
-        "predictions_intelligence": {
-            "enabled": backtest_params.predictions_enabled,
-            "markets_with_signals": sum(
-                1 for m in selected_markets if m.get("prediction_signal")
-            ),
-            "skew_strength_bps": backtest_params.predictions_skew_strength_bps,
-            "score_boost": backtest_params.predictions_score_boost,
-            "note": (
-                "Seren Predictions intelligence active — costs SerenBucks per batch call."
-                if backtest_params.predictions_enabled
-                else "Disabled. Set predictions_enabled: true in config to activate (costs SerenBucks)."
-            ),
-        },
-        "backtest_summary": {
-            "days": days,
-            "source": source,
-            "start_utc": datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat(),
-            "end_utc": datetime.fromtimestamp(end_ts, tz=timezone.utc).isoformat(),
-            "markets_selected": len(market_summaries),
-            "considered_points": total_considered,
-            "quoted_points": total_quoted,
-            "fill_events": total_fill_events,
-            "orderbook_mode": ",".join(sorted(orderbook_modes)),
-            "quote_rate_pct": round(
-                (total_quoted / total_considered) * 100.0 if total_considered else 0.0,
-                4,
-            ),
-        },
-        "results": {
-            "starting_bankroll_usd": round(strategy_params.bankroll_usd, 4),
-            "ending_bankroll_usd": round(ending_equity, 4),
-            "total_pnl_usd": round(total_pnl, 4),
-            "return_pct": round(return_pct, 4),
-            "filled_notional_usd": round(total_notional, 4),
-            "events": total_fill_events,
-            "max_drawdown_usd": round(max_drawdown, 4),
-            "telemetry_path": backtest_params.telemetry_path or None,
-            "decision_hint": decision,
-            "disclaimer": (
-                "Backtests are estimates and do not guarantee future performance."
-            ),
-        },
-        "markets": sorted(market_summaries, key=lambda item: item["pnl_usd"], reverse=True),
-        **(
-            {
-                "predictions_upgrade_prompt": {
-                    "message": (
-                        "Improve your edge with Seren Predictions intelligence. "
-                        "Cross-platform consensus and divergence signals from Kalshi, Manifold, "
-                        "Metaculus, PredictIt, and Betfair can boost market selection and directional "
-                        "quote skew. Estimated cost: ~$0.30 per backtest run."
-                    ),
-                    "action": 'Set "predictions_enabled": true in your config.json backtest section.',
-                    "publisher": "seren-polymarket-intelligence",
-                    "estimated_cost_usd": 0.30,
-                    "endpoints_used": [
-                        "POST /api/oracle/divergence/batch ($0.15)",
-                        "POST /api/oracle/consensus/batch ($0.15)",
-                    ],
-                    "benefits": [
-                        "Boost mm_score for markets with cross-platform price divergence",
-                        "Add directional skew to quotes based on consensus vs Polymarket price",
-                        "Filter for markets where other platforms disagree — higher edge potential",
-                    ],
-                },
-            }
-            if not backtest_params.predictions_enabled
-            else {}
-        ),
-        "next_steps": [
-            "Review negative-PnL markets and edge assumptions.",
-            "Tune spread, participation, and risk caps before live mode.",
-            "Run quote mode only after backtest results are acceptable.",
-            *(
-                []
-                if backtest_params.predictions_enabled
-                else [
-                    "Enable Seren Predictions intelligence for better edge detection "
-                    "(set predictions_enabled: true in config).",
-                ]
-            ),
-        ],
-    }
+    return _optimize_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
 
 
 def quote_market(
@@ -2049,6 +2320,12 @@ def main() -> int:
             backtest_file=args.backtest_file,
             backtest_days_override=args.backtest_days,
         )
+        if result.get("status") == "ok" and isinstance(result.get("config_updates"), dict):
+            _apply_config_updates_in_place(config, result["config_updates"])
+            try:
+                _write_config(args.config, config)
+            except Exception as exc:  # pragma: no cover - defensive runtime path
+                result["config_writeback_warning"] = str(exc)
     else:
         result = run_quote(config=config, markets_file=args.markets_file, yes_live=args.yes_live)
         if isinstance(result.get("state"), dict):

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import json
 import math
@@ -262,6 +263,46 @@ def test_spread_decay_reduces_filled_notional_when_spread_widens(tmp_path: Path)
     assert narrow_output["status"] == "ok"
     assert wide_output["status"] == "ok"
     assert wide_output["results"]["filled_notional_usd"] < narrow_output["results"]["filled_notional_usd"]
+
+
+def test_main_persists_backtest_optimizer_updates_to_config(monkeypatch, tmp_path: Path) -> None:
+    agent = _load_agent_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"strategy": {"markets_max": 12}, "backtest": {}}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        agent,
+        "parse_args",
+        lambda: argparse.Namespace(
+            config=str(config_path),
+            run_type="backtest",
+            markets_file=None,
+            backtest_file=None,
+            backtest_days=None,
+            yes_live=False,
+        ),
+    )
+    monkeypatch.setattr(
+        agent,
+        "run_backtest",
+        lambda config, backtest_file, backtest_days_override: {
+            "status": "ok",
+            "config_updates": {
+                "strategy": {"markets_max": 4},
+                "state": {
+                    "backtest_optimizer": {
+                        "target_met": True,
+                        "target_markets": [{"market_id": "MKT-1", "question": "Synthetic market"}],
+                    }
+                },
+            },
+        },
+    )
+
+    assert agent.main() == 0
+    persisted = json.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted["strategy"]["markets_max"] == 4
+    assert persisted["state"]["backtest_optimizer"]["target_met"] is True
 
 
 def test_backtest_requires_orderbook_history_when_configured(tmp_path: Path) -> None:

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -38,6 +38,11 @@
     "history_interval": "max",
     "history_fidelity_minutes": 60,
     "history_fetch_workers": 12,
+    "optimization": {
+      "enabled": true,
+      "target_return_pct": 25.0,
+      "max_iterations": 8
+    },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"
   },

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -115,6 +115,13 @@ class BacktestParams:
     predictions_score_boost: float = 0.3  # pair score boost for prediction-confirmed pairs
 
 
+@dataclass(frozen=True)
+class OptimizationParams:
+    enabled: bool = True
+    target_return_pct: float = 25.0
+    max_iterations: int = 8
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run paired-market basis maker strategy.")
     parser.add_argument("--config", default="config.json", help="Config file path.")
@@ -196,6 +203,22 @@ def load_config(config_path: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _clone_config(config: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(config))
+
+
+def _write_config(config_path: str, config: dict[str, Any]) -> None:
+    Path(config_path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def _apply_config_updates_in_place(config: dict[str, Any], updates: dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
+
+
 def _persist_runtime_state(config_path: str, config: dict[str, Any], state: dict[str, Any]) -> None:
     if not isinstance(state, dict) or not state:
         return
@@ -270,6 +293,18 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
         history_fetch_workers=max(1, _safe_int(raw.get("history_fetch_workers"), 12)),
         predictions_enabled=bool(raw.get("predictions_enabled", False)),
         predictions_score_boost=_safe_float(raw.get("predictions_score_boost"), 0.3),
+    )
+
+
+def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
+    backtest_raw = config.get("backtest", {})
+    raw = backtest_raw.get("optimization", {}) if isinstance(backtest_raw, dict) else {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return OptimizationParams(
+        enabled=_safe_bool(raw.get("enabled"), True),
+        target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
     )
 
 
@@ -903,6 +938,143 @@ def _simulate_pair(market: dict[str, Any], p: StrategyParams, bt: BacktestParams
     }
 
 
+def _pair_target_descriptors(markets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "market_id": _safe_str(market.get("market_id"), "unknown"),
+            "pair_market_id": _safe_str(market.get("pair_market_id"), "unknown"),
+            "question": _safe_str(market.get("question"), ""),
+            "pair_question": _safe_str(market.get("pair_question"), ""),
+        }
+        for market in markets
+    ]
+
+
+def _diff_section(original: dict[str, Any], updated: dict[str, Any]) -> dict[str, Any]:
+    diff: dict[str, Any] = {}
+    for key, value in updated.items():
+        if original.get(key) != value:
+            diff[key] = value
+    return diff
+
+
+def _rank_pair_markets(markets: list[dict[str, Any]], result: dict[str, Any]) -> list[dict[str, Any]]:
+    pnl_by_pair: dict[tuple[str, str], float] = {}
+    for row in result.get("pairs", []):
+        if not isinstance(row, dict):
+            continue
+        key = (
+            _safe_str(row.get("market_id"), "unknown"),
+            _safe_str(row.get("pair_market_id"), "unknown"),
+        )
+        pnl_by_pair[key] = _safe_float(row.get("pnl_usd"), 0.0)
+    return sorted(
+        markets,
+        key=lambda market: (
+            pnl_by_pair.get(
+                (
+                    _safe_str(market.get("market_id"), "unknown"),
+                    _safe_str(market.get("pair_market_id"), "unknown"),
+                ),
+                float("-inf"),
+            ),
+            _safe_float(market.get("rebate_bps"), 0.0),
+        ),
+        reverse=True,
+    )
+
+
+def _optimization_attempt_summary(
+    *,
+    name: str,
+    result: dict[str, Any],
+    strategy_updates: dict[str, Any],
+    backtest_updates: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": _safe_str(result.get("status"), "error"),
+        "return_pct": round(_safe_float(result.get("results", {}).get("return_pct"), 0.0), 4),
+        "total_pnl_usd": round(_safe_float(result.get("results", {}).get("total_pnl_usd"), 0.0), 4),
+        "target_market_count": len(targets),
+        "target_market_ids": [target["market_id"] for target in targets],
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+
+
+def _is_better_backtest_result(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
+    if candidate.get("status") != "ok":
+        return False
+    if current.get("status") != "ok":
+        return True
+    candidate_return = _safe_float(candidate.get("results", {}).get("return_pct"), float("-inf"))
+    current_return = _safe_float(current.get("results", {}).get("return_pct"), float("-inf"))
+    if candidate_return != current_return:
+        return candidate_return > current_return
+    candidate_pnl = _safe_float(candidate.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    current_pnl = _safe_float(current.get("results", {}).get("total_pnl_usd"), float("-inf"))
+    return candidate_pnl > current_pnl
+
+
+def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) -> list[dict[str, Any]]:
+    p = to_strategy_params(config)
+    base_pairs = max(2, min(total_markets, p.pairs_max))
+    focus_pairs = max(2, min(total_markets, max(2, int(round(base_pairs * 0.6)))))
+    broad_pairs = max(2, min(total_markets, max(base_pairs, int(round(total_markets * 0.75)))))
+    return [
+        {
+            "name": "focus-lower-entry",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.1, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "focus-higher-capacity",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.75), 4),
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.75), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.15, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.15, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.15, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.15, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-tighter-exit",
+            "subset_size": base_pairs,
+            "strategy": {
+                "pairs_max": base_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.8), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.05, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-higher-capacity",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.1, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.2, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
+    ]
+
+
 def _check_serenbucks_balance(api_key: str) -> float:
     """Check SerenBucks balance. Returns balance in USD or 0.0 on error."""
     try:
@@ -999,56 +1171,18 @@ def _fetch_predictions_pair_signals(
     return result
 
 
-def run_backtest(
+def _evaluate_backtest(
+    *,
     config: dict[str, Any],
-    backtest_days: int | None,
-    backtest_file: str | None = None,
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
-    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
-    configured_backtest_file = ""
-    if isinstance(config.get("backtest"), dict):
-        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
-    selected_backtest_file = backtest_file or configured_backtest_file or None
-
-    end_ts = int(time.time())
-    start_ts = end_ts - (days * 24 * 60 * 60)
-
-    try:
-        if selected_backtest_file:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-                backtest_file=selected_backtest_file,
-            )
-        else:
-            markets, source = _load_backtest_markets(
-                p=p,
-                bt=bt,
-                start_ts=start_ts,
-                end_ts=end_ts,
-            )
-    except Exception as exc:
-        return {
-            "status": "error",
-            "error_code": "backtest_data_load_failed",
-            "message": str(exc),
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
-    if not markets:
-        return {
-            "status": "error",
-            "error_code": "no_backtest_markets",
-            "message": "No paired historical markets were available for backtest.",
-            "disclaimer": DISCLAIMER,
-            "dry_run": True,
-        }
-
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0
@@ -1058,8 +1192,7 @@ def run_backtest(
     total_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     orderbook_modes: dict[str, int] = defaultdict(int)
-    num_pairs = len(markets)
-    capital_per_pair = p.bankroll_usd / max(1, num_pairs)
+    capital_per_pair = p.bankroll_usd / max(1, len(markets))
 
     for market in markets:
         result = _simulate_pair(market, p, bt, allocated_capital=capital_per_pair)
@@ -1095,7 +1228,6 @@ def run_backtest(
     total_pnl = equity - p.bankroll_usd
     total_return_pct = (total_pnl / p.bankroll_usd) * 100.0
     max_drawdown_usd, max_drawdown_pct = _max_drawdown_stats(equity_curve)
-    # UI-facing percentages should not report losses below -100% or drawdowns above 100%.
     display_total_return_pct = max(total_return_pct, -100.0)
     display_max_drawdown_pct = min(max_drawdown_pct, 100.0)
     events = len(event_pnls)
@@ -1127,15 +1259,13 @@ def run_backtest(
         }
 
     write_telemetry_records(bt.telemetry_path, telemetry)
-
-    # Fetch Seren Predictions pair intelligence (costs SerenBucks)
     predictions = _fetch_predictions_pair_signals(backtest_params=bt)
     predictions_pairs_count = len(predictions.get("suggested_pairs", []))
     predictions_correlations_count = len(predictions.get("correlations", []))
 
     return {
         "status": "ok",
-        "skill": "paired-market-basis-maker",
+        "skill": skill_name,
         "mode": "backtest",
         "dry_run": True,
         "predictions_intelligence": {
@@ -1217,6 +1347,168 @@ def run_backtest(
             else {}
         ),
     }
+
+
+def _optimize_backtest(
+    *,
+    config: dict[str, Any],
+    markets: list[dict[str, Any]],
+    source: str,
+    days: int,
+    start_ts: int,
+    end_ts: int,
+    skill_name: str,
+) -> dict[str, Any]:
+    baseline = _evaluate_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name=skill_name,
+    )
+    if baseline.get("status") != "ok":
+        return baseline
+
+    optimization = to_optimization_params(config)
+    ranked_markets = _rank_pair_markets(markets, baseline)
+    best_result = baseline
+    best_config = _clone_config(config)
+    best_targets = _pair_target_descriptors(ranked_markets)
+    attempts = [
+        _optimization_attempt_summary(
+            name="baseline",
+            result=baseline,
+            strategy_updates={},
+            backtest_updates={},
+            targets=best_targets,
+        )
+    ]
+
+    if optimization.enabled:
+        max_attempts = max(1, optimization.max_iterations)
+        for candidate in _pair_optimization_candidates(config, len(ranked_markets))[: max(0, max_attempts - 1)]:
+            if _safe_float(best_result.get("results", {}).get("return_pct"), 0.0) >= optimization.target_return_pct:
+                break
+            subset_size = max(2, min(len(ranked_markets), _safe_int(candidate.get("subset_size"), len(ranked_markets))))
+            candidate_markets = ranked_markets[:subset_size]
+            candidate_config = _clone_config(config)
+            candidate_config.setdefault("strategy", {}).update(candidate.get("strategy", {}))
+            candidate_config.setdefault("backtest", {}).update(candidate.get("backtest", {}))
+            candidate_result = _evaluate_backtest(
+                config=candidate_config,
+                markets=candidate_markets,
+                source=f"{source}|optimized:{candidate['name']}",
+                days=days,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                skill_name=skill_name,
+            )
+            candidate_targets = _pair_target_descriptors(candidate_markets)
+            attempts.append(
+                _optimization_attempt_summary(
+                    name=_safe_str(candidate.get("name"), "candidate"),
+                    result=candidate_result,
+                    strategy_updates=_diff_section(config.get("strategy", {}), candidate_config.get("strategy", {})),
+                    backtest_updates=_diff_section(config.get("backtest", {}), candidate_config.get("backtest", {})),
+                    targets=candidate_targets,
+                )
+            )
+            if _is_better_backtest_result(candidate_result, best_result):
+                best_result = candidate_result
+                best_config = candidate_config
+                best_targets = candidate_targets
+
+    strategy_updates = _diff_section(config.get("strategy", {}), best_config.get("strategy", {}))
+    backtest_updates = _diff_section(config.get("backtest", {}), best_config.get("backtest", {}))
+    best_return_pct = _safe_float(best_result.get("results", {}).get("return_pct"), 0.0)
+    optimization_state = {
+        "enabled": optimization.enabled,
+        "target_return_pct": round(optimization.target_return_pct, 4),
+        "target_met": best_return_pct >= optimization.target_return_pct,
+        "selected_attempt": next(
+            (attempt["name"] for attempt in attempts if attempt["return_pct"] == round(best_return_pct, 4)),
+            attempts[0]["name"],
+        ),
+        "best_return_pct": round(best_return_pct, 4),
+        "attempt_count": len(attempts),
+        "target_pairs": best_targets,
+        "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    best_result["optimization_summary"] = {
+        **optimization_state,
+        "attempts": attempts,
+        "strategy_updates": strategy_updates,
+        "backtest_updates": backtest_updates,
+    }
+    best_result["config_updates"] = {
+        "strategy": strategy_updates,
+        "backtest": backtest_updates,
+        "state": {"backtest_optimizer": optimization_state},
+    }
+    return best_result
+
+
+def run_backtest(
+    config: dict[str, Any],
+    backtest_days: int | None,
+    backtest_file: str | None = None,
+) -> dict[str, Any]:
+    p = to_strategy_params(config)
+    bt = to_backtest_params(config)
+    days = int(clamp(backtest_days if backtest_days is not None else bt.days, bt.days_min, bt.days_max))
+    configured_backtest_file = ""
+    if isinstance(config.get("backtest"), dict):
+        configured_backtest_file = _safe_str(config["backtest"].get("backtest_file"), "")
+    selected_backtest_file = backtest_file or configured_backtest_file or None
+
+    end_ts = int(time.time())
+    start_ts = end_ts - (days * 24 * 60 * 60)
+
+    try:
+        if selected_backtest_file:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                backtest_file=selected_backtest_file,
+            )
+        else:
+            markets, source = _load_backtest_markets(
+                p=p,
+                bt=bt,
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "error_code": "backtest_data_load_failed",
+            "message": str(exc),
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    if not markets:
+        return {
+            "status": "error",
+            "error_code": "no_backtest_markets",
+            "message": "No paired historical markets were available for backtest.",
+            "disclaimer": DISCLAIMER,
+            "dry_run": True,
+        }
+
+    return _optimize_backtest(
+        config=config,
+        markets=markets,
+        source=source,
+        days=days,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        skill_name="paired-market-basis-maker",
+    )
 
 
 def _extract_live_mid_price(payload: dict[str, Any]) -> float:
@@ -1695,6 +1987,13 @@ def main() -> int:
     if backtest.get("status") != "ok":
         print(json.dumps(backtest, sort_keys=True))
         return 1
+
+    if isinstance(backtest.get("config_updates"), dict):
+        _apply_config_updates_in_place(config, backtest["config_updates"])
+        try:
+            _write_config(args.config, config)
+        except Exception as exc:  # pragma: no cover - defensive runtime path
+            backtest["config_writeback_warning"] = str(exc)
 
     if args.run_type == "backtest":
         print(json.dumps(backtest, sort_keys=True))

--- a/polymarket/paired-market-basis-maker/tests/test_smoke.py
+++ b/polymarket/paired-market-basis-maker/tests/test_smoke.py
@@ -102,7 +102,9 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
     assert output["results"]["starting_bankroll_usd"] == 1000
     assert output["results"]["fill_events"] > 0
     assert output["backtest_summary"]["quoted_points"] > 0
-    assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(synthetic_markets)
+    assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(
+        output["optimization_summary"]["target_pairs"]
+    )
     assert output["results"]["return_pct"] >= -100.0
     assert output["pairs"][0]["orderbook_mode"] in output["backtest_summary"]["orderbook_modes"]
 


### PR DESCRIPTION
## Summary
- add bounded backtest optimizers to the Polymarket invocation backtests so they iterate config/target subsets until they hit a 25% return target or exhaust the attempt budget
- persist tuned `strategy`/`backtest` updates plus selected target market IDs back into config/state, and apply those updates before paired trade mode continues
- document the optimizer in the example configs and cover the optimizer/writeback critical path in smoke tests

## Testing
- `pytest --import-mode=importlib polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py polymarket/liquidity-paired-basis-maker/tests/test_smoke.py polymarket/paired-market-basis-maker/tests/test_smoke.py polymarket/maker-rebate-bot/tests/test_smoke.py`

Closes #149