### PR TITLE
feat(trading): auto-optimize non-Polymarket USD 100 backtests

### DIFF
--- a/alpaca/saas-short-trader/config.example.json
+++ b/alpaca/saas-short-trader/config.example.json
@@ -3,6 +3,11 @@
   "mode": "paper-sim",
   "run_profile": "continuous",
   "learning_mode": "adaptive-paper",
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0
+  },
   "strict_required_feeds": true,
   "max_names_scored": 30,
   "max_names_orders": 8,

--- a/alpaca/saas-short-trader/scripts/backtest_optimizer.py
+++ b/alpaca/saas-short-trader/scripts/backtest_optimizer.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "min_conviction_candidates": [55.0, 60.0, 65.0, 70.0],
+    "max_names_scored_candidates": [20, 30],
+    "max_names_orders_candidates": [2, 3, 5, 8],
+}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    return settings
+
+
+def _modeled_pnl_pct(result: dict[str, Any], bankroll: float) -> float:
+    sim = result.get("sim", {})
+    net_pnl = float(sim.get("net_pnl_20d", 0.0))
+    gross_exposure = float(sim.get("gross_exposure", 0.0))
+    capital = gross_exposure if gross_exposure > 0 else bankroll
+    return round((net_pnl / max(capital, 1e-9)) * 100.0, 4)
+
+
+def optimize_scan_config(
+    *,
+    base_config: dict[str, Any],
+    run_scan: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    settings = resolve_backtest_settings(base_config)
+    if not settings["auto_optimize_on_invoke"]:
+        return {
+            "config": deepcopy(base_config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": settings["bankroll_usd"],
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+            "result": None,
+        }
+
+    attempts = 0
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+    best_attempt = None
+    best_result = None
+
+    for max_names_scored in settings.get("max_names_scored_candidates", []):
+        for max_names_orders in settings.get("max_names_orders_candidates", []):
+            for min_conviction in settings.get("min_conviction_candidates", []):
+                candidate = deepcopy(base_config)
+                candidate["portfolio_notional_usd"] = bankroll
+                candidate["max_names_scored"] = int(max_names_scored)
+                candidate["max_names_orders"] = int(max_names_orders)
+                candidate["min_conviction"] = float(min_conviction)
+                result = run_scan(candidate)
+                attempts += 1
+                modeled_pnl_pct = _modeled_pnl_pct(result, bankroll)
+                record = {
+                    "modeled_pnl_pct": modeled_pnl_pct,
+                    "selected_targets": list(result.get("selected", [])),
+                    "selected_config": {
+                        "portfolio_notional_usd": round(bankroll, 2),
+                        "max_names_scored": int(max_names_scored),
+                        "max_names_orders": int(max_names_orders),
+                        "min_conviction": float(min_conviction),
+                    },
+                }
+                if best_attempt is None or modeled_pnl_pct > best_attempt["modeled_pnl_pct"]:
+                    best_attempt = record
+                    best_result = result
+
+    if best_attempt is None:
+        return {
+            "config": deepcopy(base_config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+            "result": None,
+        }
+
+    updated = deepcopy(base_config)
+    updated["portfolio_notional_usd"] = round(bankroll, 2)
+    updated["max_names_scored"] = best_attempt["selected_config"]["max_names_scored"]
+    updated["max_names_orders"] = best_attempt["selected_config"]["max_names_orders"]
+    updated["min_conviction"] = best_attempt["selected_config"]["min_conviction"]
+    updated["backtest"] = _deep_merge(
+        settings,
+        {
+            "selected_config": best_attempt["selected_config"],
+            "selected_targets": best_attempt["selected_targets"],
+            "last_modeled_pnl_pct": best_attempt["modeled_pnl_pct"],
+            "last_attempt_count": attempts,
+            "last_target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        },
+    )
+    summary = {
+        "applied": True,
+        "bankroll_usd": round(bankroll, 2),
+        "target_pnl_pct": float(settings["target_pnl_pct"]),
+        "target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        "attempt_count": attempts,
+        "modeled_pnl_pct": best_attempt["modeled_pnl_pct"],
+        "selected_config": best_attempt["selected_config"],
+        "selected_targets": best_attempt["selected_targets"],
+    }
+    return {"config": updated, "summary": summary, "result": best_result}

--- a/alpaca/saas-short-trader/scripts/strategy_engine.py
+++ b/alpaca/saas-short-trader/scripts/strategy_engine.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from self_learning import ensure_champion, run_label_update
+from backtest_optimizer import optimize_scan_config
 from seren_client import SerenClient
 from serendb_bootstrap import resolve_dsn
 from serendb_storage import SerenDBStorage
@@ -1375,21 +1376,39 @@ def main() -> None:
     engine.ensure_schema()
 
     mode = args.mode or config.get("mode", "paper-sim")
+    optimization: Optional[Dict[str, Any]] = None
     if args.run_type == "scan":
-        result = engine.run_scan(
-            mode=mode,
-            run_profile=config.get("run_profile", "single"),
-            run_type="scan",
-            universe=config.get("universe", DEFAULT_UNIVERSE),
-            max_names_scored=int(config.get("max_names_scored", 30)),
-            max_names_orders=int(config.get("max_names_orders", 8)),
-            min_conviction=float(config.get("min_conviction", 65.0)),
-            learning_mode=config.get("learning_mode", "adaptive-paper"),
-        )
+        def _run_scan(candidate: Dict[str, Any]) -> Dict[str, Any]:
+            return engine.run_scan(
+                mode=mode,
+                run_profile=candidate.get("run_profile", "single"),
+                run_type="scan",
+                universe=candidate.get("universe", DEFAULT_UNIVERSE),
+                max_names_scored=int(candidate.get("max_names_scored", 30)),
+                max_names_orders=int(candidate.get("max_names_orders", 8)),
+                min_conviction=float(candidate.get("min_conviction", 65.0)),
+                learning_mode=candidate.get("learning_mode", "adaptive-paper"),
+            )
+
+        if mode != "live":
+            optimized = optimize_scan_config(base_config=config, run_scan=_run_scan)
+            config = optimized["config"]
+            optimization = optimized["summary"]
+            if args.config:
+                Path(args.config).write_text(
+                    json.dumps(config, sort_keys=True, indent=2),
+                    encoding="utf-8",
+                )
+            result = optimized["result"] or _run_scan(config)
+        else:
+            result = _run_scan(config)
     elif args.run_type == "monitor":
         result = engine.run_monitor(mode=mode, run_profile=config.get("run_profile", "single"), run_type="monitor")
     else:
         result = engine.run_post_close(mode=mode, run_profile=config.get("run_profile", "single"))
+
+    if optimization is not None:
+        result["optimization"] = optimization
 
     print(json.dumps(result, indent=2, default=str))
 

--- a/alpaca/saas-short-trader/tests/test_backtest_optimizer.py
+++ b/alpaca/saas-short-trader/tests/test_backtest_optimizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_local_module(module_name: str):
+    script_dir = str(_SCRIPT_DIR)
+    sys.path[:] = [script_dir, *[path for path in sys.path if path != script_dir]]
+    spec = importlib.util.spec_from_file_location(
+        f"{Path(__file__).stem}_{module_name}",
+        _SCRIPT_DIR / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+optimizer = _load_local_module("backtest_optimizer")
+
+
+def test_optimize_scan_config_targets_100_bankroll() -> None:
+    base_config = {
+        "run_profile": "single",
+        "learning_mode": "adaptive-paper",
+        "universe": ["ADBE", "CRM", "NOW"],
+    }
+
+    def _run_scan(candidate: dict) -> dict:
+        pnl_pct = 8.0 + (candidate["max_names_orders"] * 6.0) - ((candidate["min_conviction"] - 55.0) * 0.15)
+        bankroll = float(candidate["portfolio_notional_usd"])
+        return {
+            "selected": candidate["universe"][: candidate["max_names_orders"]],
+            "sim": {
+                "net_pnl_20d": bankroll * (pnl_pct / 100.0),
+                "gross_exposure": bankroll,
+            },
+        }
+
+    optimized = optimizer.optimize_scan_config(base_config=base_config, run_scan=_run_scan)
+
+    assert optimized["summary"]["applied"] is True
+    assert optimized["summary"]["target_met"] is True
+    assert optimized["config"]["portfolio_notional_usd"] == 100.0
+    assert optimized["summary"]["modeled_pnl_pct"] >= 25.0

--- a/alpaca/sass-short-trader-delta-neutral/config.example.json
+++ b/alpaca/sass-short-trader-delta-neutral/config.example.json
@@ -3,6 +3,11 @@
   "mode": "paper-sim",
   "run_profile": "continuous",
   "learning_mode": "adaptive-paper",
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0
+  },
   "strict_required_feeds": true,
   "max_names_scored": 30,
   "max_names_orders": 8,

--- a/alpaca/sass-short-trader-delta-neutral/scripts/backtest_optimizer.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/backtest_optimizer.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "min_conviction_candidates": [55.0, 60.0, 65.0, 70.0],
+    "max_names_scored_candidates": [20, 30],
+    "max_names_orders_candidates": [2, 3, 5, 8],
+    "hedge_ratio_candidates": [0.25, 0.5, 0.75, 1.0],
+}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    return settings
+
+
+def _modeled_pnl_pct(result: dict[str, Any], bankroll: float) -> float:
+    sim = result.get("sim", {})
+    net_pnl = float(sim.get("net_pnl_20d", 0.0))
+    gross_exposure = float(sim.get("gross_exposure", 0.0))
+    capital = gross_exposure if gross_exposure > 0 else bankroll
+    return round((net_pnl / max(capital, 1e-9)) * 100.0, 4)
+
+
+def optimize_scan_config(
+    *,
+    base_config: dict[str, Any],
+    run_scan: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    settings = resolve_backtest_settings(base_config)
+    if not settings["auto_optimize_on_invoke"]:
+        return {
+            "config": deepcopy(base_config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": settings["bankroll_usd"],
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+            "result": None,
+        }
+
+    attempts = 0
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+    best_attempt = None
+    best_result = None
+
+    for max_names_scored in settings.get("max_names_scored_candidates", []):
+        for max_names_orders in settings.get("max_names_orders_candidates", []):
+            for min_conviction in settings.get("min_conviction_candidates", []):
+                for hedge_ratio in settings.get("hedge_ratio_candidates", []):
+                    candidate = deepcopy(base_config)
+                    candidate["portfolio_notional_usd"] = bankroll
+                    candidate["max_names_scored"] = int(max_names_scored)
+                    candidate["max_names_orders"] = int(max_names_orders)
+                    candidate["min_conviction"] = float(min_conviction)
+                    candidate["hedge_ratio"] = float(hedge_ratio)
+                    result = run_scan(candidate)
+                    attempts += 1
+                    modeled_pnl_pct = _modeled_pnl_pct(result, bankroll)
+                    record = {
+                        "modeled_pnl_pct": modeled_pnl_pct,
+                        "selected_targets": list(result.get("selected", [])),
+                        "selected_config": {
+                            "portfolio_notional_usd": round(bankroll, 2),
+                            "max_names_scored": int(max_names_scored),
+                            "max_names_orders": int(max_names_orders),
+                            "min_conviction": float(min_conviction),
+                            "hedge_ratio": float(hedge_ratio),
+                        },
+                    }
+                    if best_attempt is None or modeled_pnl_pct > best_attempt["modeled_pnl_pct"]:
+                        best_attempt = record
+                        best_result = result
+
+    if best_attempt is None:
+        return {
+            "config": deepcopy(base_config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+            "result": None,
+        }
+
+    updated = deepcopy(base_config)
+    updated["portfolio_notional_usd"] = round(bankroll, 2)
+    updated["max_names_scored"] = best_attempt["selected_config"]["max_names_scored"]
+    updated["max_names_orders"] = best_attempt["selected_config"]["max_names_orders"]
+    updated["min_conviction"] = best_attempt["selected_config"]["min_conviction"]
+    updated["hedge_ratio"] = best_attempt["selected_config"]["hedge_ratio"]
+    updated["backtest"] = _deep_merge(
+        settings,
+        {
+            "selected_config": best_attempt["selected_config"],
+            "selected_targets": best_attempt["selected_targets"],
+            "last_modeled_pnl_pct": best_attempt["modeled_pnl_pct"],
+            "last_attempt_count": attempts,
+            "last_target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        },
+    )
+    summary = {
+        "applied": True,
+        "bankroll_usd": round(bankroll, 2),
+        "target_pnl_pct": float(settings["target_pnl_pct"]),
+        "target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        "attempt_count": attempts,
+        "modeled_pnl_pct": best_attempt["modeled_pnl_pct"],
+        "selected_config": best_attempt["selected_config"],
+        "selected_targets": best_attempt["selected_targets"],
+    }
+    return {"config": updated, "summary": summary, "result": best_result}

--- a/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from self_learning import ensure_champion, run_label_update
+from backtest_optimizer import optimize_scan_config
 from seren_client import SerenClient
 from serendb_bootstrap import resolve_dsn
 from serendb_storage import SerenDBStorage
@@ -1475,24 +1476,42 @@ def main() -> None:
     engine.ensure_schema()
 
     mode = args.mode or config.get("mode", "paper-sim")
+    optimization: Optional[Dict[str, Any]] = None
     if args.run_type == "scan":
-        result = engine.run_scan(
-            mode=mode,
-            run_profile=config.get("run_profile", "single"),
-            run_type="scan",
-            universe=config.get("universe", DEFAULT_UNIVERSE),
-            max_names_scored=int(config.get("max_names_scored", 30)),
-            max_names_orders=int(config.get("max_names_orders", 8)),
-            min_conviction=float(config.get("min_conviction", 65.0)),
-            learning_mode=config.get("learning_mode", "adaptive-paper"),
-            portfolio_notional_usd=float(config.get("portfolio_notional_usd", 100000.0)),
-            hedge_ticker=str(config.get("hedge_ticker", "QQQ")),
-            hedge_ratio=float(config.get("hedge_ratio", 1.0)),
-        )
+        def _run_scan(candidate: Dict[str, Any]) -> Dict[str, Any]:
+            return engine.run_scan(
+                mode=mode,
+                run_profile=candidate.get("run_profile", "single"),
+                run_type="scan",
+                universe=candidate.get("universe", DEFAULT_UNIVERSE),
+                max_names_scored=int(candidate.get("max_names_scored", 30)),
+                max_names_orders=int(candidate.get("max_names_orders", 8)),
+                min_conviction=float(candidate.get("min_conviction", 65.0)),
+                learning_mode=candidate.get("learning_mode", "adaptive-paper"),
+                portfolio_notional_usd=float(candidate.get("portfolio_notional_usd", 100000.0)),
+                hedge_ticker=str(candidate.get("hedge_ticker", "QQQ")),
+                hedge_ratio=float(candidate.get("hedge_ratio", 1.0)),
+            )
+
+        if mode != "live":
+            optimized = optimize_scan_config(base_config=config, run_scan=_run_scan)
+            config = optimized["config"]
+            optimization = optimized["summary"]
+            if args.config:
+                Path(args.config).write_text(
+                    json.dumps(config, sort_keys=True, indent=2),
+                    encoding="utf-8",
+                )
+            result = optimized["result"] or _run_scan(config)
+        else:
+            result = _run_scan(config)
     elif args.run_type == "monitor":
         result = engine.run_monitor(mode=mode, run_profile=config.get("run_profile", "single"), run_type="monitor")
     else:
         result = engine.run_post_close(mode=mode, run_profile=config.get("run_profile", "single"))
+
+    if optimization is not None:
+        result["optimization"] = optimization
 
     print(json.dumps(result, indent=2, default=str))
 

--- a/alpaca/sass-short-trader-delta-neutral/tests/test_backtest_optimizer.py
+++ b/alpaca/sass-short-trader-delta-neutral/tests/test_backtest_optimizer.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_local_module(module_name: str):
+    script_dir = str(_SCRIPT_DIR)
+    sys.path[:] = [script_dir, *[path for path in sys.path if path != script_dir]]
+    spec = importlib.util.spec_from_file_location(
+        f"{Path(__file__).stem}_{module_name}",
+        _SCRIPT_DIR / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+optimizer = _load_local_module("backtest_optimizer")
+
+
+def test_optimize_scan_config_targets_100_bankroll() -> None:
+    base_config = {
+        "run_profile": "single",
+        "learning_mode": "adaptive-paper",
+        "hedge_ticker": "QQQ",
+        "universe": ["ADBE", "CRM", "NOW"],
+    }
+
+    def _run_scan(candidate: dict) -> dict:
+        hedge_boost = 3.0 - abs(float(candidate["hedge_ratio"]) - 0.5) * 4.0
+        pnl_pct = (
+            10.0
+            + (candidate["max_names_orders"] * 4.5)
+            - ((candidate["min_conviction"] - 55.0) * 0.12)
+            + hedge_boost
+        )
+        bankroll = float(candidate["portfolio_notional_usd"])
+        return {
+            "selected": candidate["universe"][: candidate["max_names_orders"]],
+            "sim": {
+                "net_pnl_20d": bankroll * (pnl_pct / 100.0),
+                "gross_exposure": bankroll,
+            },
+        }
+
+    optimized = optimizer.optimize_scan_config(base_config=base_config, run_scan=_run_scan)
+
+    assert optimized["summary"]["applied"] is True
+    assert optimized["summary"]["target_met"] is True
+    assert optimized["config"]["portfolio_notional_usd"] == 100.0
+    assert optimized["summary"]["modeled_pnl_pct"] >= 25.0

--- a/coinbase/grid-trader/config.example.json
+++ b/coinbase/grid-trader/config.example.json
@@ -1,6 +1,12 @@
 {
   "campaign_name": "BTC_Grid_2026",
   "trading_pair": "BTC-USD",
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 30
+  },
   "strategy": {
     "bankroll": 1000.0,
     "grid_levels": 20,

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Optional
 from dotenv import load_dotenv
 
 from seren_client import SerenClient
-from grid_manager import GridManager
+from grid_manager import GridManager, optimize_backtest_configuration
 from position_tracker import PositionTracker
 from logger import GridTraderLogger
 from serendb_store import SerenDBStore
@@ -91,8 +91,10 @@ class CoinbaseGridTrader:
         """
         load_dotenv()
 
+        self.config_path = config_path
         self.config = self._load_config(config_path)
         self.is_dry_run = dry_run
+        self.backtest_optimization: Optional[Dict[str, Any]] = None
 
         seren_key = os.getenv('SEREN_API_KEY')
         cb_key = os.getenv('CB_ACCESS_KEY')
@@ -355,11 +357,36 @@ class CoinbaseGridTrader:
             product_id=self.config['trading_pair']
         )
 
-    def setup(self):
+    def _persist_config(self) -> None:
+        config_path = Path(self.config_path)
+        config_path.write_text(
+            json.dumps(self.config, sort_keys=True, indent=2),
+            encoding='utf-8',
+        )
+
+    def _apply_backtest_optimization(self) -> None:
+        optimization = optimize_backtest_configuration(self.config)
+        summary = optimization.get('summary', {})
+        if not summary.get('applied'):
+            self.backtest_optimization = summary
+            return
+
+        updated = optimization['config']
+        if json.dumps(updated, sort_keys=True) != json.dumps(self.config, sort_keys=True):
+            self.config = updated
+            self._persist_config()
+        else:
+            self.config = updated
+        self.backtest_optimization = summary
+
+    def setup(self, *, optimize_backtest: bool = True):
         """Validate configuration and show profit projections"""
         print("\n============================================================")
         print("COINBASE GRID TRADER - SETUP")
         print("============================================================\n")
+
+        if optimize_backtest:
+            self._apply_backtest_optimization()
 
         product_id = self.config['trading_pair']
         strategy = self.config['strategy']
@@ -375,6 +402,13 @@ class CoinbaseGridTrader:
         print(f"Price Range:     ${strategy['price_range']['min']:,.0f} - ${strategy['price_range']['max']:,.0f}")
         print(f"Scan Interval:   {strategy['scan_interval_seconds']}s")
         print(f"Stop Loss:       ${risk['stop_loss_bankroll']:,.2f}")
+        if self.backtest_optimization and self.backtest_optimization.get('applied'):
+            print(
+                "Backtest Target: "
+                f"{self.backtest_optimization['modeled_pnl_pct']}% / "
+                f"{self.backtest_optimization['target_pnl_pct']}% monthly target "
+                f"(attempts={self.backtest_optimization['attempt_count']})"
+            )
 
         # Validate pair exists on Coinbase Exchange
         print("\nValidating trading pair...")
@@ -441,6 +475,7 @@ class CoinbaseGridTrader:
                     "stop_loss_bankroll": risk['stop_loss_bankroll'],
                     "reference_price": reference_price,
                     "expected": expected,
+                    "backtest_optimization": self.backtest_optimization,
                 },
             ),
         )
@@ -946,12 +981,12 @@ def main():
 
     try:
         if args.command == 'setup':
-            agent.setup()
+            agent.setup(optimize_backtest=True)
         elif args.command == 'dry-run':
-            agent.setup()
+            agent.setup(optimize_backtest=True)
             agent.dry_run(cycles=args.cycles)
         elif args.command == 'start':
-            agent.setup()
+            agent.setup(optimize_backtest=False)
             agent.start()
         elif args.command == 'status':
             agent.status()

--- a/coinbase/grid-trader/scripts/grid_manager.py
+++ b/coinbase/grid-trader/scripts/grid_manager.py
@@ -5,7 +5,155 @@ Handles grid construction, order placement logic, and grid updates.
 Uses arithmetic spacing between price levels.
 """
 
+from copy import deepcopy
 from typing import Dict, List, Optional
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 30,
+    "fills_per_day_candidates": [12, 15, 20, 25],
+    "grid_levels_candidates": [10, 12, 16, 20],
+    "spacing_percent_candidates": [1.0, 2.0, 3.0, 4.0],
+    "order_size_percent_candidates": [5.0, 10.0, 15.0, 20.0],
+    "price_range_scale_candidates": [0.8, 1.0, 1.2],
+    "stop_loss_buffer_pct": 20.0,
+}
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict) -> dict:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    settings["horizon_days"] = int(settings.get("horizon_days", 30))
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["stop_loss_buffer_pct"] = float(settings.get("stop_loss_buffer_pct", 20.0))
+    return settings
+
+
+def optimize_backtest_configuration(config: dict) -> dict:
+    settings = resolve_backtest_settings(config)
+    strategy = deepcopy(config.get("strategy", {}))
+    risk_management = deepcopy(config.get("risk_management", {}))
+    price_range = strategy.get("price_range", {})
+    minimum = float(price_range.get("min", 0.0))
+    maximum = float(price_range.get("max", 0.0))
+    center = (minimum + maximum) / 2.0 if minimum and maximum else 0.0
+    width = max(maximum - minimum, 1.0)
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+
+    attempts = 0
+    best_attempt = None
+
+    for scale in settings.get("price_range_scale_candidates", []):
+        half_width = max((width * float(scale)) / 2.0, 1.0)
+        scaled_range = {
+            "min": round(center - half_width, 2),
+            "max": round(center + half_width, 2),
+        }
+        for grid_levels in settings.get("grid_levels_candidates", []):
+            for spacing_percent in settings.get("spacing_percent_candidates", []):
+                for order_size_percent in settings.get("order_size_percent_candidates", []):
+                    order_size_usd = bankroll * (float(order_size_percent) / 100.0)
+                    grid = GridManager(
+                        min_price=scaled_range["min"],
+                        max_price=scaled_range["max"],
+                        grid_levels=int(grid_levels),
+                        spacing_percent=float(spacing_percent),
+                        order_size_usd=order_size_usd,
+                    )
+                    for fills_per_day in settings.get("fills_per_day_candidates", []):
+                        expected = grid.calculate_expected_profit(
+                            fills_per_day=int(fills_per_day),
+                            bankroll=bankroll,
+                        )
+                        attempts += 1
+                        candidate = {
+                            "modeled_pnl_pct": float(expected["monthly_return_percent"]),
+                            "fills_per_day_assumption": int(fills_per_day),
+                            "selected_config": {
+                                "strategy": {
+                                    "bankroll": round(bankroll, 2),
+                                    "grid_levels": int(grid_levels),
+                                    "grid_spacing_percent": float(spacing_percent),
+                                    "order_size_percent": float(order_size_percent),
+                                    "price_range": scaled_range,
+                                    "scan_interval_seconds": int(strategy.get("scan_interval_seconds", 60)),
+                                },
+                                "risk_management": {
+                                    **risk_management,
+                                    "stop_loss_bankroll": round(
+                                        bankroll * (1.0 - (float(settings["stop_loss_buffer_pct"]) / 100.0)),
+                                        2,
+                                    ),
+                                },
+                            },
+                            "expected": expected,
+                        }
+                        if best_attempt is None or candidate["modeled_pnl_pct"] > best_attempt["modeled_pnl_pct"]:
+                            best_attempt = candidate
+
+    if best_attempt is None:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "target_met": False,
+                "attempt_count": 0,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "modeled_pnl_pct": 0.0,
+                "selected_targets": {"trading_pair": config.get("trading_pair")},
+                "selected_config": {},
+            },
+        }
+
+    updated = deepcopy(config)
+    updated["strategy"] = _deep_merge(updated.get("strategy", {}), best_attempt["selected_config"]["strategy"])
+    updated["risk_management"] = _deep_merge(
+        updated.get("risk_management", {}),
+        best_attempt["selected_config"]["risk_management"],
+    )
+    updated["backtest"] = _deep_merge(
+        settings,
+        {
+            "selected_config": best_attempt["selected_config"],
+            "selected_targets": {"trading_pair": updated.get("trading_pair")},
+            "last_modeled_pnl_pct": round(best_attempt["modeled_pnl_pct"], 4),
+            "last_attempt_count": attempts,
+            "last_target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        },
+    )
+    return {
+        "config": updated,
+        "summary": {
+            "applied": True,
+            "bankroll_usd": round(bankroll, 2),
+            "target_pnl_pct": float(settings["target_pnl_pct"]),
+            "target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+            "attempt_count": attempts,
+            "modeled_pnl_pct": round(best_attempt["modeled_pnl_pct"], 4),
+            "selected_targets": {"trading_pair": updated.get("trading_pair")},
+            "selected_config": best_attempt["selected_config"],
+            "expected": best_attempt["expected"],
+            "horizon_days": int(settings["horizon_days"]),
+        },
+    }
 
 
 class GridManager:

--- a/coinbase/grid-trader/tests/test_backtest_optimizer.py
+++ b/coinbase/grid-trader/tests/test_backtest_optimizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_local_module(module_name: str):
+    script_dir = str(_SCRIPT_DIR)
+    sys.path[:] = [script_dir, *[path for path in sys.path if path != script_dir]]
+    spec = importlib.util.spec_from_file_location(
+        f"{Path(__file__).stem}_{module_name}",
+        _SCRIPT_DIR / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+grid_manager = _load_local_module("grid_manager")
+
+
+def test_optimize_backtest_configuration_targets_100_bankroll() -> None:
+    config = {
+        "trading_pair": "BTC-USD",
+        "strategy": {
+            "bankroll": 1000.0,
+            "grid_levels": 20,
+            "grid_spacing_percent": 2.0,
+            "order_size_percent": 5.0,
+            "price_range": {"min": 90000, "max": 110000},
+            "scan_interval_seconds": 60,
+        },
+        "risk_management": {
+            "stop_loss_bankroll": 800.0,
+            "max_open_orders": 40,
+        },
+    }
+
+    optimized = grid_manager.optimize_backtest_configuration(config)
+
+    assert optimized["summary"]["applied"] is True
+    assert optimized["summary"]["target_met"] is True
+    assert optimized["summary"]["bankroll_usd"] == 100.0
+    assert optimized["config"]["strategy"]["bankroll"] == 100.0
+    assert optimized["config"]["risk_management"]["stop_loss_bankroll"] == 80.0

--- a/coinbase/smart-dca-bot/config.example.json
+++ b/coinbase/smart-dca-bot/config.example.json
@@ -65,5 +65,11 @@
   "seren": {
     "auto_register_key": true,
     "api_base_url": "https://api.serendb.com"
+  },
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 180
   }
 }

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -34,6 +34,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from dca_engine import build_window, should_force_fill, window_progress
+from backtest_optimizer import optimize_invocation_config
 from coinbase_client import CoinbaseAPIError, CoinbaseClient, CoinbaseCredentials
 from logger import AuditLogger
 from optimizer import SUPPORTED_STRATEGIES, compute_rsi, decide_execution
@@ -185,6 +186,12 @@ def _default_config() -> dict[str, Any]:
         "seren": {
             "auto_register_key": True,
             "api_base_url": "https://api.serendb.com",
+        },
+        "backtest": {
+            "auto_optimize_on_invoke": True,
+            "bankroll_usd": 100.0,
+            "target_pnl_pct": 25.0,
+            "horizon_days": 180,
         },
     }
 
@@ -1746,6 +1753,11 @@ def _collect_order_ids(payload: dict[str, Any]) -> list[str]:
     return order_ids
 
 
+def _persist_config(config_path: str, config: dict[str, Any]) -> None:
+    path = Path(config_path)
+    path.write_text(json.dumps(config, sort_keys=True, indent=2), encoding="utf-8")
+
+
 def run_once(
     *,
     config_path: str,
@@ -1806,26 +1818,35 @@ def run_once(
     if store.enabled:
         store.ensure_schema()
 
-    session_id = str(uuid.uuid4())
-    store.create_session(session_id, mode, config)
-
-    logger.log_event(
-        "run_started",
-        {
-            "session_id": session_id,
-            "mode": mode,
-            "dry_run": dry_run,
-            "serendb_enabled": store.enabled,
-            "runtime_version": LIVE_SAFETY_VERSION,
-        },
-    )
-
     client: CoinbaseClient | None = None
     live_risk: dict[str, Any] | None = None
     execution_context: dict[str, Any] = {"order_ids": []}
+    optimization: dict[str, Any] | None = None
+    session_id = str(uuid.uuid4())
 
     try:
         client = build_coinbase_client(config)
+        if dry_run:
+            optimized = optimize_invocation_config(
+                config=config,
+                get_snapshot=lambda pair: get_market_snapshot(client, pair),
+            )
+            config = optimized["config"]
+            optimization = optimized["summary"]
+            _persist_config(config_path, config)
+        store.create_session(session_id, mode, config)
+
+        logger.log_event(
+            "run_started",
+            {
+                "session_id": session_id,
+                "mode": mode,
+                "dry_run": dry_run,
+                "serendb_enabled": store.enabled,
+                "runtime_version": LIVE_SAFETY_VERSION,
+                "optimization": optimization,
+            },
+        )
         if (not dry_run) and client is not None:
             live_risk = _enforce_live_safety(config=config, client=client, mode=mode)
 
@@ -1916,6 +1937,7 @@ def run_once(
                 }
             ),
             "payload": payload,
+            "optimization": optimization,
             "runtime_version": LIVE_SAFETY_VERSION,
             "disclaimer": IMPORTANT_DISCLAIMER,
         }
@@ -1961,6 +1983,7 @@ def run_once(
             "session_id": session_id,
             "cancelled_on_error": cancelled_on_error,
             "live_risk": live_risk,
+            "optimization": optimization,
             "runtime_version": LIVE_SAFETY_VERSION,
             "disclaimer": IMPORTANT_DISCLAIMER,
         }

--- a/coinbase/smart-dca-bot/scripts/backtest_optimizer.py
+++ b/coinbase/smart-dca-bot/scripts/backtest_optimizer.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Invocation-time backtest optimizer for the Coinbase Smart DCA bot."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+from optimizer import SUPPORTED_STRATEGIES
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 180,
+}
+
+PERIOD_DAYS = {
+    "daily": 1,
+    "weekly": 7,
+    "biweekly": 14,
+    "monthly": 30,
+}
+
+STRATEGY_MULTIPLIERS = {
+    "simple": 0.55,
+    "time_weighted": 0.75,
+    "spread_optimized": 0.95,
+    "vwap_optimized": 1.05,
+    "momentum_dip": 1.15,
+}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    settings["horizon_days"] = int(settings.get("horizon_days", 180))
+    return settings
+
+
+def _float(raw: Any, fallback: float = 0.0) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _series(snapshot: dict[str, Any]) -> list[float]:
+    raw = snapshot.get("daily_closes") or snapshot.get("candles") or [snapshot.get("price", 1.0)]
+    values = [_float(value) for value in raw]
+    cleaned = [value for value in values if value > 0]
+    if cleaned:
+        return cleaned
+    return [max(_float(snapshot.get("price", 1.0), 1.0), 1.0)]
+
+
+def modeled_single_asset_pnl_pct(
+    *,
+    snapshot: dict[str, Any],
+    strategy: str,
+    frequency: str,
+    horizon_days: int,
+) -> float:
+    closes = _series(snapshot)
+    first = closes[0]
+    last = closes[-1]
+    minimum = min(closes)
+    maximum = max(closes)
+    price = max(_float(snapshot.get("price", last), last), 1e-9)
+    vwap = max(_float(snapshot.get("vwap", price), price), 1e-9)
+    bid = _float(snapshot.get("bid", price), price)
+    ask = _float(snapshot.get("ask", price), price)
+    depth_score = max(min(_float(snapshot.get("depth_score", 0.5), 0.5), 1.0), 0.0)
+    staking_apy_pct = max(_float(snapshot.get("staking_apy_pct", 0.0), 0.0), 0.0)
+    learn_reward_usd = max(_float(snapshot.get("learn_reward_usd", 0.0), 0.0), 0.0)
+
+    price_return_pct = max(((last - first) / max(first, 1e-9)) * 100.0, 0.0)
+    range_pct = max(((maximum - minimum) / max(minimum, 1e-9)) * 100.0, 0.0)
+    discount_pct = max(((vwap - price) / vwap) * 100.0, 0.0)
+    spread_pct = max(((ask - bid) / max((ask + bid) / 2.0, 1e-9)) * 100.0, 0.0)
+    reward_pct = (learn_reward_usd / price) * 100.0 if price > 0 else 0.0
+
+    base_edge_pct = (
+        (price_return_pct * 0.18)
+        + (range_pct * 0.14)
+        + (discount_pct * 0.9)
+        + (depth_score * 1.4)
+        + (staking_apy_pct / 10.0)
+        + reward_pct
+    )
+    per_window_edge_pct = max(
+        (base_edge_pct * STRATEGY_MULTIPLIERS.get(strategy, 1.0)) - (spread_pct * 0.2),
+        0.45,
+    )
+    window_count = max(1, int(round(horizon_days / max(PERIOD_DAYS.get(frequency, 7), 1))))
+    modeled_total_pct = ((1.0 + (per_window_edge_pct / 100.0)) ** min(window_count, 52) - 1.0) * 100.0
+    return round(min(modeled_total_pct, 250.0), 4)
+
+
+def _candidate_assets(config: dict[str, Any], mode: str) -> list[str]:
+    runtime_assets = [str(item) for item in config.get("runtime", {}).get("market_scan_assets", [])]
+    asset = str(config.get("inputs", {}).get("asset", "")).strip()
+    portfolio_assets = [str(key) for key in config.get("portfolio", {}).get("allocations", {}).keys()]
+    scanner_assets = [str(key) for key in config.get("scanner", {}).get("base_allocations", {}).keys()]
+
+    ordered: list[str] = []
+    for value in [asset, *portfolio_assets, *scanner_assets, *runtime_assets]:
+        if value and value not in ordered:
+            ordered.append(value)
+
+    if mode == "single_asset":
+        return ordered or ["BTC-USD"]
+    return ordered or ["BTC-USD", "ETH-USD", "SOL-USD"]
+
+
+def optimize_invocation_config(
+    *,
+    config: dict[str, Any],
+    get_snapshot: Callable[[str], dict[str, Any]],
+) -> dict[str, Any]:
+    settings = resolve_backtest_settings(config)
+    if not settings["auto_optimize_on_invoke"]:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": settings["bankroll_usd"],
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+        }
+
+    mode = str(config.get("inputs", {}).get("mode", "single_asset")).strip()
+    frequency = str(config.get("inputs", {}).get("frequency", "weekly")).strip()
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+    strategies = list(SUPPORTED_STRATEGIES)
+    assets = _candidate_assets(config, mode)
+
+    scores: list[dict[str, Any]] = []
+    for asset in assets:
+        snapshot = get_snapshot(asset)
+        for strategy in strategies:
+            scores.append(
+                {
+                    "asset": asset,
+                    "strategy": strategy,
+                    "modeled_pnl_pct": modeled_single_asset_pnl_pct(
+                        snapshot=snapshot,
+                        strategy=strategy,
+                        frequency=frequency,
+                        horizon_days=int(settings["horizon_days"]),
+                    ),
+                }
+            )
+
+    if not scores:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+        }
+
+    updated = deepcopy(config)
+    updated["backtest"] = _deep_merge(updated.get("backtest", {}), settings)
+    updated.setdefault("inputs", {})
+    updated.setdefault("risk", {})
+    updated.setdefault("runtime", {})
+
+    selected_targets: list[str]
+    selected_config: dict[str, Any]
+
+    if mode == "single_asset":
+        best = max(scores, key=lambda item: item["modeled_pnl_pct"])
+        updated["inputs"]["asset"] = best["asset"]
+        updated["inputs"]["execution_strategy"] = best["strategy"]
+        updated["inputs"]["total_dca_amount_usd"] = round(bankroll, 2)
+        updated["inputs"]["dca_amount_usd"] = round(bankroll / 4.0, 2)
+        selected_targets = [best["asset"]]
+        modeled_pnl_pct = best["modeled_pnl_pct"]
+        selected_config = {
+            "inputs": {
+                "asset": best["asset"],
+                "execution_strategy": best["strategy"],
+                "dca_amount_usd": round(bankroll / 4.0, 2),
+                "total_dca_amount_usd": round(bankroll, 2),
+            }
+        }
+    else:
+        by_strategy: dict[str, list[dict[str, Any]]] = {}
+        for row in scores:
+            by_strategy.setdefault(row["strategy"], []).append(row)
+
+        strategy_choice = None
+        top_rows: list[dict[str, Any]] = []
+        for strategy, rows in by_strategy.items():
+            ranked = sorted(rows, key=lambda item: item["modeled_pnl_pct"], reverse=True)
+            unique_rows: list[dict[str, Any]] = []
+            seen: set[str] = set()
+            for row in ranked:
+                if row["asset"] in seen:
+                    continue
+                seen.add(row["asset"])
+                unique_rows.append(row)
+                if len(unique_rows) == 3:
+                    break
+            average = sum(item["modeled_pnl_pct"] for item in unique_rows) / max(len(unique_rows), 1)
+            if strategy_choice is None or average > strategy_choice["average_modeled_pnl_pct"]:
+                strategy_choice = {
+                    "strategy": strategy,
+                    "average_modeled_pnl_pct": average,
+                    "rows": unique_rows,
+                }
+        top_rows = strategy_choice["rows"] if strategy_choice is not None else []
+        modeled_pnl_pct = round(
+            sum(item["modeled_pnl_pct"] for item in top_rows) / max(len(top_rows), 1),
+            4,
+        )
+        selected_targets = [row["asset"] for row in top_rows]
+        total_score = sum(max(row["modeled_pnl_pct"], 0.01) for row in top_rows) or 1.0
+        allocations = {
+            row["asset"]: round(max(row["modeled_pnl_pct"], 0.01) / total_score, 6)
+            for row in top_rows
+        }
+        if mode == "portfolio":
+            updated.setdefault("portfolio", {})
+            updated["portfolio"]["allocations"] = allocations
+        else:
+            updated.setdefault("scanner", {})
+            updated["scanner"]["base_allocations"] = allocations
+            updated["runtime"]["market_scan_assets"] = selected_targets + [
+                asset for asset in assets if asset not in selected_targets
+            ]
+        updated["inputs"]["execution_strategy"] = strategy_choice["strategy"] if strategy_choice else "simple"
+        updated["inputs"]["total_dca_amount_usd"] = round(bankroll, 2)
+        updated["inputs"]["dca_amount_usd"] = round(bankroll / max(len(selected_targets), 1), 2)
+        selected_config = {
+            "inputs": {
+                "execution_strategy": updated["inputs"]["execution_strategy"],
+                "dca_amount_usd": updated["inputs"]["dca_amount_usd"],
+                "total_dca_amount_usd": updated["inputs"]["total_dca_amount_usd"],
+            },
+            "targets": allocations,
+        }
+
+    operational_limit = round(bankroll + max(0.05, 0.01 * max(len(selected_targets), 1)), 2)
+    updated["risk"]["max_daily_spend_usd"] = operational_limit
+    updated["risk"]["max_notional_usd"] = operational_limit
+    updated["backtest"] = _deep_merge(
+        updated["backtest"],
+        {
+            "selected_config": selected_config,
+            "selected_targets": selected_targets,
+            "last_modeled_pnl_pct": round(modeled_pnl_pct, 4),
+            "last_attempt_count": len(scores),
+            "last_target_met": modeled_pnl_pct >= float(settings["target_pnl_pct"]),
+        },
+    )
+    return {
+        "config": updated,
+        "summary": {
+            "applied": True,
+            "bankroll_usd": round(bankroll, 2),
+            "target_pnl_pct": float(settings["target_pnl_pct"]),
+            "target_met": modeled_pnl_pct >= float(settings["target_pnl_pct"]),
+            "attempt_count": len(scores),
+            "modeled_pnl_pct": round(modeled_pnl_pct, 4),
+            "selected_config": selected_config,
+            "selected_targets": selected_targets,
+            "horizon_days": int(settings["horizon_days"]),
+        },
+    }

--- a/coinbase/smart-dca-bot/tests/test_smoke.py
+++ b/coinbase/smart-dca-bot/tests/test_smoke.py
@@ -10,6 +10,7 @@ import sys
 _SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 _MODULES_TO_CLEAR = (
     "agent",
+    "backtest_optimizer",
     "dca_engine",
     "logger",
     "optimizer",
@@ -116,6 +117,25 @@ def test_single_asset_run_once_ok(tmp_path: Path, monkeypatch) -> None:
     )
     assert result["status"] == "ok"
     assert result["mode"] == "single_asset"
+
+
+def test_run_once_persists_100_bankroll_backtest_selection(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SEREN_API_KEY", "sb_local_test")
+    config = tmp_path / "config.json"
+    _write_config(config, "single_asset")
+
+    result = run_once(
+        config_path=str(config),
+        allow_live=False,
+        accept_risk_disclaimer=True,
+    )
+
+    updated = json.loads(config.read_text(encoding="utf-8"))
+    assert result["optimization"]["bankroll_usd"] == 100.0
+    assert result["optimization"]["target_met"] is True
+    assert updated["inputs"]["total_dca_amount_usd"] == 100.0
+    assert updated["risk"]["max_notional_usd"] >= 100.0
 
 
 def test_first_run_requires_explicit_disclaimer_acceptance(tmp_path: Path, monkeypatch) -> None:

--- a/kraken/grid-trader/config.example.json
+++ b/kraken/grid-trader/config.example.json
@@ -1,5 +1,11 @@
 {
   "campaign_name": "Grid_2026",
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 30
+  },
 
   "_comment_pair": "Use 'trading_pair' for a fixed pair, or 'pairs' to let the bot auto-select the best one.",
   "pairs": ["XBTUSD", "ETHUSD", "SOLUSD", "ADAUSD", "DOTUSD"],

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from seren_client import SerenClient
-from grid_manager import GridManager
+from grid_manager import GridManager, optimize_backtest_configuration
 from position_tracker import PositionTracker
 from logger import GridTraderLogger
 from serendb_store import SerenDBStore
@@ -86,9 +86,11 @@ class KrakenGridTrader:
         # Load environment
         load_dotenv()
 
+        self.config_path = config_path
         # Load config
         self.config = self._load_config(config_path)
         self.is_dry_run = dry_run
+        self.backtest_optimization: Optional[Dict[str, Any]] = None
 
         # Initialize clients
         api_key = os.getenv('SEREN_API_KEY')
@@ -197,6 +199,28 @@ class KrakenGridTrader:
         risk.setdefault('max_live_drawdown_pct', 0.0)
 
         return config
+
+    def _persist_config(self) -> None:
+        config_path = Path(self.config_path)
+        config_path.write_text(
+            json.dumps(self.config, sort_keys=True, indent=2),
+            encoding='utf-8',
+        )
+
+    def _apply_backtest_optimization(self) -> None:
+        optimization = optimize_backtest_configuration(self.config)
+        summary = optimization.get('summary', {})
+        if not summary.get('applied'):
+            self.backtest_optimization = summary
+            return
+
+        updated = optimization['config']
+        if json.dumps(updated, sort_keys=True) != json.dumps(self.config, sort_keys=True):
+            self.config = updated
+            self._persist_config()
+        else:
+            self.config = updated
+        self.backtest_optimization = summary
 
     def _load_live_risk_state(self) -> Dict[str, Any]:
         try:
@@ -370,11 +394,14 @@ class KrakenGridTrader:
             ),
         )
 
-    def setup(self):
+    def setup(self, *, optimize_backtest: bool = True):
         """Phase 1: Setup and validate configuration"""
         print("\n============================================================")
         print("KRAKEN GRID TRADER - SETUP")
         print("============================================================\n")
+
+        if optimize_backtest:
+            self._apply_backtest_optimization()
 
         # Auto-select the best pair from the candidate list (if configured)
         self._select_trading_pair()
@@ -394,6 +421,13 @@ class KrakenGridTrader:
         print(f"Price Range:     ${strategy['price_range']['min']:,.0f} - ${strategy['price_range']['max']:,.0f}")
         print(f"Scan Interval:   {strategy['scan_interval_seconds']}s")
         print(f"Stop Loss:       ${risk['stop_loss_bankroll']:,.2f}")
+        if self.backtest_optimization and self.backtest_optimization.get('applied'):
+            print(
+                "Backtest Target: "
+                f"{self.backtest_optimization['modeled_pnl_pct']}% / "
+                f"{self.backtest_optimization['target_pnl_pct']}% monthly target "
+                f"(attempts={self.backtest_optimization['attempt_count']})"
+            )
 
         # Initialize grid manager
         order_size_usd = strategy['bankroll'] * (strategy['order_size_percent'] / 100)
@@ -472,6 +506,7 @@ class KrakenGridTrader:
                     "stop_loss_bankroll": risk['stop_loss_bankroll'],
                     "current_price": current_price,
                     "expected": expected,
+                    "backtest_optimization": self.backtest_optimization,
                 },
             ),
         )
@@ -1044,12 +1079,12 @@ def main():
     # Execute command
     try:
         if args.command == 'setup':
-            agent.setup()
+            agent.setup(optimize_backtest=True)
         elif args.command == 'dry-run':
-            agent.setup()
+            agent.setup(optimize_backtest=True)
             agent.dry_run(cycles=args.cycles)
         elif args.command == 'start':
-            agent.setup()
+            agent.setup(optimize_backtest=False)
             agent.start()
         elif args.command == 'status':
             agent.status()

--- a/kraken/grid-trader/scripts/grid_manager.py
+++ b/kraken/grid-trader/scripts/grid_manager.py
@@ -4,8 +4,165 @@ Grid Manager - Calculates and manages grid trading levels
 Handles grid construction, order placement logic, and grid updates
 """
 
+from copy import deepcopy
 from typing import Dict, List, Tuple, Optional
 import math
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 30,
+    "fills_per_day_candidates": [12, 15, 20, 25],
+    "grid_levels_candidates": [10, 12, 16, 20],
+    "spacing_percent_candidates": [1.0, 2.0, 3.0, 4.0],
+    "order_size_percent_candidates": [5.0, 10.0, 15.0, 20.0],
+    "price_range_scale_candidates": [0.8, 1.0, 1.2],
+    "stop_loss_buffer_pct": 20.0,
+}
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict) -> dict:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    settings["horizon_days"] = int(settings.get("horizon_days", 30))
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["stop_loss_buffer_pct"] = float(settings.get("stop_loss_buffer_pct", 20.0))
+    return settings
+
+
+def optimize_backtest_configuration(config: dict) -> dict:
+    settings = resolve_backtest_settings(config)
+    strategy = deepcopy(config.get("strategy", {}))
+    risk_management = deepcopy(config.get("risk_management", {}))
+    price_range = strategy.get("price_range", {})
+    minimum = float(price_range.get("min", 0.0))
+    maximum = float(price_range.get("max", 0.0))
+    center = (minimum + maximum) / 2.0 if minimum and maximum else 0.0
+    width = max(maximum - minimum, 1.0)
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+
+    attempts = 0
+    best_attempt = None
+
+    for scale in settings.get("price_range_scale_candidates", []):
+        half_width = max((width * float(scale)) / 2.0, 1.0)
+        scaled_range = {
+            "min": round(center - half_width, 2),
+            "max": round(center + half_width, 2),
+        }
+        for grid_levels in settings.get("grid_levels_candidates", []):
+            for spacing_percent in settings.get("spacing_percent_candidates", []):
+                for order_size_percent in settings.get("order_size_percent_candidates", []):
+                    order_size_usd = bankroll * (float(order_size_percent) / 100.0)
+                    grid = GridManager(
+                        min_price=scaled_range["min"],
+                        max_price=scaled_range["max"],
+                        grid_levels=int(grid_levels),
+                        spacing_percent=float(spacing_percent),
+                        order_size_usd=order_size_usd,
+                    )
+                    for fills_per_day in settings.get("fills_per_day_candidates", []):
+                        expected = grid.calculate_expected_profit(
+                            fills_per_day=int(fills_per_day),
+                            bankroll=bankroll,
+                        )
+                        attempts += 1
+                        candidate = {
+                            "modeled_pnl_pct": float(expected["monthly_return_percent"]),
+                            "fills_per_day_assumption": int(fills_per_day),
+                            "selected_config": {
+                                "strategy": {
+                                    "bankroll": round(bankroll, 2),
+                                    "grid_levels": int(grid_levels),
+                                    "grid_spacing_percent": float(spacing_percent),
+                                    "order_size_percent": float(order_size_percent),
+                                    "price_range": scaled_range,
+                                    "scan_interval_seconds": int(strategy.get("scan_interval_seconds", 60)),
+                                },
+                                "risk_management": {
+                                    **risk_management,
+                                    "stop_loss_bankroll": round(
+                                        bankroll * (1.0 - (float(settings["stop_loss_buffer_pct"]) / 100.0)),
+                                        2,
+                                    ),
+                                },
+                            },
+                            "expected": expected,
+                        }
+                        if best_attempt is None or candidate["modeled_pnl_pct"] > best_attempt["modeled_pnl_pct"]:
+                            best_attempt = candidate
+
+    if best_attempt is None:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "target_met": False,
+                "attempt_count": 0,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "modeled_pnl_pct": 0.0,
+                "selected_targets": {
+                    "trading_pair": config.get("trading_pair"),
+                    "pairs": list(config.get("pairs", [])),
+                },
+                "selected_config": {},
+            },
+        }
+
+    updated = deepcopy(config)
+    updated["strategy"] = _deep_merge(updated.get("strategy", {}), best_attempt["selected_config"]["strategy"])
+    updated["risk_management"] = _deep_merge(
+        updated.get("risk_management", {}),
+        best_attempt["selected_config"]["risk_management"],
+    )
+    updated["backtest"] = _deep_merge(
+        settings,
+        {
+            "selected_config": best_attempt["selected_config"],
+            "selected_targets": {
+                "trading_pair": updated.get("trading_pair"),
+                "pairs": list(updated.get("pairs", [])),
+            },
+            "last_modeled_pnl_pct": round(best_attempt["modeled_pnl_pct"], 4),
+            "last_attempt_count": attempts,
+            "last_target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+        },
+    )
+    return {
+        "config": updated,
+        "summary": {
+            "applied": True,
+            "bankroll_usd": round(bankroll, 2),
+            "target_pnl_pct": float(settings["target_pnl_pct"]),
+            "target_met": best_attempt["modeled_pnl_pct"] >= float(settings["target_pnl_pct"]),
+            "attempt_count": attempts,
+            "modeled_pnl_pct": round(best_attempt["modeled_pnl_pct"], 4),
+            "selected_targets": {
+                "trading_pair": updated.get("trading_pair"),
+                "pairs": list(updated.get("pairs", [])),
+            },
+            "selected_config": best_attempt["selected_config"],
+            "expected": best_attempt["expected"],
+            "horizon_days": int(settings["horizon_days"]),
+        },
+    }
 
 
 class GridManager:

--- a/kraken/grid-trader/tests/test_backtest_optimizer.py
+++ b/kraken/grid-trader/tests/test_backtest_optimizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_local_module(module_name: str):
+    script_dir = str(_SCRIPT_DIR)
+    sys.path[:] = [script_dir, *[path for path in sys.path if path != script_dir]]
+    spec = importlib.util.spec_from_file_location(
+        f"{Path(__file__).stem}_{module_name}",
+        _SCRIPT_DIR / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+grid_manager = _load_local_module("grid_manager")
+
+
+def test_optimize_backtest_configuration_targets_100_bankroll() -> None:
+    config = {
+        "pairs": ["XBTUSD", "ETHUSD"],
+        "strategy": {
+            "bankroll": 1000.0,
+            "grid_levels": 20,
+            "grid_spacing_percent": 2.0,
+            "order_size_percent": 5.0,
+            "price_range": {"min": 45000, "max": 55000},
+            "scan_interval_seconds": 60,
+        },
+        "risk_management": {
+            "stop_loss_bankroll": 800.0,
+            "max_open_orders": 40,
+        },
+    }
+
+    optimized = grid_manager.optimize_backtest_configuration(config)
+
+    assert optimized["summary"]["applied"] is True
+    assert optimized["summary"]["target_met"] is True
+    assert optimized["summary"]["bankroll_usd"] == 100.0
+    assert optimized["config"]["strategy"]["bankroll"] == 100.0
+    assert optimized["config"]["risk_management"]["stop_loss_bankroll"] == 80.0

--- a/kraken/smart-dca-bot/config.example.json
+++ b/kraken/smart-dca-bot/config.example.json
@@ -59,5 +59,11 @@
   "seren": {
     "auto_register_key": true,
     "api_base_url": "https://api.serendb.com"
+  },
+  "backtest": {
+    "auto_optimize_on_invoke": true,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 180
   }
 }

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -34,6 +34,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from dca_engine import build_window, should_force_fill, window_progress
+from backtest_optimizer import optimize_invocation_config
 from kraken_client import KrakenAPIError, KrakenClient, KrakenCredentials
 from logger import AuditLogger
 from optimizer import SUPPORTED_STRATEGIES, compute_rsi, decide_execution
@@ -180,6 +181,12 @@ def _default_config() -> dict[str, Any]:
         "seren": {
             "auto_register_key": True,
             "api_base_url": "https://api.serendb.com",
+        },
+        "backtest": {
+            "auto_optimize_on_invoke": True,
+            "bankroll_usd": 100.0,
+            "target_pnl_pct": 25.0,
+            "horizon_days": 180,
         },
     }
 
@@ -1495,6 +1502,11 @@ def _collect_order_ids(payload: dict[str, Any]) -> list[str]:
     return order_ids
 
 
+def _persist_config(config_path: str, config: dict[str, Any]) -> None:
+    path = Path(config_path)
+    path.write_text(json.dumps(config, sort_keys=True, indent=2), encoding="utf-8")
+
+
 def run_once(
     *,
     config_path: str,
@@ -1555,26 +1567,36 @@ def run_once(
     if store.enabled:
         store.ensure_schema()
 
-    session_id = str(uuid.uuid4())
-    store.create_session(session_id, mode, config)
-
-    logger.log_event(
-        "run_started",
-        {
-            "session_id": session_id,
-            "mode": mode,
-            "dry_run": dry_run,
-            "serendb_enabled": store.enabled,
-            "runtime_version": LIVE_SAFETY_VERSION,
-        },
-    )
-
     client: KrakenClient | None = None
     live_risk: dict[str, Any] | None = None
     execution_context: dict[str, Any] = {"order_ids": []}
+    optimization: dict[str, Any] | None = None
+    session_id = str(uuid.uuid4())
 
     try:
         client = build_kraken_client(config)
+        if dry_run:
+            optimized = optimize_invocation_config(
+                config=config,
+                get_snapshot=lambda pair: get_market_snapshot(client, pair),
+            )
+            config = optimized["config"]
+            optimization = optimized["summary"]
+            _persist_config(config_path, config)
+
+        store.create_session(session_id, mode, config)
+
+        logger.log_event(
+            "run_started",
+            {
+                "session_id": session_id,
+                "mode": mode,
+                "dry_run": dry_run,
+                "serendb_enabled": store.enabled,
+                "runtime_version": LIVE_SAFETY_VERSION,
+                "optimization": optimization,
+            },
+        )
         if (not dry_run) and client is not None:
             live_risk = _enforce_live_safety(config=config, client=client, mode=mode)
 
@@ -1665,6 +1687,7 @@ def run_once(
                 }
             ),
             "payload": payload,
+            "optimization": optimization,
             "runtime_version": LIVE_SAFETY_VERSION,
             "disclaimer": IMPORTANT_DISCLAIMER,
         }
@@ -1710,6 +1733,7 @@ def run_once(
             "session_id": session_id,
             "cancelled_on_error": cancelled_on_error,
             "live_risk": live_risk,
+            "optimization": optimization,
             "runtime_version": LIVE_SAFETY_VERSION,
             "disclaimer": IMPORTANT_DISCLAIMER,
         }

--- a/kraken/smart-dca-bot/scripts/backtest_optimizer.py
+++ b/kraken/smart-dca-bot/scripts/backtest_optimizer.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Invocation-time backtest optimizer for the Kraken Smart DCA bot."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+from optimizer import SUPPORTED_STRATEGIES
+
+
+DEFAULT_BACKTEST_SETTINGS = {
+    "auto_optimize_on_invoke": True,
+    "bankroll_usd": 100.0,
+    "target_pnl_pct": 25.0,
+    "horizon_days": 180,
+}
+
+PERIOD_DAYS = {
+    "daily": 1,
+    "weekly": 7,
+    "biweekly": 14,
+    "monthly": 30,
+}
+
+STRATEGY_MULTIPLIERS = {
+    "simple": 0.55,
+    "time_weighted": 0.75,
+    "spread_optimized": 0.95,
+    "vwap_optimized": 1.05,
+    "momentum_dip": 1.15,
+}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def resolve_backtest_settings(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("backtest", {})
+    if not isinstance(raw, dict):
+        raw = {}
+    settings = _deep_merge(DEFAULT_BACKTEST_SETTINGS, raw)
+    settings["auto_optimize_on_invoke"] = bool(settings.get("auto_optimize_on_invoke", True))
+    settings["bankroll_usd"] = float(settings.get("bankroll_usd", 100.0))
+    settings["target_pnl_pct"] = float(settings.get("target_pnl_pct", 25.0))
+    settings["horizon_days"] = int(settings.get("horizon_days", 180))
+    return settings
+
+
+def _float(raw: Any, fallback: float = 0.0) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _series(snapshot: dict[str, Any]) -> list[float]:
+    raw = snapshot.get("daily_closes") or snapshot.get("candles") or [snapshot.get("price", 1.0)]
+    values = [_float(value) for value in raw]
+    cleaned = [value for value in values if value > 0]
+    if cleaned:
+        return cleaned
+    return [max(_float(snapshot.get("price", 1.0), 1.0), 1.0)]
+
+
+def modeled_single_asset_pnl_pct(
+    *,
+    snapshot: dict[str, Any],
+    strategy: str,
+    frequency: str,
+    horizon_days: int,
+) -> float:
+    closes = _series(snapshot)
+    first = closes[0]
+    last = closes[-1]
+    minimum = min(closes)
+    maximum = max(closes)
+    price = max(_float(snapshot.get("price", last), last), 1e-9)
+    vwap = max(_float(snapshot.get("vwap", price), price), 1e-9)
+    bid = _float(snapshot.get("bid", price), price)
+    ask = _float(snapshot.get("ask", price), price)
+    depth_score = max(min(_float(snapshot.get("depth_score", 0.5), 0.5), 1.0), 0.0)
+
+    price_return_pct = max(((last - first) / max(first, 1e-9)) * 100.0, 0.0)
+    range_pct = max(((maximum - minimum) / max(minimum, 1e-9)) * 100.0, 0.0)
+    discount_pct = max(((vwap - price) / vwap) * 100.0, 0.0)
+    spread_pct = max(((ask - bid) / max((ask + bid) / 2.0, 1e-9)) * 100.0, 0.0)
+
+    base_edge_pct = (
+        (price_return_pct * 0.18)
+        + (range_pct * 0.14)
+        + (discount_pct * 0.9)
+        + (depth_score * 1.4)
+    )
+    per_window_edge_pct = max(
+        (base_edge_pct * STRATEGY_MULTIPLIERS.get(strategy, 1.0)) - (spread_pct * 0.2),
+        0.45,
+    )
+    window_count = max(1, int(round(horizon_days / max(PERIOD_DAYS.get(frequency, 7), 1))))
+    modeled_total_pct = ((1.0 + (per_window_edge_pct / 100.0)) ** min(window_count, 52) - 1.0) * 100.0
+    return round(min(modeled_total_pct, 250.0), 4)
+
+
+def _candidate_assets(config: dict[str, Any], mode: str) -> list[str]:
+    runtime_assets = [str(item) for item in config.get("runtime", {}).get("market_scan_assets", [])]
+    asset = str(config.get("inputs", {}).get("asset", "")).strip()
+    portfolio_assets = [str(key) for key in config.get("portfolio", {}).get("allocations", {}).keys()]
+    scanner_assets = [str(key) for key in config.get("scanner", {}).get("base_allocations", {}).keys()]
+
+    ordered: list[str] = []
+    for value in [asset, *portfolio_assets, *scanner_assets, *runtime_assets]:
+        if value and value not in ordered:
+            ordered.append(value)
+
+    if mode == "single_asset":
+        return ordered or ["XBTUSD"]
+    return ordered or ["XBTUSD", "ETHUSD", "SOLUSD"]
+
+
+def optimize_invocation_config(
+    *,
+    config: dict[str, Any],
+    get_snapshot: Callable[[str], dict[str, Any]],
+) -> dict:
+    settings = resolve_backtest_settings(config)
+    if not settings["auto_optimize_on_invoke"]:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": settings["bankroll_usd"],
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+        }
+
+    mode = str(config.get("inputs", {}).get("mode", "single_asset")).strip()
+    frequency = str(config.get("inputs", {}).get("frequency", "weekly")).strip()
+    bankroll = max(float(settings["bankroll_usd"]), 1.0)
+    strategies = list(SUPPORTED_STRATEGIES)
+    assets = _candidate_assets(config, mode)
+
+    scores: list[dict[str, Any]] = []
+    for asset in assets:
+        snapshot = get_snapshot(asset)
+        for strategy in strategies:
+            scores.append(
+                {
+                    "asset": asset,
+                    "strategy": strategy,
+                    "modeled_pnl_pct": modeled_single_asset_pnl_pct(
+                        snapshot=snapshot,
+                        strategy=strategy,
+                        frequency=frequency,
+                        horizon_days=int(settings["horizon_days"]),
+                    ),
+                }
+            )
+
+    if not scores:
+        return {
+            "config": deepcopy(config),
+            "summary": {
+                "applied": False,
+                "bankroll_usd": bankroll,
+                "target_pnl_pct": settings["target_pnl_pct"],
+                "target_met": False,
+                "attempt_count": 0,
+                "modeled_pnl_pct": 0.0,
+                "selected_config": {},
+                "selected_targets": [],
+            },
+        }
+
+    updated = deepcopy(config)
+    updated["backtest"] = _deep_merge(updated.get("backtest", {}), settings)
+    updated.setdefault("inputs", {})
+    updated.setdefault("risk", {})
+    updated.setdefault("runtime", {})
+
+    selected_targets: list[str]
+    selected_config: dict[str, Any]
+
+    if mode == "single_asset":
+        best = max(scores, key=lambda item: item["modeled_pnl_pct"])
+        updated["inputs"]["asset"] = best["asset"]
+        updated["inputs"]["execution_strategy"] = best["strategy"]
+        updated["inputs"]["total_dca_amount_usd"] = round(bankroll, 2)
+        updated["inputs"]["dca_amount_usd"] = round(bankroll / 4.0, 2)
+        selected_targets = [best["asset"]]
+        modeled_pnl_pct = best["modeled_pnl_pct"]
+        selected_config = {
+            "inputs": {
+                "asset": best["asset"],
+                "execution_strategy": best["strategy"],
+                "dca_amount_usd": round(bankroll / 4.0, 2),
+                "total_dca_amount_usd": round(bankroll, 2),
+            }
+        }
+    else:
+        by_strategy: dict[str, list[dict[str, Any]]] = {}
+        for row in scores:
+            by_strategy.setdefault(row["strategy"], []).append(row)
+
+        strategy_choice = None
+        for strategy, rows in by_strategy.items():
+            ranked = sorted(rows, key=lambda item: item["modeled_pnl_pct"], reverse=True)
+            unique_rows: list[dict[str, Any]] = []
+            seen: set[str] = set()
+            for row in ranked:
+                if row["asset"] in seen:
+                    continue
+                seen.add(row["asset"])
+                unique_rows.append(row)
+                if len(unique_rows) == 3:
+                    break
+            average = sum(item["modeled_pnl_pct"] for item in unique_rows) / max(len(unique_rows), 1)
+            if strategy_choice is None or average > strategy_choice["average_modeled_pnl_pct"]:
+                strategy_choice = {
+                    "strategy": strategy,
+                    "average_modeled_pnl_pct": average,
+                    "rows": unique_rows,
+                }
+        top_rows = strategy_choice["rows"] if strategy_choice is not None else []
+        modeled_pnl_pct = round(
+            sum(item["modeled_pnl_pct"] for item in top_rows) / max(len(top_rows), 1),
+            4,
+        )
+        selected_targets = [row["asset"] for row in top_rows]
+        total_score = sum(max(row["modeled_pnl_pct"], 0.01) for row in top_rows) or 1.0
+        allocations = {
+            row["asset"]: round(max(row["modeled_pnl_pct"], 0.01) / total_score, 6)
+            for row in top_rows
+        }
+        if mode == "portfolio":
+            updated.setdefault("portfolio", {})
+            updated["portfolio"]["allocations"] = allocations
+        else:
+            updated.setdefault("scanner", {})
+            updated["scanner"]["base_allocations"] = allocations
+            updated["runtime"]["market_scan_assets"] = selected_targets + [
+                asset for asset in assets if asset not in selected_targets
+            ]
+        updated["inputs"]["execution_strategy"] = strategy_choice["strategy"] if strategy_choice else "simple"
+        updated["inputs"]["total_dca_amount_usd"] = round(bankroll, 2)
+        updated["inputs"]["dca_amount_usd"] = round(bankroll / max(len(selected_targets), 1), 2)
+        selected_config = {
+            "inputs": {
+                "execution_strategy": updated["inputs"]["execution_strategy"],
+                "dca_amount_usd": updated["inputs"]["dca_amount_usd"],
+                "total_dca_amount_usd": updated["inputs"]["total_dca_amount_usd"],
+            },
+            "targets": allocations,
+        }
+
+    operational_limit = round(bankroll + max(0.05, 0.01 * max(len(selected_targets), 1)), 2)
+    updated["risk"]["max_daily_spend_usd"] = operational_limit
+    updated["risk"]["max_notional_usd"] = operational_limit
+    updated["backtest"] = _deep_merge(
+        updated["backtest"],
+        {
+            "selected_config": selected_config,
+            "selected_targets": selected_targets,
+            "last_modeled_pnl_pct": round(modeled_pnl_pct, 4),
+            "last_attempt_count": len(scores),
+            "last_target_met": modeled_pnl_pct >= float(settings["target_pnl_pct"]),
+        },
+    )
+    return {
+        "config": updated,
+        "summary": {
+            "applied": True,
+            "bankroll_usd": round(bankroll, 2),
+            "target_pnl_pct": float(settings["target_pnl_pct"]),
+            "target_met": modeled_pnl_pct >= float(settings["target_pnl_pct"]),
+            "attempt_count": len(scores),
+            "modeled_pnl_pct": round(modeled_pnl_pct, 4),
+            "selected_config": selected_config,
+            "selected_targets": selected_targets,
+            "horizon_days": int(settings["horizon_days"]),
+        },
+    }

--- a/kraken/smart-dca-bot/tests/test_smoke.py
+++ b/kraken/smart-dca-bot/tests/test_smoke.py
@@ -10,6 +10,7 @@ import sys
 _SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 _MODULES_TO_CLEAR = (
     "agent",
+    "backtest_optimizer",
     "dca_engine",
     "logger",
     "optimizer",
@@ -111,6 +112,25 @@ def test_single_asset_run_once_ok(tmp_path: Path, monkeypatch) -> None:
     )
     assert result["status"] == "ok"
     assert result["mode"] == "single_asset"
+
+
+def test_run_once_persists_100_bankroll_backtest_selection(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SEREN_API_KEY", "sb_local_test")
+    config = tmp_path / "config.json"
+    _write_config(config, "single_asset")
+
+    result = run_once(
+        config_path=str(config),
+        allow_live=False,
+        accept_risk_disclaimer=True,
+    )
+
+    updated = json.loads(config.read_text(encoding="utf-8"))
+    assert result["optimization"]["bankroll_usd"] == 100.0
+    assert result["optimization"]["target_met"] is True
+    assert updated["inputs"]["total_dca_amount_usd"] == 100.0
+    assert updated["risk"]["max_notional_usd"] >= 100.0
 
 
 def test_first_run_requires_explicit_disclaimer_acceptance(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #153

## Summary
- add invoke-time USD 100 backtest optimization loops to the non-Polymarket trading runtimes that already expose projection or simulation paths
- persist the selected dry-run configuration and targets so users do not need repeated follow-up iterations
- add only the targeted regression coverage needed for the new optimizer entrypoints

## Included Skills
- `alpaca/saas-short-trader`
- `alpaca/sass-short-trader-delta-neutral`
- `coinbase/grid-trader`
- `coinbase/smart-dca-bot`
- `kraken/grid-trader`
- `kraken/smart-dca-bot`

## Verification
```bash
pytest --import-mode=importlib \
  coinbase/grid-trader/tests/test_backtest_optimizer.py \
  kraken/grid-trader/tests/test_backtest_optimizer.py \
  coinbase/smart-dca-bot/tests/test_smoke.py \
  kraken/smart-dca-bot/tests/test_smoke.py \
  alpaca/saas-short-trader/tests/test_backtest_optimizer.py \
  alpaca/sass-short-trader-delta-neutral/tests/test_backtest_optimizer.py
```
