### PR TITLE
fix(polymarket): detect missing NegRiskAdapter approvals before neg-risk orders

### DIFF
--- a/polymarket/_shared/polymarket_live.py
+++ b/polymarket/_shared/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0

--- a/polymarket/bot/scripts/polymarket_live.py
+++ b/polymarket/bot/scripts/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0

--- a/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0

--- a/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -630,3 +630,36 @@ def test_unwind_all_requires_yes_live() -> None:
         unwind_all=True, markets_file=None, backtest_file=None, backtest_days=None,
     )
     assert hasattr(args, "unwind_all")
+
+
+def test_check_neg_risk_approvals_returns_structured_result() -> None:
+    """#159: check_neg_risk_approvals returns actionable errors for missing approvals."""
+    live = _load_live_module()
+    assert hasattr(live, "check_neg_risk_approvals")
+    assert hasattr(live, "POLYGON_NEG_RISK_ADAPTER")
+    assert live.POLYGON_NEG_RISK_ADAPTER == "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+    # Test with a zero-address wallet (no approvals) against a non-responding RPC
+    result = live.check_neg_risk_approvals(
+        "0x0000000000000000000000000000000000000000",
+        rpc_url="http://127.0.0.1:1",  # unreachable — forces 0x0 fallback
+        timeout_seconds=1.0,
+    )
+    assert isinstance(result, dict)
+    assert result["checks_passed"] is False
+    assert len(result["errors"]) >= 1
+    assert "NegRiskAdapter" in result["errors"][0]
+
+
+def test_neg_risk_market_skipped_when_approvals_missing() -> None:
+    """#159: Neg-risk markets are skipped with actionable error when approvals missing."""
+    live = _load_live_module()
+    # Verify the skip reason string exists in the code
+    import inspect
+    source = inspect.getsource(live.execute_single_market_quotes)
+    assert "neg_risk_approval_missing" in source
+
+
+def test_direct_clob_trader_has_preflight_neg_risk() -> None:
+    """#159: DirectClobTrader exposes preflight_neg_risk method."""
+    live = _load_live_module()
+    assert hasattr(live.DirectClobTrader, "preflight_neg_risk")

--- a/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
@@ -27,8 +27,17 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v2"
+LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
 USDC_DECIMALS = 6
+
+# Polymarket contract addresses on Polygon mainnet
+POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+POLYGON_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+POLYGON_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+POLYGON_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+POLYGON_CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ERC20_ALLOWANCE_ABI_FRAGMENT = "0xdd62ed3e"  # allowance(address,address)
+ERC1155_IS_APPROVED_ABI_FRAGMENT = "0xe985e9c5"  # isApprovedForAll(address,address)
 
 
 def maybe_load_dotenv(skill_root: Path) -> None:
@@ -1051,6 +1060,78 @@ class PolymarketPublisherTrader:
         return self._call("GET", "/positions")
 
 
+def check_neg_risk_approvals(
+    wallet_address: str,
+    *,
+    rpc_url: str = "https://polygon-rpc.com",
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
+
+    Returns a dict with approval status and actionable error messages.
+    Does not revert or block — callers decide how to handle missing approvals.
+    """
+    results: dict[str, Any] = {
+        "wallet": wallet_address,
+        "neg_risk_adapter": POLYGON_NEG_RISK_ADAPTER,
+        "usdc_approved": False,
+        "ct_approved": False,
+        "checks_passed": False,
+        "errors": [],
+    }
+
+    wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
+    adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
+
+    def _eth_call(to: str, data: str) -> str:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urlopen(req, timeout=timeout_seconds) as resp:
+                body = json.loads(resp.read())
+                return safe_str(body.get("result"), "0x0")
+        except Exception:
+            return "0x0"
+
+    # Check USDC.e allowance to NegRiskAdapter
+    usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_allowance = int(usdc_result, 16)
+    except (ValueError, TypeError):
+        usdc_allowance = 0
+    results["usdc_allowance_raw"] = usdc_allowance
+    results["usdc_approved"] = usdc_allowance > 10 ** USDC_DECIMALS  # > 1 USDC.e
+
+    # Check CT isApprovedForAll to NegRiskAdapter
+    ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
+    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_approved = int(ct_result, 16) > 0
+    except (ValueError, TypeError):
+        ct_approved = False
+    results["ct_approved"] = ct_approved
+
+    if not results["usdc_approved"]:
+        results["errors"].append(
+            f"USDC.e ({POLYGON_USDC_E}) is not approved for NegRiskAdapter "
+            f"({POLYGON_NEG_RISK_ADAPTER}). Neg-risk market orders will fail with "
+            f"'not enough balance / allowance'. Run: approve(NegRiskAdapter, MAX_UINT256) "
+            f"on USDC.e contract."
+        )
+    if not results["ct_approved"]:
+        results["errors"].append(
+            f"Conditional Tokens ({POLYGON_CONDITIONAL_TOKENS}) setApprovalForAll is not "
+            f"set for NegRiskAdapter ({POLYGON_NEG_RISK_ADAPTER}). Neg-risk SELL orders "
+            f"will fail. Run: setApprovalForAll(NegRiskAdapter, true) on CT contract."
+        )
+    results["checks_passed"] = results["usdc_approved"] and results["ct_approved"]
+    return results
+
+
 class DirectClobTrader:
     """Direct Polymarket CLOB client for local py-clob-client execution."""
 
@@ -1105,6 +1186,22 @@ class DirectClobTrader:
             creds=creds,
         )
         self.address = safe_str(self._client.get_address(), "").lower()
+        self._neg_risk_checked = False
+        self._neg_risk_approval_status: dict[str, Any] | None = None
+
+    def preflight_neg_risk(self) -> dict[str, Any]:
+        """Check NegRiskAdapter approvals. Caches result for the session."""
+        if self._neg_risk_checked:
+            return self._neg_risk_approval_status or {"checks_passed": True}
+        self._neg_risk_checked = True
+        try:
+            self._neg_risk_approval_status = check_neg_risk_approvals(self.address)
+        except Exception as exc:
+            self._neg_risk_approval_status = {
+                "checks_passed": False,
+                "errors": [f"Approval check failed: {exc}"],
+            }
+        return self._neg_risk_approval_status
 
     def create_order(
         self,
@@ -1573,6 +1670,20 @@ def execute_single_market_quotes(
             token_id = safe_str(market.get("token_id"), safe_str(market.get("market_id"), ""))
             tick_size = safe_str(market.get("tick_size"), "0.01")
             neg_risk = bool(market.get("neg_risk", False))
+            if neg_risk and hasattr(trader, "preflight_neg_risk"):
+                nr_status = trader.preflight_neg_risk()
+                if not nr_status.get("checks_passed", True):
+                    skips.append({
+                        "market_id": market["market_id"],
+                        "reason": "neg_risk_approval_missing",
+                        "errors": nr_status.get("errors", []),
+                        "hint": (
+                            f"Approve USDC.e and CT to NegRiskAdapter "
+                            f"({POLYGON_NEG_RISK_ADAPTER}) on Polygon. "
+                            f"See issue #159 for details."
+                        ),
+                    })
+                    continue
             fee_rate_bps = fetch_fee_rate_bps(token_id)
             fallback_notional = max(0.0, safe_float(quote.get("quote_notional_usd"), 0.0))
             bid_notional = max(0.0, safe_float(quote.get("bid_notional_usd"), fallback_notional))
@@ -1900,6 +2011,12 @@ def execute_pair_trades(
                         "notional_usd": round(notional, 4),
                     }
                 )
+
+            if not skip_reason and any(ls.get("neg_risk") for ls in leg_specs):
+                if hasattr(trader, "preflight_neg_risk"):
+                    nr_status = trader.preflight_neg_risk()
+                    if not nr_status.get("checks_passed", True):
+                        skip_reason = "neg_risk_approval_missing"
 
             if not skip_reason and (
                 execution_settings.min_cash_reserve_usd > 0.0


### PR DESCRIPTION
## Summary

- Add `check_neg_risk_approvals()` — queries on-chain USDC.e allowance and CT isApprovedForAll to NegRiskAdapter (`0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`)
- Add `preflight_neg_risk()` to DirectClobTrader (cached per session, no repeated RPC calls)
- Skip neg-risk markets with `neg_risk_approval_missing` reason and actionable error messages when approvals are missing
- Check integrated into both `execute_single_market_quotes` and `execute_pair_trades`
- Contract address constants added for all Polymarket Polygon contracts

Applied across all 5 Polymarket skills + _shared.

## Test plan

- [x] 23/23 tests pass
- [x] All polymarket_live.py copies identical (md5 verified)
- [x] check_neg_risk_approvals returns structured errors for zero-address wallet
- [x] neg_risk_approval_missing skip reason present in execution code
- [x] DirectClobTrader.preflight_neg_risk method exists

Closes #159

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com