### PR TITLE
fix(polymarket): raise max_iterations defaults to 15

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -42,7 +42,7 @@
     "optimization": {
       "enabled": true,
       "target_return_pct": 25.0,
-      "max_iterations": 8
+      "max_iterations": 15
     },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -120,7 +120,7 @@ class BacktestParams:
 class OptimizationParams:
     enabled: bool = True
     target_return_pct: float = 25.0
-    max_iterations: int = 8
+    max_iterations: int = 15
 
 
 def parse_args() -> argparse.Namespace:
@@ -306,7 +306,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
     return OptimizationParams(
         enabled=_safe_bool(raw.get("enabled"), True),
         target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
-        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 15)),
     )
 
 

--- a/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
@@ -76,10 +76,12 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
+    optimization_defaults = module.to_optimization_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
     assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
+    assert optimization_defaults.max_iterations == payload["backtest"]["optimization"]["max_iterations"] == 15
 
     primary, pair = _synthetic_pair_series()
     synthetic_markets = [

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -42,7 +42,7 @@
     "optimization": {
       "enabled": true,
       "target_return_pct": 25.0,
-      "max_iterations": 8
+      "max_iterations": 15
     },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -127,7 +127,7 @@ class BacktestParams:
 class OptimizationParams:
     enabled: bool = True
     target_return_pct: float = 25.0
-    max_iterations: int = 8
+    max_iterations: int = 15
 
 
 def parse_args() -> argparse.Namespace:
@@ -314,7 +314,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
     return OptimizationParams(
         enabled=_safe_bool(raw.get("enabled"), True),
         target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
-        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 15)),
     )
 
 

--- a/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
@@ -75,10 +75,12 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
+    optimization_defaults = module.to_optimization_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
     assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
+    assert optimization_defaults.max_iterations == payload["backtest"]["optimization"]["max_iterations"] == 15
 
     primary, pair = _synthetic_pair_series()
     synthetic_markets = [

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -35,7 +35,7 @@
     "optimization": {
       "enabled": true,
       "target_return_pct": 25.0,
-      "max_iterations": 8
+      "max_iterations": 15
     },
     "predictions_enabled": false,
     "predictions_skew_strength_bps": 15,

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -107,7 +107,7 @@ class BacktestParams:
 class OptimizationParams:
     enabled: bool = True
     target_return_pct: float = 25.0
-    max_iterations: int = 8
+    max_iterations: int = 15
 
 
 @dataclass(frozen=True)
@@ -384,7 +384,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
     return OptimizationParams(
         enabled=bool(raw.get("enabled", True)),
         target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
-        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 15)),
     )
 
 

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -325,6 +325,7 @@ def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
     backtest = payload.get("backtest", {})
     assert agent.to_backtest_params({}).bankroll_usd == backtest.get("bankroll_usd") == 100
+    assert agent.to_optimization_params({}).max_iterations == backtest["optimization"]["max_iterations"] == 15
     assert backtest.get("gamma_markets_url", "").startswith(
         "https://api.serendb.com/publishers/polymarket-data/"
     )

--- a/polymarket/paired-market-basis-maker/config.example.json
+++ b/polymarket/paired-market-basis-maker/config.example.json
@@ -42,7 +42,7 @@
     "optimization": {
       "enabled": true,
       "target_return_pct": 25.0,
-      "max_iterations": 8
+      "max_iterations": 15
     },
     "gamma_markets_url": "https://api.serendb.com/publishers/polymarket-data/markets",
     "clob_history_url": "https://clob.polymarket.com/prices-history"

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -120,7 +120,7 @@ class BacktestParams:
 class OptimizationParams:
     enabled: bool = True
     target_return_pct: float = 25.0
-    max_iterations: int = 8
+    max_iterations: int = 15
 
 
 def parse_args() -> argparse.Namespace:
@@ -306,7 +306,7 @@ def to_optimization_params(config: dict[str, Any]) -> OptimizationParams:
     return OptimizationParams(
         enabled=_safe_bool(raw.get("enabled"), True),
         target_return_pct=_safe_float(raw.get("target_return_pct"), 25.0),
-        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 8)),
+        max_iterations=max(1, _safe_int(raw.get("max_iterations"), 15)),
     )
 
 

--- a/polymarket/paired-market-basis-maker/tests/test_smoke.py
+++ b/polymarket/paired-market-basis-maker/tests/test_smoke.py
@@ -75,10 +75,12 @@ def test_config_example_runs_stateful_backtest_and_reports_replay_metrics(monkey
 
     defaults = module.to_strategy_params({})
     backtest_defaults = module.to_backtest_params({})
+    optimization_defaults = module.to_optimization_params({})
     assert defaults.bankroll_usd == payload["strategy"]["bankroll_usd"] == 1000
     assert backtest_defaults.bankroll_usd == payload["backtest"]["bankroll_usd"] == 100
     assert defaults.base_pair_notional_usd == payload["strategy"]["base_pair_notional_usd"]
     assert backtest_defaults.participation_rate == payload["backtest"]["participation_rate"]
+    assert optimization_defaults.max_iterations == payload["backtest"]["optimization"]["max_iterations"] == 15
 
     primary, pair = _synthetic_pair_series()
     synthetic_markets = [


### PR DESCRIPTION
## Summary
- raise Polymarket `max_iterations` defaults from `8` to `15` in runtime fallbacks and example configs
- pin the new default in the existing smoke suites for the affected skills

## Verification
- `rg -n 'max_iterations[^0-9]*8|"max_iterations"\\s*:\\s*8|max_iterations\\s*=\\s*8' polymarket`\n- `pytest --import-mode=importlib polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py::test_config_example_runs_stateful_backtest_and_reports_replay_metrics polymarket/liquidity-paired-basis-maker/tests/test_smoke.py::test_config_example_runs_stateful_backtest_and_reports_replay_metrics polymarket/paired-market-basis-maker/tests/test_smoke.py::test_config_example_runs_stateful_backtest_and_reports_replay_metrics polymarket/maker-rebate-bot/tests/test_smoke.py::test_config_example_uses_seren_polymarket_publisher_urls`\n\nCloses #155