### PR TITLE
feat(skills): externalize runtime config paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,16 +65,18 @@ Seren repo conventions:
 Skills with executable code should include:
 
 - `scripts/` - executable code (for example, `scripts/agent.py`, `scripts/index.js`, `scripts/run.sh`)
+- `scripts/runtime_paths.py` - generated helper for runtime config resolution when the skill needs stable runtime paths
 - `requirements.txt` (python) or `package.json` (node) at skill root when needed
 - `config.example.json` at skill root when needed
 - `.env.example` at skill root when needed
-- `.gitignore` for local config and secrets
+- `.gitignore` for repo-local development files and secrets
 
 ```
 coinbase/grid-trader/
 ├── SKILL.md               # Required - skill documentation
 ├── scripts/
-│   └── grid_trader.py     # Runtime code
+│   ├── grid_trader.py     # Runtime code
+│   └── runtime_paths.py   # Generated from seren/skill-runtime when needed
 ├── requirements.txt       # Python dependencies
 ├── package.json           # Node dependencies
 ├── config.example.json    # Configuration template
@@ -82,7 +84,65 @@ coinbase/grid-trader/
 ```
 
 Keep dependency/config templates (`requirements.txt`, `package.json`, `config.example.json`, `.env.example`) at the skill root, not inside `scripts/`.
-Local `config.json` should also live at the skill root and be gitignored.
+Do not assume real `config.json` or `.env` files live in the installed skill directory. Seren refreshes installed skills by replacing the managed directory, so user-owned runtime files must live outside it:
+
+- shared runtime root:
+  - macOS/Linux: `$XDG_CONFIG_HOME/seren` with `~/.config/seren` fallback
+  - Windows: `%APPDATA%\seren`
+- global skill runtime files: `$SEREN_CONFIG_DIR/skills-data/<slug>/`
+- project overrides: `<project>/.seren/skills-data/<slug>/`
+
+Use `config.example.json` and `.env.example` as templates only. Skill runtimes should accept explicit `--config` and `--env-file` paths, or equivalent environment variables, so `seren` and `seren-desktop` can pass files from the runtime directory.
+
+For Python skills, prefer generating a local `scripts/runtime_paths.py` from [`seren/skill-runtime`](./seren/skill-runtime/) and then using `activate_runtime()` near process start:
+
+```python
+from runtime_paths import activate_runtime
+
+args.config = str(activate_runtime(args.config))
+```
+
+That pattern gives you:
+
+- project override support via `<project>/.seren/skills-data/<slug>/`
+- shared runtime config under XDG / `%APPDATA%`
+- legacy skill-root fallback with a deprecation warning
+- relative `state/` and `logs/` paths rooted in the runtime directory instead of the installed skill directory
+
+If you are not using the shared helper yet, keep the resolution order simple. Resolve the env file in this order:
+
+1. `--env-file` CLI argument
+2. project override: `<project>/.seren/skills-data/<slug>/.env`
+3. shared config root:
+   - macOS/Linux: `$XDG_CONFIG_HOME/seren/skills-data/<slug>/.env`
+   - Windows: `%APPDATA%\seren\skills-data\<slug>\.env`
+4. fallback on macOS/Linux: `~/.config/seren/skills-data/<slug>/.env`
+
+Minimal helper pattern:
+
+```python
+from pathlib import Path
+import os
+
+
+def default_skill_env_path(slug: str, project_root: str | None = None) -> Path:
+    if project_root:
+        project_env = Path(project_root) / ".seren" / "skills-data" / slug / ".env"
+        if project_env.exists():
+            return project_env
+
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        return Path(appdata) / "seren" / "skills-data" / slug / ".env"
+
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        return Path(xdg_config_home) / "seren" / "skills-data" / slug / ".env"
+
+    return Path.home() / ".config" / "seren" / "skills-data" / slug / ".env"
+```
+
+Then pass the resolved path to `load_dotenv()` or your own parser if the file exists. If your skill uses the shared `activate_runtime()` pattern, relative `state/` and `logs/` paths will follow the runtime directory automatically.
 
 Documentation-only skills only need `SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,41 @@ Seren Desktop consumes skills by slug in a flat namespace.
 org/skill-name/
 ├── SKILL.md               # Required - docs and frontmatter
 ├── scripts/               # Executable code (agent skills only)
-│   └── agent.py
+│   ├── agent.py
+│   └── runtime_paths.py   # Generated helper for runtime config resolution
 ├── requirements.txt       # Python dependencies
 ├── package.json           # Node dependencies
 ├── config.example.json    # Config template (optional)
 └── .env.example           # Environment template (optional)
 ```
+
+Mutable skill configuration files do not belong in the installed skill directory. Seren-managed skill installs are replaceable, so real `config.json` and `.env` files should live outside the install tree:
+
+- shared runtime root:
+  - macOS/Linux: `$XDG_CONFIG_HOME/seren` with `~/.config/seren` as the fallback
+  - Windows: `%APPDATA%\seren`
+- global skill runtime files: `$SEREN_CONFIG_DIR/skills-data/<slug>/`
+- project overrides: `<project>/.seren/skills-data/<slug>/`
+
+Recommended config layout:
+
+```
+$SEREN_CONFIG_DIR/
+└── skills-data/
+    └── <slug>/
+        ├── config.json    # User-owned runtime config
+        └── .env           # User-owned secrets / local env
+```
+
+On Windows, replace `$SEREN_CONFIG_DIR` with `%APPDATA%\seren`.
+
+For executable Python skills, the recommended integration pattern is:
+
+1. generate a local `scripts/runtime_paths.py` from [`seren/skill-runtime`](./seren/skill-runtime/)
+2. import `activate_runtime` near process start
+3. call `args.config = str(activate_runtime(args.config))`
+
+That keeps the installed skill self-contained while still using the shared Seren runtime contract. For skills that follow this pattern, relative `state/` and `logs/` paths will also resolve under the runtime directory instead of the installed skill directory.
 
 ## Adding a Skill
 
@@ -79,7 +108,8 @@ Quick version:
 1. Create `<org>/<skill-name>/` at the repo root
 2. Add a `SKILL.md` with valid frontmatter where `name` equals `<skill-name>`
 3. For agent skills, put runtime code in `scripts/` and keep dependency/config templates at the skill root
-4. Open a PR
+4. If the skill needs stable runtime config or state paths, generate a local `scripts/runtime_paths.py` from `seren/skill-runtime` and use `activate_runtime()`
+5. Open a PR
 
 ## SKILL.md Frontmatter
 
@@ -98,3 +128,5 @@ Conventions:
 - Use the first `# H1` in the document body as the display name
 - Keep runtime code in `scripts/`
 - `metadata` is available per spec but not used by Seren skills today
+- Skill runtimes should accept absolute `--config` and `--env-file` paths, or equivalent environment variables, so callers can point them at files under `skills-data/<slug>/`
+- For Python skills, prefer generating `scripts/runtime_paths.py` from `seren/skill-runtime` rather than hand-rolling path resolution in each skill

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -28,6 +28,7 @@ from seren_client import SerenClient
 from grid_manager import GridManager, optimize_backtest_configuration
 from position_tracker import PositionTracker
 from logger import GridTraderLogger
+from runtime_paths import activate_runtime
 from serendb_store import SerenDBStore
 import pair_selector
 from urllib.request import Request, urlopen
@@ -977,6 +978,7 @@ def main():
         sys.exit(1)
 
     dry_run = (args.command == 'dry-run')
+    args.config = str(activate_runtime(args.config))
     agent = CoinbaseGridTrader(config_path=args.config, dry_run=dry_run)
 
     try:

--- a/coinbase/grid-trader/scripts/runtime_paths.py
+++ b/coinbase/grid-trader/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "coinbase-grid-trader"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -40,6 +40,7 @@ from logger import AuditLogger
 from optimizer import SUPPORTED_STRATEGIES, compute_rsi, decide_execution
 from portfolio_manager import PortfolioManager
 from position_tracker import PositionTracker
+from runtime_paths import activate_runtime
 from scanner import OpportunityScanner
 from seren_api_client import SerenAPIError, SerenAPIKeyManager
 from serendb_store import SerenDBStore
@@ -2130,6 +2131,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
 
     command = args.command or "run"
     if command == "init-db":

--- a/coinbase/smart-dca-bot/scripts/run_agent_server.py
+++ b/coinbase/smart-dca-bot/scripts/run_agent_server.py
@@ -19,6 +19,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from agent import run_once
+from runtime_paths import activate_runtime
 
 try:
     from datetime import UTC
@@ -137,8 +138,9 @@ def _load_loop_interval_seconds(config_path: str, fallback: int = 60) -> int:
 
 
 def main() -> int:
-    load_dotenv()
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
+    load_dotenv()
     DCARequestHandler.config_path = args.config
     DCARequestHandler.allow_live = bool(args.allow_live)
     DCARequestHandler.accept_risk_disclaimer = bool(args.accept_risk_disclaimer)

--- a/coinbase/smart-dca-bot/scripts/runtime_paths.py
+++ b/coinbase/smart-dca-bot/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "coinbase-smart-dca-bot"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/coinbase/smart-dca-bot/scripts/setup_serendb.py
+++ b/coinbase/smart-dca-bot/scripts/setup_serendb.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from serendb_store import SerenDBStore
+from runtime_paths import activate_runtime
 
 
 def parse_args() -> argparse.Namespace:
@@ -26,8 +27,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    load_dotenv()
     args = parse_args()
+    activate_runtime()
+    load_dotenv()
     dsn = args.dsn.strip() or os.getenv("SERENDB_URL", "")
     store = SerenDBStore(dsn)
 

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -28,6 +28,7 @@ from seren_client import SerenClient
 from grid_manager import GridManager, optimize_backtest_configuration
 from position_tracker import PositionTracker
 from logger import GridTraderLogger
+from runtime_paths import activate_runtime
 from serendb_store import SerenDBStore
 import pair_selector
 from urllib.request import Request, urlopen
@@ -1074,6 +1075,7 @@ def main():
 
     # Initialize agent
     dry_run = (args.command == 'dry-run')
+    args.config = str(activate_runtime(args.config))
     agent = KrakenGridTrader(config_path=args.config, dry_run=dry_run)
 
     # Execute command

--- a/kraken/grid-trader/scripts/runtime_paths.py
+++ b/kraken/grid-trader/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "kraken-grid-trader"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 
 from kraken_client import KrakenClient
 from mode_engine import ModeEngine
+from runtime_paths import activate_runtime
 from serendb_store import SerenDBStore
 from urllib.request import Request, urlopen
 
@@ -420,6 +421,10 @@ def _check_serenbucks_balance(api_key: str) -> float:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+    if hasattr(args, "config"):
+        args.config = str(activate_runtime(args.config))
+    else:
+        activate_runtime()
     return args.func(args)
 
 

--- a/kraken/money-mode-router/scripts/runtime_paths.py
+++ b/kraken/money-mode-router/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "kraken-money-mode-router"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -40,6 +40,7 @@ from logger import AuditLogger
 from optimizer import SUPPORTED_STRATEGIES, compute_rsi, decide_execution
 from portfolio_manager import PortfolioManager
 from position_tracker import PositionTracker
+from runtime_paths import activate_runtime
 from scanner import OpportunityScanner
 from seren_api_client import SerenAPIError, SerenAPIKeyManager
 from serendb_store import SerenDBStore
@@ -1880,6 +1881,7 @@ def _check_serenbucks_balance(api_key: str) -> float:
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
 
     command = args.command or "run"
     if command == "init-db":

--- a/kraken/smart-dca-bot/scripts/run_agent_server.py
+++ b/kraken/smart-dca-bot/scripts/run_agent_server.py
@@ -19,6 +19,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from agent import run_once
+from runtime_paths import activate_runtime
 
 try:
     from datetime import UTC
@@ -137,8 +138,9 @@ def _load_loop_interval_seconds(config_path: str, fallback: int = 60) -> int:
 
 
 def main() -> int:
-    load_dotenv()
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
+    load_dotenv()
     DCARequestHandler.config_path = args.config
     DCARequestHandler.allow_live = bool(args.allow_live)
     DCARequestHandler.accept_risk_disclaimer = bool(args.accept_risk_disclaimer)

--- a/kraken/smart-dca-bot/scripts/runtime_paths.py
+++ b/kraken/smart-dca-bot/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "kraken-smart-dca-bot"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/kraken/smart-dca-bot/scripts/setup_serendb.py
+++ b/kraken/smart-dca-bot/scripts/setup_serendb.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover
         return False
 
 from serendb_store import SerenDBStore
+from runtime_paths import activate_runtime
 
 
 def parse_args() -> argparse.Namespace:
@@ -26,8 +27,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    load_dotenv()
     args = parse_args()
+    activate_runtime()
+    load_dotenv()
     dsn = args.dsn.strip() or os.getenv("SERENDB_URL", "")
     store = SerenDBStore(dsn)
 

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -42,6 +42,7 @@ from pair_stateful_replay import (
     snapshot_from_live_book,
     write_telemetry_records,
 )
+from runtime_paths import activate_runtime
 
 
 DISCLAIMER = (
@@ -2020,6 +2021,7 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
     config = load_config(args.config)
 
     if args.unwind_all:

--- a/polymarket/high-throughput-paired-basis-maker/scripts/runtime_paths.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "polymarket-high-throughput-paired-basis-maker"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -42,6 +42,7 @@ from pair_stateful_replay import (
     snapshot_from_live_book,
     write_telemetry_records,
 )
+from runtime_paths import activate_runtime
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -2081,6 +2082,7 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
     config = load_config(args.config)
 
     if args.unwind_all:

--- a/polymarket/liquidity-paired-basis-maker/scripts/runtime_paths.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "polymarket-liquidity-paired-basis-maker"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -34,6 +34,7 @@ from polymarket_live import (
     positions_by_key,
     single_market_inventory_notional,
 )
+from runtime_paths import activate_runtime
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -2389,6 +2390,7 @@ def run_quote(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
     config = load_config(args.config)
 
     if args.unwind_all:

--- a/polymarket/maker-rebate-bot/scripts/runtime_paths.py
+++ b/polymarket/maker-rebate-bot/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "polymarket-maker-rebate-bot"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -42,6 +42,7 @@ from pair_stateful_replay import (
     snapshot_from_live_book,
     write_telemetry_records,
 )
+from runtime_paths import activate_runtime
 
 
 DISCLAIMER = (
@@ -2020,6 +2021,7 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
 
 def main() -> int:
     args = parse_args()
+    args.config = str(activate_runtime(args.config))
     config = load_config(args.config)
 
     if args.unwind_all:

--- a/polymarket/paired-market-basis-maker/scripts/runtime_paths.py
+++ b/polymarket/paired-market-basis-maker/scripts/runtime_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Generated from seren/skill-runtime/scripts/seren_runtime.py. Do not edit by hand.
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+SKILL_SLUG = "polymarket-paired-market-basis-maker"
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    warned: set[Path] = set()
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(config_path: str = "config.json", *, start: Path | None = None, create: bool = True) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime
+
+
+resolve_config_path, resolve_env_path, resolve_runtime_dir, default_runtime_dir, load_skill_env, activate_runtime = (
+    make_runtime_paths(SKILL_SLUG, SKILL_ROOT)
+)

--- a/seren/skill-runtime/SKILL.md
+++ b/seren/skill-runtime/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: skill-runtime
+description: Shared runtime contract for executable seren skills that need stable config, env, state, and log paths outside the installed skill directory.
+---
+
+# Skill Runtime
+
+Use this library skill when an executable Seren skill needs stable runtime file paths for `.env`, `config.json`, `state/`, or `logs/`.
+
+## Runtime Contract
+
+Installed skill directories are replaceable. User-managed runtime files live outside the install directory.
+
+Shared runtime root:
+
+- macOS/Linux: `$XDG_CONFIG_HOME/seren` with `~/.config/seren` fallback
+- Windows: `%APPDATA%\seren`
+
+Per-skill runtime directory:
+
+- shared: `<runtime-root>/skills-data/<slug>/`
+- project override: `<project>/.seren/skills-data/<slug>/`
+
+Slug example:
+
+- `coinbase/smart-dca-bot` -> `coinbase-smart-dca-bot`
+
+Expected runtime files:
+
+- `.env`
+- `config.json`
+- `state/`
+- `logs/`
+
+## Resolution Priority
+
+For `.env` and `config.json`, resolve in this order:
+
+1. explicit absolute path
+2. explicit relative path with directory segments, resolved from the current working directory
+3. project-level `.seren/skills-data/<slug>/` discovered by walking up from `cwd`
+4. shared runtime root under XDG or `%APPDATA%`
+5. legacy fallback in the installed skill directory, only if the file already exists there
+
+If no file exists yet, return the preferred runtime location rather than the legacy install-directory path.
+
+## Environment Override
+
+Use `SEREN_SKILL_ENV_FILE` to override `.env` resolution when a skill needs a non-standard env file location.
+
+## Legacy Fallback
+
+Legacy skill-root files are still supported for backward compatibility, but they are deprecated.
+
+When the resolver falls back to a skill-root file, it should emit a deprecation warning and point to the preferred runtime path under `skills-data/<slug>/`.
+
+## Migration
+
+Move legacy files from the skill install directory into the runtime directory:
+
+- move `.env` to `<runtime-root>/skills-data/<slug>/.env`
+- move `config.json` to `<runtime-root>/skills-data/<slug>/config.json`
+- move `state/` to `<runtime-root>/skills-data/<slug>/state/`
+- move `logs/` to `<runtime-root>/skills-data/<slug>/logs/`
+
+Skill code should continue accepting explicit `--config` and `--env-file` style inputs when available, but defaults should resolve through this runtime contract.
+
+## Integration Pattern
+
+Consume this skill by generating a local `scripts/runtime_paths.py` into each executable skill.
+
+Recommended entrypoint pattern:
+
+1. import `activate_runtime` from the local `runtime_paths.py`
+2. call `args.config = str(activate_runtime(args.config))` near process start
+3. let existing relative `state/`, `logs/`, and `.env` usage resolve inside the runtime directory
+
+This keeps executable skills self-contained at install time while preserving a single canonical source for the runtime contract.

--- a/seren/skill-runtime/scripts/seren_runtime.py
+++ b/seren/skill-runtime/scripts/seren_runtime.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Canonical source for the vendored runtime_paths.py helper.
+
+Each executable skill carries a generated scripts/runtime_paths.py that is
+produced from this file. The generator prepends SKILL_SLUG / SKILL_ROOT
+constants and appends a module-level unpack of make_runtime_paths(SKILL_SLUG,
+SKILL_ROOT). Everything else is copied verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+__all__ = [
+    "LegacyRuntimePathWarning",
+    "make_runtime_paths",
+]
+
+
+class LegacyRuntimePathWarning(UserWarning):
+    """Emitted when a file is resolved from the deprecated skill install directory."""
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shared_runtime_root() -> Path:
+    if _is_windows():
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            return Path(appdata).expanduser() / "seren"
+    xdg = os.getenv("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "seren"
+    return Path.home() / ".config" / "seren"
+
+
+def _project_runtime_dir(skill_slug: str, start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".seren").is_dir():
+            return candidate / ".seren" / "skills-data" / skill_slug
+    return None
+
+
+def _default_runtime_dir(skill_slug: str, start: Path | None = None) -> Path:
+    project = _project_runtime_dir(skill_slug, start=start)
+    if project is not None:
+        return project
+    return _shared_runtime_root() / "skills-data" / skill_slug
+
+
+def _warn_legacy(legacy: Path, preferred: Path, warned: set[Path]) -> None:
+    resolved = legacy.resolve()
+    if resolved in warned:
+        return
+    warned.add(resolved)
+    warnings.warn(
+        f"Using deprecated legacy path '{resolved}'. Move this file to '{preferred}'.",
+        LegacyRuntimePathWarning,
+        stacklevel=4,
+    )
+
+
+def make_runtime_paths(skill_slug: str, skill_root: Path):
+    """Return runtime path helpers bound to *skill_slug* and *skill_root*."""
+    warned: set[Path] = set()
+
+    def _resolve(raw: str, *, default_name: str, start: Path | None = None) -> Path:
+        candidate = Path(raw).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        if candidate.parent != Path("."):
+            return (Path.cwd() / candidate).resolve()
+        filename = candidate.name or default_name
+        preferred = _default_runtime_dir(skill_slug, start=start) / filename
+        legacy = skill_root / filename
+        if preferred.exists():
+            return preferred
+        if legacy.exists():
+            _warn_legacy(legacy, preferred, warned)
+            return legacy
+        return preferred
+
+    def default_runtime_dir(start: Path | None = None) -> Path:
+        return _default_runtime_dir(skill_slug, start=start)
+
+    def resolve_config_path(config_path: str = "config.json", *, start: Path | None = None) -> Path:
+        return _resolve(config_path, default_name="config.json", start=start)
+
+    def resolve_env_path(env_path: str | None = None, *, start: Path | None = None) -> Path:
+        raw = env_path or os.getenv("SEREN_SKILL_ENV_FILE") or ".env"
+        return _resolve(raw, default_name=".env", start=start)
+
+    def resolve_runtime_dir(config_path: str | Path | None = None, *, start: Path | None = None) -> Path:
+        if config_path is not None:
+            return resolve_config_path(str(config_path), start=start).parent
+        return default_runtime_dir(start=start)
+
+    def load_skill_env(
+        env_path: str | None = None,
+        *,
+        start: Path | None = None,
+        override: bool = False,
+    ) -> Path | None:
+        resolved = resolve_env_path(env_path, start=start)
+        if not resolved.exists():
+            return None
+        try:
+            from dotenv import load_dotenv  # type: ignore
+        except ImportError:
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                key, sep, value = line.partition("=")
+                if sep != "=":
+                    continue
+                key = key.strip()
+                if not key:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                if override or key not in os.environ:
+                    os.environ[key] = value
+        else:
+            load_dotenv(resolved, override=override)
+        return resolved
+
+    def activate_runtime(
+        config_path: str = "config.json",
+        *,
+        start: Path | None = None,
+        create: bool = True,
+    ) -> Path:
+        start_path = (start or Path.cwd()).resolve()
+        resolved_config = resolve_config_path(config_path, start=start_path)
+        runtime_dir = resolve_runtime_dir(str(resolved_config), start=start_path)
+        if create:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+        load_skill_env(start=start_path)
+        os.chdir(runtime_dir)
+        return resolved_config
+
+    return (
+        resolve_config_path,
+        resolve_env_path,
+        resolve_runtime_dir,
+        default_runtime_dir,
+        load_skill_env,
+        activate_runtime,
+    )

--- a/seren/skill-runtime/skill.spec.yaml
+++ b/seren/skill-runtime/skill.spec.yaml
@@ -1,0 +1,9 @@
+skill: skill-runtime
+type: library
+description: Shared runtime path resolution for executable seren skills.
+version: "1.0"
+exports:
+  - scripts/seren_runtime.py
+publish:
+  org: seren
+  slug: skill-runtime

--- a/seren/skill-runtime/tests/test_runtime_paths.py
+++ b/seren/skill-runtime/tests/test_runtime_paths.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import seren_runtime
+from seren_runtime import LegacyRuntimePathWarning, make_runtime_paths
+
+SLUG = "coinbase-smart-dca-bot"
+
+
+class RuntimePathsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        self.skill_root = self.tmp_path / "coinbase" / "smart-dca-bot"
+        self.skill_root.mkdir(parents=True)
+        self.original_cwd = Path.cwd()
+        self.original_env = os.environ.copy()
+        (
+            self.resolve_config_path,
+            self.resolve_env_path,
+            self.resolve_runtime_dir,
+            self.default_runtime_dir,
+            self.load_skill_env,
+            self.activate_runtime,
+        ) = make_runtime_paths(SLUG, self.skill_root)
+
+    def tearDown(self) -> None:
+        os.chdir(self.original_cwd)
+        os.environ.clear()
+        os.environ.update(self.original_env)
+        self.tmp.cleanup()
+
+    # --- default_runtime_dir ---
+
+    def test_prefers_project_runtime_dir(self) -> None:
+        project_root = self.tmp_path / "workspace"
+        runtime_dir = project_root / ".seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        nested = project_root / "app" / "src"
+        nested.mkdir(parents=True)
+        os.chdir(nested)
+
+        self.assertEqual(self.default_runtime_dir().resolve(), runtime_dir.resolve())
+
+    def test_falls_back_to_shared_runtime_root(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        expected = shared_root / "seren" / "skills-data" / SLUG
+        self.assertEqual(self.default_runtime_dir(), expected)
+
+    def test_appdata_wins_over_xdg(self) -> None:
+        appdata = self.tmp_path / "appdata"
+        xdg = self.tmp_path / "xdg"
+        os.environ["APPDATA"] = str(appdata)
+        os.environ["XDG_CONFIG_HOME"] = str(xdg)
+        os.chdir(self.tmp_path)
+
+        with mock.patch.object(seren_runtime, "_is_windows", return_value=True):
+            expected = appdata / "seren" / "skills-data" / SLUG
+            self.assertEqual(self.default_runtime_dir(), expected)
+
+    def test_xdg_wins_on_non_windows_even_if_appdata_is_set(self) -> None:
+        appdata = self.tmp_path / "appdata"
+        xdg = self.tmp_path / "xdg"
+        os.environ["APPDATA"] = str(appdata)
+        os.environ["XDG_CONFIG_HOME"] = str(xdg)
+        os.chdir(self.tmp_path)
+
+        with mock.patch.object(seren_runtime, "_is_windows", return_value=False):
+            expected = xdg / "seren" / "skills-data" / SLUG
+            self.assertEqual(self.default_runtime_dir(), expected)
+
+    # --- resolve_config_path ---
+
+    def test_resolve_config_prefers_runtime_dir(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "config.json").write_text("{}", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        self.assertEqual(self.resolve_config_path(), runtime_dir / "config.json")
+
+    def test_resolve_config_accepts_absolute_path(self) -> None:
+        explicit = self.tmp_path / "my-config.json"
+        explicit.write_text("{}", encoding="utf-8")
+
+        self.assertEqual(self.resolve_config_path(str(explicit)), explicit)
+
+    def test_resolve_config_relative_subpath_uses_cwd(self) -> None:
+        nested = self.tmp_path / "workspace"
+        nested.mkdir(parents=True)
+        explicit = nested / "configs" / "config.json"
+        explicit.parent.mkdir(parents=True)
+        explicit.write_text("{}", encoding="utf-8")
+        os.chdir(nested)
+
+        self.assertEqual(self.resolve_config_path("configs/config.json"), explicit.resolve())
+
+    def test_missing_config_returns_preferred_not_legacy(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        expected = shared_root / "seren" / "skills-data" / SLUG / "config.json"
+        self.assertEqual(self.resolve_config_path(), expected)
+
+    # --- resolve_env_path ---
+
+    def test_env_override_var_accepts_absolute_path(self) -> None:
+        explicit = self.tmp_path / "custom.env"
+        explicit.write_text("KEY=val\n", encoding="utf-8")
+        os.environ["SEREN_SKILL_ENV_FILE"] = str(explicit)
+
+        self.assertEqual(self.resolve_env_path(), explicit)
+
+    def test_resolve_env_uses_shared_runtime_root(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / ".env").write_text("KEY=val\n", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        self.assertEqual(self.resolve_env_path(), runtime_dir / ".env")
+
+    def test_load_skill_env_reads_runtime_env_file(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / ".env").write_text("SEREN_API_KEY=test-key\n", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.environ.pop("SEREN_API_KEY", None)
+        os.chdir(self.tmp_path)
+
+        loaded = self.load_skill_env()
+
+        self.assertEqual(loaded, runtime_dir / ".env")
+        self.assertEqual(os.environ["SEREN_API_KEY"], "test-key")
+
+    # --- legacy fallback ---
+
+    def test_legacy_fallback_warns_once(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+        (self.skill_root / ".env").write_text("KEY=val\n", encoding="utf-8")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            first = self.resolve_env_path()
+            self.assertEqual(first, self.skill_root / ".env")
+            self.assertEqual(len(caught), 1)
+            self.assertIs(caught[0].category, LegacyRuntimePathWarning)
+
+        with warnings.catch_warnings(record=True) as caught2:
+            warnings.simplefilter("always")
+            second = self.resolve_env_path()
+            self.assertEqual(second, self.skill_root / ".env")
+            self.assertEqual(len(caught2), 0)
+
+    def test_legacy_warned_sets_are_per_skill(self) -> None:
+        """Each make_runtime_paths call gets its own warned set."""
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        other_root = self.tmp_path / "other" / "skill"
+        other_root.mkdir(parents=True)
+        (other_root / ".env").write_text("KEY=val\n", encoding="utf-8")
+        _, resolve_env_other, _, _, _, _ = make_runtime_paths("other-skill", other_root)
+        (self.skill_root / ".env").write_text("KEY=val\n", encoding="utf-8")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.resolve_env_path()
+            resolve_env_other()
+            self.assertEqual(len(caught), 2)
+
+    # --- resolve_runtime_dir ---
+
+    def test_resolve_runtime_dir_from_config_path(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "config.json").write_text("{}", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        self.assertEqual(self.resolve_runtime_dir("config.json"), runtime_dir)
+
+    def test_resolve_runtime_dir_default(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        expected = shared_root / "seren" / "skills-data" / SLUG
+        self.assertEqual(self.resolve_runtime_dir(), expected)
+
+    def test_activate_runtime_switches_into_runtime_dir(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        project = self.tmp_path / "workspace"
+        project.mkdir(parents=True)
+        os.chdir(project)
+
+        resolved = self.activate_runtime("config.json")
+
+        self.assertEqual(resolved, runtime_dir / "config.json")
+        self.assertEqual(Path.cwd().resolve(), runtime_dir.resolve())
+
+
+    # --- load_skill_env ---
+
+    def test_load_skill_env_override_replaces_existing_var(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / ".env").write_text("KEY=new-value\n", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.environ["KEY"] = "old-value"
+        os.chdir(self.tmp_path)
+
+        self.load_skill_env(override=True)
+
+        self.assertEqual(os.environ["KEY"], "new-value")
+
+    def test_load_skill_env_no_override_preserves_existing_var(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / ".env").write_text("KEY=new-value\n", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.environ["KEY"] = "old-value"
+        os.chdir(self.tmp_path)
+
+        self.load_skill_env(override=False)
+
+        self.assertEqual(os.environ["KEY"], "old-value")
+
+    def test_load_skill_env_returns_none_when_file_missing(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.chdir(self.tmp_path)
+
+        self.assertIsNone(self.load_skill_env())
+
+    # --- activate_runtime ---
+
+    def test_activate_runtime_loads_env(self) -> None:
+        shared_root = self.tmp_path / "xdg"
+        runtime_dir = shared_root / "seren" / "skills-data" / SLUG
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / ".env").write_text("SEREN_API_KEY=activated-key\n", encoding="utf-8")
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+        os.environ.pop("SEREN_API_KEY", None)
+        os.chdir(self.tmp_path)
+
+        self.activate_runtime()
+
+        self.assertEqual(os.environ["SEREN_API_KEY"], "activated-key")
+
+    # --- project runtime dir ---
+
+    def test_project_runtime_dir_returns_none_with_no_seren_ancestor(self) -> None:
+        isolated = self.tmp_path / "isolated"
+        isolated.mkdir()
+        shared_root = self.tmp_path / "xdg"
+        os.environ["XDG_CONFIG_HOME"] = str(shared_root)
+        os.environ.pop("APPDATA", None)
+
+        expected = shared_root / "seren" / "skills-data" / SLUG
+        self.assertEqual(self.default_runtime_dir(start=isolated), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Executable skills have been storing user-managed runtime files like `.env`, `config.json`, `state/`, and `logs/` relative to the installed skill directory. That breaks down when an installer such as `seren-desktop` updates a skill by replacing its directory, because local runtime files can be overwritten or lost.

We also had duplicated `runtime_paths.py` implementations across multiple skills. The copies had already started to drift, which made fixes risky and repetitive.

## Solution
This PR introduces a shared runtime-path contract in `seren/skill-runtime` and applies it to the current executable-skill batch.

The contract resolves runtime files in this order:
- explicit absolute path when provided
- explicit relative path with directory segments, resolved from the current working directory
- project-level `.seren/skills-data/<slug>/` found by walking up from the current working directory
- shared config root:
  - macOS/Linux: `$XDG_CONFIG_HOME/seren/skills-data/<slug>/` or `~/.config/seren/skills-data/<slug>/`
  - Windows: `%APPDATA%\seren\skills-data\<slug>\`
- legacy fallback to the skill install directory only when the file already exists there, with a deprecation warning

For migrated skills, `activate_runtime()` is called near startup so relative runtime paths now resolve from the selected runtime directory instead of the installed skill directory.

## What Changed
- add `seren/skill-runtime` as the canonical source for runtime-path behavior, docs, and tests
- vendor a local `scripts/runtime_paths.py` into migrated executable skills so installs stay self-contained
- migrate the current skill batch to call `activate_runtime()` during startup
- update repo docs to explain the external runtime-config convention and helper pattern
- preserve backward compatibility with the legacy skill-root fallback while warning on use

## Why This Approach
This keeps installs portable across different installers and avoids depending on a global Python package or shared import path. Each skill remains self-contained at runtime, while `seren/skill-runtime` serves as the single maintained source for the contract and implementation pattern.

## Testing
- `python3 -m unittest seren/skill-runtime/tests/test_runtime_paths.py`

Commit: `d7aaecb`