### PR TITLE
feat(polymarket): default backtests to 00 bankroll

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -16,6 +16,7 @@
     "max_live_drawdown_pct": 15
   },
   "backtest": {
+    "bankroll_usd": 100,
     "days": 270,
     "days_range": {
       "min": 90,

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -11,7 +11,7 @@ import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import pstdev
@@ -85,6 +85,7 @@ class StrategyParams:
 
 @dataclass(frozen=True)
 class BacktestParams:
+    bankroll_usd: float = 100.0
     days: int = 270
     days_min: int = 90
     days_max: int = 540
@@ -261,6 +262,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
     days_max = max(days_min, _safe_int(range_raw.get("max"), 540))
     days = int(clamp(_safe_int(raw.get("days"), 270), days_min, days_max))
     return BacktestParams(
+        bankroll_usd=max(1.0, _safe_float(raw.get("bankroll_usd"), 100.0)),
         days=days,
         days_min=days_min,
         days_max=days_max,
@@ -310,7 +312,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
 
 def _to_pair_replay_params(p: StrategyParams, bt: BacktestParams) -> PairReplayParams:
     return PairReplayParams(
-        bankroll_usd=p.bankroll_usd,
+        bankroll_usd=bt.bankroll_usd,
         min_seconds_to_resolution=p.min_seconds_to_resolution,
         min_edge_bps=p.min_edge_bps,
         maker_rebate_bps=p.maker_rebate_bps,
@@ -1183,6 +1185,7 @@ def _evaluate_backtest(
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
+    p = replace(p, bankroll_usd=bt.bankroll_usd)
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0

--- a/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
@@ -72,10 +72,12 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
 def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkeypatch) -> None:
     module = _load_agent_module()
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    payload["backtest"]["min_events"] = 1
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
+    assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
 
@@ -100,7 +102,7 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     output = module.run_backtest(payload, None)
     assert output["status"] == "ok"
-    assert output["results"]["starting_bankroll_usd"] == 1000
+    assert output["results"]["starting_bankroll_usd"] == 100
     assert output["results"]["fill_events"] > 0
     assert output["backtest_summary"]["quoted_points"] > 0
     assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(synthetic_markets)
@@ -163,7 +165,13 @@ def test_backtest_optimizer_selects_targeted_pair_subset_and_tuned_config(monkey
     now_ts = int(time.time())
     config = {
         "strategy": {"bankroll_usd": 1000, "pairs_max": 3, "basis_entry_bps": 35, "base_pair_notional_usd": 600},
-        "backtest": {"days": 90, "min_events": 1, "telemetry_path": "", "optimization": {"target_return_pct": 25.0}},
+        "backtest": {
+            "bankroll_usd": 100,
+            "days": 90,
+            "min_events": 1,
+            "telemetry_path": "",
+            "optimization": {"target_return_pct": 25.0},
+        },
     }
     markets = [
         {"market_id": "M0", "pair_market_id": "P0", "question": "A", "pair_question": "B", "history": [], "pair_history": [], "rebate_bps": 2.3},

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -16,6 +16,7 @@
     "max_live_drawdown_pct": 15
   },
   "backtest": {
+    "bankroll_usd": 100,
     "days": 90,
     "days_range": {
       "min": 90,

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -11,7 +11,7 @@ import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import pstdev
@@ -92,6 +92,7 @@ class StrategyParams:
 
 @dataclass(frozen=True)
 class BacktestParams:
+    bankroll_usd: float = 100.0
     days: int = 90
     days_min: int = 90
     days_max: int = 365
@@ -269,6 +270,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
     days_max = max(days_min, _safe_int(range_raw.get("max"), 365))
     days = int(clamp(_safe_int(raw.get("days"), 90), days_min, days_max))
     return BacktestParams(
+        bankroll_usd=max(1.0, _safe_float(raw.get("bankroll_usd"), 100.0)),
         days=days,
         days_min=days_min,
         days_max=days_max,
@@ -318,7 +320,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
 
 def _to_pair_replay_params(p: StrategyParams, bt: BacktestParams) -> PairReplayParams:
     return PairReplayParams(
-        bankroll_usd=p.bankroll_usd,
+        bankroll_usd=bt.bankroll_usd,
         min_seconds_to_resolution=p.min_seconds_to_resolution,
         min_edge_bps=p.min_edge_bps,
         maker_rebate_bps=p.maker_rebate_bps,
@@ -1244,6 +1246,7 @@ def _evaluate_backtest(
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
+    p = replace(p, bankroll_usd=bt.bankroll_usd)
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0

--- a/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
@@ -71,10 +71,12 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
 def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkeypatch) -> None:
     module = _load_agent_module()
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    payload["backtest"]["min_events"] = 1
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
+    assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
 
@@ -99,7 +101,7 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     output = module.run_backtest(payload, None)
     assert output["status"] == "ok"
-    assert output["results"]["starting_bankroll_usd"] == 1000
+    assert output["results"]["starting_bankroll_usd"] == 100
     assert output["results"]["fill_events"] > 0
     assert output["backtest_summary"]["quoted_points"] > 0
     assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -15,6 +15,7 @@
     "max_live_drawdown_pct": 15
   },
   "backtest": {
+    "bankroll_usd": 100,
     "days": 90,
     "fidelity_minutes": 60,
     "participation_rate": 0.6,

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -10,7 +10,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import pstdev
@@ -78,6 +78,7 @@ class StrategyParams:
 
 @dataclass(frozen=True)
 class BacktestParams:
+    bankroll_usd: float = 100.0
     days: int = 90
     fidelity_minutes: int = 60
     participation_rate: float = 0.6
@@ -319,6 +320,7 @@ def to_params(config: dict[str, Any]) -> StrategyParams:
 def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
     backtest = config.get("backtest", {})
     return BacktestParams(
+        bankroll_usd=max(1.0, _safe_float(backtest.get("bankroll_usd"), 100.0)),
         days=max(1, _safe_int(backtest.get("days"), 90)),
         fidelity_minutes=max(1, _safe_int(backtest.get("fidelity_minutes"), 60)),
         participation_rate=clamp(
@@ -1768,6 +1770,7 @@ def _evaluate_backtest(
 ) -> dict[str, Any]:
     strategy_params = to_params(config)
     backtest_params = to_backtest_params(config)
+    strategy_params = replace(strategy_params, bankroll_usd=backtest_params.bankroll_usd)
     market_summaries: list[dict[str, Any]] = []
     equity_curve = [strategy_params.bankroll_usd]
     total_considered = 0

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -56,6 +56,7 @@ def _base_backtest_payload(now_ts: int, telemetry_path: Path) -> dict:
     return {
         "execution": {"dry_run": True, "live_mode": False},
         "backtest": {
+            "bankroll_usd": 100,
             "days": 90,
             "fidelity_minutes": 60,
             "participation_rate": 0.25,
@@ -210,6 +211,7 @@ def test_backtest_run_type_returns_stateful_result_and_telemetry(tmp_path: Path)
     assert output["backtest_summary"]["source"] == "config"
     assert output["backtest_summary"]["markets_selected"] == 1
     assert output["backtest_summary"]["orderbook_mode"] == "historical"
+    assert output["results"]["starting_bankroll_usd"] == 100
     assert output["results"]["events"] > 0
     assert output["results"]["telemetry_path"] == str(telemetry_path)
     telemetry_lines = telemetry_path.read_text(encoding="utf-8").strip().splitlines()
@@ -319,8 +321,10 @@ def test_backtest_requires_orderbook_history_when_configured(tmp_path: Path) -> 
 
 
 def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
+    agent = _load_agent_module()
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
     backtest = payload.get("backtest", {})
+    assert agent.to_backtest_params({}).bankroll_usd == backtest.get("bankroll_usd") == 100
     assert backtest.get("gamma_markets_url", "").startswith(
         "https://api.serendb.com/publishers/polymarket-data/"
     )

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -16,6 +16,7 @@
     "max_live_drawdown_pct": 15
   },
   "backtest": {
+    "bankroll_usd": 100,
     "days": 270,
     "days_range": {
       "min": 90,

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -11,7 +11,7 @@ import sys
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import pstdev
@@ -85,6 +85,7 @@ class StrategyParams:
 
 @dataclass(frozen=True)
 class BacktestParams:
+    bankroll_usd: float = 100.0
     days: int = 270
     days_min: int = 90
     days_max: int = 540
@@ -261,6 +262,7 @@ def to_backtest_params(config: dict[str, Any]) -> BacktestParams:
     days_max = max(days_min, _safe_int(range_raw.get("max"), 540))
     days = int(clamp(_safe_int(raw.get("days"), 270), days_min, days_max))
     return BacktestParams(
+        bankroll_usd=max(1.0, _safe_float(raw.get("bankroll_usd"), 100.0)),
         days=days,
         days_min=days_min,
         days_max=days_max,
@@ -310,7 +312,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
 
 def _to_pair_replay_params(p: StrategyParams, bt: BacktestParams) -> PairReplayParams:
     return PairReplayParams(
-        bankroll_usd=p.bankroll_usd,
+        bankroll_usd=bt.bankroll_usd,
         min_seconds_to_resolution=p.min_seconds_to_resolution,
         min_edge_bps=p.min_edge_bps,
         maker_rebate_bps=p.maker_rebate_bps,
@@ -1183,6 +1185,7 @@ def _evaluate_backtest(
 ) -> dict[str, Any]:
     p = to_strategy_params(config)
     bt = to_backtest_params(config)
+    p = replace(p, bankroll_usd=bt.bankroll_usd)
     summaries: list[dict[str, Any]] = []
     event_pnls: list[float] = []
     considered = 0

--- a/polymarket/paired-market-basis-maker/tests/test_smoke.py
+++ b/polymarket/paired-market-basis-maker/tests/test_smoke.py
@@ -71,10 +71,12 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
 def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkeypatch) -> None:
     module = _load_agent_module()
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    payload["backtest"]["min_events"] = 1
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
+    assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
 
@@ -99,7 +101,7 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     output = module.run_backtest(payload, None)
     assert output["status"] == "ok"
-    assert output["results"]["starting_bankroll_usd"] == 1000
+    assert output["results"]["starting_bankroll_usd"] == 100
     assert output["results"]["fill_events"] > 0
     assert output["backtest_summary"]["quoted_points"] > 0
     assert sum(output["backtest_summary"]["orderbook_modes"].values()) == len(


### PR DESCRIPTION
## Summary
- default Polymarket backtests to `backtest.bankroll_usd = 100` across the four Seren Desktop backtesting skills
- keep live sizing on `strategy.bankroll_usd` so the new bankroll only affects backtest capital
- update the example configs and the critical smoke assertions that cover the new default behavior

## Testing
- `pytest --import-mode=importlib polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py polymarket/liquidity-paired-basis-maker/tests/test_smoke.py polymarket/paired-market-basis-maker/tests/test_smoke.py polymarket/maker-rebate-bot/tests/test_smoke.py`

Closes #151