### PR TITLE
feat: add GDEX Trading skill under gdex/trading/

### DIFF
--- a/gdex/trading/.env.example
+++ b/gdex/trading/.env.example
@@ -1,0 +1,4 @@
+# GDEX API Key (shared keys available - see SKILL.md)
+GDEX_API_KEY=
+# Control wallet private key (for managed-custody trading)
+CONTROL_WALLET_PRIVATE_KEY=

--- a/gdex/trading/README.md
+++ b/gdex/trading/README.md
@@ -1,0 +1,84 @@
+# GDEX Trading Skill
+
+This skill integrates the [GDEX Trading SDK](https://github.com/GemachDAO/gdex-skill) into Seren Desktop, enabling AI agents to execute cross-chain DeFi operations via managed-custody wallets.
+
+## What This Skill Provides
+
+- Spot trading (buy/sell) on Solana, Sui, Ethereum, Base, Arbitrum, BSC, and 12+ EVM chains
+- Perpetual futures: open/close positions, set leverage, manage margin
+- Portfolio management: balances, trade history, open positions
+- Token discovery: trending tokens, OHLCV price data, token details
+- Cross-chain bridging: estimate and execute asset bridges
+- Limit orders: place, update, and cancel
+- Copy trading: follow top-performing traders
+
+## Source
+
+Full source code, sub-skill documentation, and examples:
+👉 [GemachDAO/gdex-skill](https://github.com/GemachDAO/gdex-skill)
+
+npm package: [`@gdexsdk/gdex-skill`](https://www.npmjs.com/package/@gdexsdk/gdex-skill)
+
+## Quick Start
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Verify the SDK is working offline:
+   ```bash
+   node scripts/verify.js
+   ```
+
+4. Run the end-to-end integration tests:
+   ```bash
+   node scripts/e2e-seren-integration.test.js
+   ```
+
+5. Validate the SKILL.md frontmatter:
+   ```bash
+   node scripts/validate-skill.js
+   ```
+
+## Directory Layout
+
+```
+gdex/trading/
+├── SKILL.md                            # Skill documentation and frontmatter
+├── README.md                           # This file
+├── package.json                        # npm dependencies
+├── .env.example                        # Environment variable template
+└── scripts/
+    ├── verify.js                       # Offline SDK smoke test
+    ├── e2e-seren-integration.test.js   # End-to-end integration tests
+    └── validate-skill.js              # SKILL.md frontmatter validator
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GDEX_API_KEY` | Yes (for live trading) | Shared API key from GDEX dashboard |
+| `CONTROL_WALLET_PRIVATE_KEY` | Yes (for live trading) | Control wallet private key for managed-custody signing |
+
+> **Note**: The `walletAddress` field in API calls must be your **control** address, not the managed address.
+
+## Supported Chains
+
+| Chain | ChainId |
+|---|---|
+| Ethereum | 1 |
+| Base | 8453 |
+| Arbitrum | 42161 |
+| BSC | 56 |
+| Avalanche | 43114 |
+| Polygon | 137 |
+| Optimism | 10 |
+| Solana | 622112261 |
+| Sui | 101 |

--- a/gdex/trading/SKILL.md
+++ b/gdex/trading/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: trading
+description: "Cross-chain DeFi trading skill for AI agents — spot trading, perpetual futures, portfolio management, and token discovery on Solana, Sui, and 12+ EVM chains via managed-custody wallets."
+license: MIT
+metadata:
+  source: "https://github.com/GemachDAO/gdex-skill"
+  npm: "@gdexsdk/gdex-skill"
+  version: "2.0.0"
+---
+
+# GDEX Trading
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## Overview
+
+GDEX Trading gives AI agents access to cross-chain DeFi operations via managed-custody wallets. Agents can trade spot markets, open and manage perpetual futures positions, bridge assets, discover tokens, and monitor portfolios — all through a single unified API at `https://trade-api.gemach.io/v1`.
+
+Supported chains: Solana, Sui, Ethereum, Base, Arbitrum, BSC, Avalanche, Polygon, and 8+ additional EVM networks.
+
+## Available Sub-Skills
+
+| Sub-skill | Purpose |
+|---|---|
+| `gdex-authentication` | API key login, session management |
+| `gdex-onboarding` | New user wallet setup and verification |
+| `gdex-wallet-setup` | Wallet configuration and key management |
+| `gdex-spot-trading` | Market buy/sell on any supported chain |
+| `gdex-perp-trading` | Open, close, and manage perp positions |
+| `gdex-perp-funding` | Deposit/withdraw perp margin |
+| `gdex-perp-copy-trading` | Copy top-trader perp strategies |
+| `gdex-copy-trading` | Copy top-trader spot strategies |
+| `gdex-limit-orders` | Place, update, and cancel limit orders |
+| `gdex-portfolio` | View balances, positions, trade history |
+| `gdex-token-discovery` | Trending tokens, OHLCV, token details |
+| `gdex-bridge` | Estimate and execute cross-chain bridges |
+| `gdex-ui-install-setup` | Frontend SDK install and setup |
+| `gdex-ui-page-layouts` | UI page layout components |
+| `gdex-ui-portfolio-dashboard` | Portfolio dashboard UI |
+| `gdex-ui-theming` | Theme and styling configuration |
+| `gdex-ui-trading-components` | Trading UI components |
+| `gdex-ui-wallet-connection` | Wallet connection UI |
+| `gdex-sdk-debugging` | SDK debugging and error diagnostics |
+
+## Quick Decision Guide
+
+- **Buy or sell a token** → `gdex-spot-trading`
+- **Open a leveraged position** → `gdex-perp-trading`
+- **Bridge assets cross-chain** → `gdex-bridge`
+- **Find trending tokens or price data** → `gdex-token-discovery`
+- **Check portfolio or balances** → `gdex-portfolio`
+- **Place limit orders** → `gdex-limit-orders`
+- **Follow top traders** → `gdex-copy-trading` or `gdex-perp-copy-trading`
+- **First-time setup** → `gdex-authentication` then `gdex-onboarding`
+
+## Installation
+
+```bash
+npm install @gdexsdk/gdex-skill
+```
+
+## Authentication
+
+GDEX uses a two-layer auth model:
+
+1. **API Key** — shared keys available via the GDEX dashboard or community keys. Set `GDEX_API_KEY` in your environment or call `loginWithApiKey(apiKey)`.
+2. **Managed-custody signing** — trading actions require a secp256k1 session key derived from your control wallet's private key (`CONTROL_WALLET_PRIVATE_KEY`). The SDK handles AES-256-CBC payload encryption and SHA256 key derivation automatically.
+
+```js
+import { GdexSkill } from '@gdexsdk/gdex-skill';
+
+const skill = new GdexSkill();
+await skill.loginWithApiKey(process.env.GDEX_API_KEY);
+```
+
+## Critical Notes
+
+- **`walletAddress` is your CONTROL address, NOT the managed address.** Always use the control wallet address for authentication and identity fields.
+- **Solana `chainId` is `622112261`**, not `900`. Using the wrong value causes silent failures.
+- **`hlCloseAll` is unreliable** — use reduce-only orders instead to close Hyperliquid perp positions.
+- **`hlUpdateLeverage`** is not implemented on the backend; use `set_perp_leverage` instead.
+
+## Environment Variables
+
+```
+GDEX_API_KEY=                    # Shared API key
+CONTROL_WALLET_PRIVATE_KEY=      # Control wallet private key (for managed-custody trading)
+```
+
+## Source Repository
+
+Full SDK source, examples, and sub-skill implementations:
+[https://github.com/GemachDAO/gdex-skill](https://github.com/GemachDAO/gdex-skill)

--- a/gdex/trading/package.json
+++ b/gdex/trading/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "seren-skill-gdex-trading",
+  "version": "1.0.0",
+  "description": "GDEX Trading skill for Seren Desktop",
+  "dependencies": {
+    "@gdexsdk/gdex-skill": "^2.0.0"
+  }
+}

--- a/gdex/trading/scripts/e2e-seren-integration.test.js
+++ b/gdex/trading/scripts/e2e-seren-integration.test.js
@@ -1,0 +1,548 @@
+#!/usr/bin/env node
+/**
+ * End-to-end integration tests: GDEX Trading skill in seren-skills
+ * Run: node scripts/e2e-seren-integration.test.js
+ *
+ * Tests run entirely offline — no network requests are made.
+ * Exit code 0 = all pass, exit code 1 = any failure.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+const RESET = '\x1b[0m';
+
+let passed = 0;
+let failed = 0;
+
+function pass(label) {
+  console.log(`  ${GREEN}✓${RESET} ${label}`);
+  passed++;
+}
+
+function fail(label, detail) {
+  console.log(`  ${RED}✗${RESET} ${label}`);
+  if (detail) console.log(`    ${RED}${detail}${RESET}`);
+  failed++;
+}
+
+function section(title) {
+  console.log(`\n${CYAN}▶ ${title}${RESET}`);
+}
+
+function assert(condition, label, detail) {
+  if (condition) {
+    pass(label);
+  } else {
+    fail(label, detail);
+  }
+}
+
+// ─── Skill root (one level up from scripts/) ────────────────────────────────
+const SKILL_ROOT = path.resolve(__dirname, '..');
+const SKILL_MD_PATH = path.join(SKILL_ROOT, 'SKILL.md');
+
+// ─── A. Skill Structure Validation ───────────────────────────────────────────
+section('A. Skill Structure Validation');
+
+// SKILL.md exists
+assert(fs.existsSync(SKILL_MD_PATH), 'SKILL.md exists');
+
+let frontmatter = null;
+let skillMdContent = '';
+if (fs.existsSync(SKILL_MD_PATH)) {
+  skillMdContent = fs.readFileSync(SKILL_MD_PATH, 'utf8');
+
+  // Extract YAML frontmatter between --- delimiters
+  const fmMatch = skillMdContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (fmMatch) {
+    // Minimal YAML parser for key: value and nested key: value lines
+    const raw = fmMatch[1];
+    frontmatter = {};
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^(\w[\w-]*):\s+"?([^"]*)"?\s*$/);
+      if (m) frontmatter[m[1]] = m[2].trim();
+    }
+    pass('SKILL.md has valid YAML frontmatter delimiters');
+  } else {
+    fail('SKILL.md is missing YAML frontmatter (--- delimiters)');
+  }
+}
+
+if (frontmatter) {
+  // name field
+  const name = frontmatter.name;
+  assert(typeof name === 'string' && name.length > 0, 'frontmatter has name field');
+
+  // name matches parent directory name ("trading")
+  const parentDir = path.basename(SKILL_ROOT);
+  assert(name === parentDir, `name "${name}" matches parent directory "${parentDir}"`);
+
+  // name spec rules
+  assert(name.length >= 1 && name.length <= 64, `name length (${name.length}) is 1-64 chars`);
+  assert(/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(name), 'name uses only lowercase letters, digits, hyphens; no leading/trailing hyphen');
+  assert(!name.includes('--'), 'name has no consecutive hyphens');
+
+  // description field
+  const desc = frontmatter.description;
+  assert(typeof desc === 'string' && desc.length > 0, 'frontmatter has non-empty description');
+  assert(desc.length <= 1024, `description length (${desc.length}) is <= 1024 chars`);
+}
+
+// H1 heading exists in body
+const h1Match = skillMdContent.match(/^# .+/m);
+assert(h1Match !== null, 'SKILL.md has an H1 heading as display name');
+
+// ─── B. SDK Import & Initialization ──────────────────────────────────────────
+section('B. SDK Import & Initialization');
+
+let sdk = null;
+try {
+  sdk = require('@gdexsdk/gdex-skill');
+  pass('require("@gdexsdk/gdex-skill") succeeded');
+} catch (err) {
+  fail('require("@gdexsdk/gdex-skill") failed — run: npm install', err.message);
+  console.log(`\n${RED}Cannot continue SDK tests without the package installed.${RESET}`);
+  printSummary();
+  process.exit(1);
+}
+
+const {
+  GdexSkill,
+  GdexApiClient,
+  ChainId,
+  getChainName,
+  getNativeToken,
+  formatUsd,
+  formatTokenAmount,
+  shortenAddress,
+  validateAddress,
+  validateAmount,
+  validateSlippage,
+  validateChain,
+  GdexAuthError,
+  GdexValidationError,
+  GdexApiError,
+  GdexNetworkError,
+  GdexRateLimitError,
+  generateEvmWallet,
+  generateGdexSessionKeyPair,
+  encryptGdexComputedData,
+  decryptGdexComputedData,
+  buildGdexSignInComputedData,
+  ENDPOINTS,
+} = sdk;
+
+// GdexSkill class is exported
+assert(typeof GdexSkill === 'function', 'GdexSkill class is exported');
+
+// Instantiate with defaults
+let skill = null;
+try {
+  skill = new GdexSkill();
+  pass('new GdexSkill() instantiated with defaults');
+} catch (err) {
+  fail('new GdexSkill() threw', err.message);
+}
+
+// Instantiate with custom config
+try {
+  const custom = new GdexSkill({ baseUrl: 'https://trade-api.gemach.io/v1', timeout: 10000 });
+  pass('new GdexSkill({ baseUrl, timeout }) instantiated with custom config');
+} catch (err) {
+  fail('new GdexSkill({ baseUrl, timeout }) threw', err.message);
+}
+
+// Expected exports are present
+const expectedExports = [
+  ['GdexSkill', GdexSkill],
+  ['GdexApiClient', GdexApiClient],
+  ['ChainId', ChainId],
+  ['getChainName', getChainName],
+  ['getNativeToken', getNativeToken],
+  ['formatUsd', formatUsd],
+  ['formatTokenAmount', formatTokenAmount],
+  ['GdexAuthError', GdexAuthError],
+  ['GdexValidationError', GdexValidationError],
+  ['GdexApiError', GdexApiError],
+  ['GdexNetworkError', GdexNetworkError],
+];
+for (const [name, val] of expectedExports) {
+  assert(val !== undefined, `${name} is exported from SDK`);
+}
+
+// ─── C. Authentication Flow (Offline) ────────────────────────────────────────
+section('C. Authentication Flow (Offline)');
+
+if (skill) {
+  // isAuthenticated() before login
+  try {
+    const auth = skill.isAuthenticated();
+    assert(auth === false, 'isAuthenticated() returns false before login');
+  } catch (err) {
+    fail('isAuthenticated() threw', err.message);
+  }
+
+  // logout() resets state
+  try {
+    skill.logout();
+    const afterLogout = skill.isAuthenticated();
+    assert(afterLogout === false, 'logout() resets isAuthenticated() to false');
+  } catch (err) {
+    fail('logout() threw', err.message);
+  }
+}
+
+// Session keypair generation
+if (typeof generateGdexSessionKeyPair === 'function') {
+  try {
+    const kp = generateGdexSessionKeyPair();
+    assert(typeof kp === 'object' && kp !== null, 'generateGdexSessionKeyPair() returns an object');
+    const hasKeys = ('privateKey' in kp || 'secretKey' in kp) && ('publicKey' in kp || 'address' in kp);
+    assert(hasKeys, 'generateGdexSessionKeyPair() result has key fields');
+  } catch (err) {
+    fail('generateGdexSessionKeyPair() threw', err.message);
+  }
+} else {
+  fail('generateGdexSessionKeyPair is not exported');
+}
+
+// AES encrypt/decrypt round-trip
+if (typeof encryptGdexComputedData === 'function' && typeof decryptGdexComputedData === 'function') {
+  try {
+    const payload = JSON.stringify({ test: 'data', value: 42 });
+    const key = 'test-aes-key-for-offline-verify';
+    const encrypted = encryptGdexComputedData(payload, key);
+    assert(typeof encrypted === 'string' && encrypted.length > 0, 'encryptGdexComputedData() returns a non-empty string');
+    const decrypted = decryptGdexComputedData(encrypted, key);
+    assert(decrypted === payload, 'AES encrypt/decrypt round-trip produces original payload');
+  } catch (err) {
+    fail('AES encrypt/decrypt round-trip failed', err.message);
+  }
+} else {
+  fail('encryptGdexComputedData or decryptGdexComputedData is not exported');
+}
+
+// buildGdexSignInComputedData
+if (typeof buildGdexSignInComputedData === 'function') {
+  try {
+    const result = buildGdexSignInComputedData({ walletAddress: '0x1234567890123456789012345678901234567890' });
+    assert(result !== undefined, 'buildGdexSignInComputedData() returns a value');
+  } catch (err) {
+    fail('buildGdexSignInComputedData() threw', err.message);
+  }
+} else {
+  fail('buildGdexSignInComputedData is not exported');
+}
+
+// ─── D. Chain Configuration ───────────────────────────────────────────────────
+section('D. Chain Configuration');
+
+const expectedChainIds = {
+  ETHEREUM: 1,
+  BASE: 8453,
+  ARBITRUM: 42161,
+  BSC: 56,
+  AVALANCHE: 43114,
+  POLYGON: 137,
+  OPTIMISM: 10,
+  SOLANA: 622112261,
+};
+
+for (const [chainName, expectedId] of Object.entries(expectedChainIds)) {
+  if (ChainId) {
+    assert(ChainId[chainName] === expectedId, `ChainId.${chainName} === ${expectedId}`);
+  } else {
+    fail(`ChainId.${chainName} (ChainId not exported)`);
+  }
+}
+
+// getChainName
+if (typeof getChainName === 'function') {
+  const chainNameTests = [[1, 'Ethereum'], [8453, 'Base'], [42161, 'Arbitrum'], [56, 'BSC']];
+  for (const [id, expected] of chainNameTests) {
+    try {
+      const name = getChainName(id);
+      assert(
+        typeof name === 'string' && name.toLowerCase().includes(expected.toLowerCase()),
+        `getChainName(${id}) contains "${expected}" (got "${name}")`
+      );
+    } catch (err) {
+      fail(`getChainName(${id}) threw`, err.message);
+    }
+  }
+} else {
+  fail('getChainName is not a function');
+}
+
+// getNativeToken
+if (typeof getNativeToken === 'function') {
+  const nativeTokenTests = [[1, 'ETH'], [56, 'BNB'], [622112261, 'SOL']];
+  for (const [id, expected] of nativeTokenTests) {
+    try {
+      const token = getNativeToken(id);
+      assert(
+        typeof token === 'string' && token === expected,
+        `getNativeToken(${id}) === "${expected}" (got "${token}")`
+      );
+    } catch (err) {
+      fail(`getNativeToken(${id}) threw`, err.message);
+    }
+  }
+} else {
+  fail('getNativeToken is not a function');
+}
+
+// ─── E. Validation Utilities ─────────────────────────────────────────────────
+section('E. Validation Utilities');
+
+if (typeof validateAddress === 'function') {
+  // Valid EVM address
+  try {
+    const r = validateAddress('0x1234567890123456789012345678901234567890');
+    assert(r === true || r === undefined || r === null, 'validateAddress() accepts valid EVM address');
+  } catch (err) {
+    fail('validateAddress() threw on valid EVM address', err.message);
+  }
+
+  // Invalid address
+  try {
+    let threw = false;
+    let result;
+    try {
+      result = validateAddress('not-an-address');
+    } catch {
+      threw = true;
+    }
+    // Either throws or returns falsy
+    assert(threw || !result, 'validateAddress() rejects invalid address');
+  } catch (err) {
+    fail('validateAddress() invalid-address test failed', err.message);
+  }
+} else {
+  fail('validateAddress is not exported');
+}
+
+if (typeof validateAmount === 'function') {
+  try {
+    const r = validateAmount(1.0);
+    assert(r === true || r === undefined || r === null, 'validateAmount() accepts positive amount');
+  } catch (err) {
+    fail('validateAmount() threw on valid amount', err.message);
+  }
+
+  try {
+    let threw = false;
+    try {
+      validateAmount(0);
+    } catch {
+      threw = true;
+    }
+    assert(threw, 'validateAmount() rejects zero');
+  } catch (err) {
+    fail('validateAmount() zero-test failed', err.message);
+  }
+
+  try {
+    let threw = false;
+    try {
+      validateAmount(-1);
+    } catch {
+      threw = true;
+    }
+    assert(threw, 'validateAmount() rejects negative');
+  } catch (err) {
+    fail('validateAmount() negative-test failed', err.message);
+  }
+} else {
+  fail('validateAmount is not exported');
+}
+
+if (typeof validateSlippage === 'function') {
+  try {
+    const r = validateSlippage(0.5);
+    assert(r === true || r === undefined || r === null, 'validateSlippage() accepts 0.5');
+  } catch (err) {
+    fail('validateSlippage() threw on valid slippage', err.message);
+  }
+
+  try {
+    let threw = false;
+    try {
+      validateSlippage(101);
+    } catch {
+      threw = true;
+    }
+    assert(threw, 'validateSlippage() rejects > 100');
+  } catch (err) {
+    fail('validateSlippage() >100 test failed', err.message);
+  }
+} else {
+  fail('validateSlippage is not exported');
+}
+
+if (typeof validateChain === 'function') {
+  try {
+    const r = validateChain(1);
+    assert(r === true || r === undefined || r === null, 'validateChain() accepts chainId 1');
+  } catch (err) {
+    fail('validateChain() threw on valid chain', err.message);
+  }
+
+  try {
+    let threw = false;
+    try {
+      validateChain(99999999);
+    } catch {
+      threw = true;
+    }
+    assert(threw, 'validateChain() rejects unknown chainId');
+  } catch (err) {
+    fail('validateChain() invalid-chain test failed', err.message);
+  }
+} else {
+  fail('validateChain is not exported');
+}
+
+// ─── F. Wallet Generation (Offline) ──────────────────────────────────────────
+section('F. Wallet Generation (Offline)');
+
+if (typeof generateEvmWallet === 'function') {
+  try {
+    const wallet = generateEvmWallet();
+    assert(typeof wallet === 'object' && wallet !== null, 'generateEvmWallet() returns an object');
+    const address = wallet.address || wallet.walletAddress;
+    assert(typeof address === 'string' && address.startsWith('0x') && address.length === 42, `EVM address starts with 0x and is 42 chars (got "${address}")`);
+    const privKey = wallet.privateKey;
+    assert(typeof privKey === 'string' && privKey.length === 66, `EVM private key is 66 chars (got length ${privKey ? privKey.length : 'N/A'})`);
+  } catch (err) {
+    fail('generateEvmWallet() threw', err.message);
+  }
+} else {
+  fail('generateEvmWallet is not exported');
+}
+
+// ─── G. Error Classes ─────────────────────────────────────────────────────────
+section('G. Error Classes');
+
+const errorClassTests = [
+  ['GdexAuthError', GdexAuthError],
+  ['GdexValidationError', GdexValidationError],
+  ['GdexApiError', GdexApiError],
+  ['GdexNetworkError', GdexNetworkError],
+  ['GdexRateLimitError', GdexRateLimitError],
+];
+
+for (const [name, Cls] of errorClassTests) {
+  if (typeof Cls === 'function') {
+    try {
+      const err = new Cls('test error');
+      assert(err instanceof Error, `${name} extends Error`);
+      assert(err instanceof Cls, `${name} is instanceof-safe`);
+      assert(err.message === 'test error', `${name} preserves message`);
+    } catch (err) {
+      fail(`${name} constructor threw`, err.message);
+    }
+  } else {
+    fail(`${name} is not exported`);
+  }
+}
+
+// ─── H. Formatting Utilities ─────────────────────────────────────────────────
+section('H. Formatting Utilities');
+
+if (typeof formatUsd === 'function') {
+  try {
+    const result = formatUsd(1234567.89);
+    assert(typeof result === 'string', 'formatUsd() returns a string');
+    assert(result.includes('$') || result.includes(',') || result.includes('1234'), `formatUsd(1234567.89) looks reasonable: "${result}"`);
+  } catch (err) {
+    fail('formatUsd() threw', err.message);
+  }
+} else {
+  fail('formatUsd is not exported');
+}
+
+if (typeof formatTokenAmount === 'function') {
+  try {
+    const result = formatTokenAmount(1.23456789, 'ETH');
+    assert(typeof result === 'string', 'formatTokenAmount() returns a string');
+    assert(result.includes('1.2') || result.includes('1.23'), `formatTokenAmount(1.23456789, "ETH") is reasonable: "${result}"`);
+  } catch (err) {
+    fail('formatTokenAmount() threw', err.message);
+  }
+} else {
+  fail('formatTokenAmount is not exported');
+}
+
+if (typeof shortenAddress === 'function') {
+  try {
+    const evmAddr = '0x1234567890123456789012345678901234567890';
+    const shortened = shortenAddress(evmAddr);
+    assert(typeof shortened === 'string' && shortened.length < evmAddr.length, `shortenAddress() shortens EVM address: "${shortened}"`);
+  } catch (err) {
+    fail('shortenAddress() threw on EVM address', err.message);
+  }
+
+  try {
+    const solAddr = 'So11111111111111111111111111111111111111112';
+    const shortened = shortenAddress(solAddr);
+    assert(typeof shortened === 'string' && shortened.length < solAddr.length, `shortenAddress() shortens Solana address: "${shortened}"`);
+  } catch (err) {
+    fail('shortenAddress() threw on Solana address', err.message);
+  }
+} else {
+  fail('shortenAddress is not exported');
+}
+
+// ─── I. API Client Configuration ─────────────────────────────────────────────
+section('I. API Client Configuration');
+
+if (typeof GdexApiClient === 'function') {
+  try {
+    const client = new GdexApiClient({ baseUrl: 'https://trade-api.gemach.io/v1' });
+    pass('new GdexApiClient({ baseUrl }) created without error');
+
+    // Default base URL
+    const defaultClient = new GdexApiClient({});
+    const url = defaultClient.baseUrl || defaultClient.config?.baseUrl || defaultClient._baseUrl;
+    if (url) {
+      assert(url === 'https://trade-api.gemach.io/v1', `default baseUrl is "https://trade-api.gemach.io/v1" (got "${url}")`);
+    } else {
+      pass('GdexApiClient instantiated (baseUrl not directly accessible)');
+    }
+  } catch (err) {
+    fail('GdexApiClient instantiation threw', err.message);
+  }
+} else {
+  fail('GdexApiClient is not exported or not a constructor');
+}
+
+if (ENDPOINTS !== undefined) {
+  assert(typeof ENDPOINTS === 'object' && ENDPOINTS !== null, 'ENDPOINTS module is exported as an object');
+  const endpointKeys = Object.keys(ENDPOINTS);
+  assert(endpointKeys.length > 0, `ENDPOINTS has ${endpointKeys.length} endpoint entries`);
+} else {
+  fail('ENDPOINTS is not exported');
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+function printSummary() {
+  console.log(`\n${'─'.repeat(50)}`);
+  const total = passed + failed;
+  console.log(`Results: ${GREEN}${passed} passed${RESET} / ${failed > 0 ? RED : ''}${failed} failed${RESET} / ${total} total`);
+  if (failed === 0) {
+    console.log(`\n${GREEN}All integration tests passed ✓${RESET}`);
+  } else {
+    console.log(`\n${RED}Some tests failed — see details above${RESET}`);
+  }
+}
+
+printSummary();
+process.exit(failed > 0 ? 1 : 0);

--- a/gdex/trading/scripts/validate-skill.js
+++ b/gdex/trading/scripts/validate-skill.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Validate SKILL.md frontmatter against seren-skills spec rules.
+ * Run: node scripts/validate-skill.js
+ *
+ * Spec rules:
+ *   - Required: name, description
+ *   - name: 1-64 chars, lowercase letters/digits/hyphens, no leading/trailing
+ *     hyphen, no consecutive hyphens, must match parent directory name
+ *   - description: non-empty, <= 1024 chars
+ *   - Optional: license, compatibility, metadata, allowed-tools
+ *   - metadata must be string key/value pairs only
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const RESET = '\x1b[0m';
+
+let passed = 0;
+let failed = 0;
+const errors = [];
+
+function pass(label) {
+  console.log(`${GREEN}✓${RESET} ${label}`);
+  passed++;
+}
+
+function fail(label, detail) {
+  const msg = detail ? `${label}: ${detail}` : label;
+  console.log(`${RED}✗${RESET} ${msg}`);
+  errors.push(msg);
+  failed++;
+}
+
+function warn(label) {
+  console.log(`${YELLOW}⚠${RESET} ${label}`);
+}
+
+// ─── Locate SKILL.md ──────────────────────────────────────────────────────────
+// This script lives in scripts/, so SKILL.md is one level up
+const SKILL_ROOT = path.resolve(__dirname, '..');
+const SKILL_MD = path.join(SKILL_ROOT, 'SKILL.md');
+const PARENT_DIR = path.basename(SKILL_ROOT);
+
+console.log(`Validating SKILL.md in: ${SKILL_ROOT}\n`);
+
+if (!fs.existsSync(SKILL_MD)) {
+  fail('SKILL.md', 'file does not exist');
+  process.exit(1);
+}
+
+const content = fs.readFileSync(SKILL_MD, 'utf8');
+
+// ─── Extract YAML frontmatter ─────────────────────────────────────────────────
+const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+if (!fmMatch) {
+  fail('Frontmatter', 'SKILL.md must start with --- YAML frontmatter ---');
+  process.exit(1);
+}
+pass('SKILL.md has --- frontmatter delimiters');
+
+// Minimal YAML line parser for seren-skills SKILL.md frontmatter.
+// Handles: bare scalars, single-quoted, and double-quoted values (with \\-escaped
+// sequences). Does NOT support multi-line scalars or complex YAML structures;
+// those are outside the scope of this spec validator.
+function parseSimpleYaml(raw) {
+  const result = {};
+  let currentKey = null;
+  const lines = raw.split('\n');
+  for (const line of lines) {
+    // Skip blank/comment lines
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    // Indented lines — sub-keys under the current mapping key
+    if (/^\s+/.test(line) && currentKey) {
+      const sub = parseKeyValue(line.trim());
+      if (sub) {
+        if (typeof result[currentKey] !== 'object' || result[currentKey] === null) {
+          result[currentKey] = {};
+        }
+        result[currentKey][sub.key] = sub.value;
+      }
+      continue;
+    }
+
+    // Top-level key: value
+    const kv = parseKeyValue(line);
+    if (kv) {
+      result[kv.key] = kv.value;
+      currentKey = kv.key;
+    }
+  }
+  return result;
+}
+
+// Parse a single "key: value" line.  Returns { key, value } or null.
+// Handles bare scalars, "double-quoted", and 'single-quoted' values.
+function parseKeyValue(line) {
+  // Key portion: word chars and hyphens
+  const keyMatch = line.match(/^([\w][\w-]*):\s*/);
+  if (!keyMatch) return null;
+  const key = keyMatch[1];
+  const rest = line.slice(keyMatch[0].length);
+
+  let value = '';
+  if (rest.startsWith('"')) {
+    // Double-quoted: consume until the closing unescaped "
+    const inner = rest.slice(1);
+    const closeIdx = findClosingQuote(inner, '"');
+    value = closeIdx === -1 ? inner : inner.slice(0, closeIdx);
+    // Unescape standard backslash sequences
+    value = value.replace(/\\(["\\nrt])/g, (_, c) => ({ '"': '"', '\\': '\\', n: '\n', r: '\r', t: '\t' }[c] || c));
+  } else if (rest.startsWith("'")) {
+    // Single-quoted: '' is an escaped single quote inside
+    const inner = rest.slice(1);
+    const closeIdx = findClosingQuote(inner, "'");
+    value = (closeIdx === -1 ? inner : inner.slice(0, closeIdx)).replace(/''/g, "'");
+  } else {
+    // Bare scalar — strip inline comment
+    value = rest.replace(/\s+#.*$/, '').trim();
+  }
+
+  return { key, value };
+}
+
+// Find the index of the first unescaped closing quote character in str.
+function findClosingQuote(str, quoteChar) {
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === '\\' && quoteChar === '"') { i++; continue; }
+    if (str[i] === quoteChar) return i;
+  }
+  return -1;
+}
+
+const fm = parseSimpleYaml(fmMatch[1]);
+
+// ─── Required field: name ─────────────────────────────────────────────────────
+console.log('\n── name ──');
+const name = fm.name;
+
+if (!name || typeof name !== 'string' || name.length === 0) {
+  fail('name', 'required field is missing or empty');
+} else {
+  pass(`name is present: "${name}"`);
+
+  // Must match parent directory name
+  if (name === PARENT_DIR) {
+    pass(`name "${name}" matches parent directory "${PARENT_DIR}"`);
+  } else {
+    fail('name vs directory', `name "${name}" must match parent directory name "${PARENT_DIR}"`);
+  }
+
+  // Length 1-64
+  if (name.length >= 1 && name.length <= 64) {
+    pass(`name length ${name.length} is within 1-64 chars`);
+  } else {
+    fail('name length', `${name.length} chars — must be 1-64`);
+  }
+
+  // Charset: lowercase letters, digits, hyphens only
+  if (/^[a-z0-9-]+$/.test(name)) {
+    pass('name uses only lowercase letters, digits, and hyphens');
+  } else {
+    fail('name charset', `"${name}" contains invalid characters — only a-z, 0-9, - allowed`);
+  }
+
+  // No leading hyphen
+  if (!name.startsWith('-')) {
+    pass('name does not start with a hyphen');
+  } else {
+    fail('name leading hyphen', `"${name}" must not start with a hyphen`);
+  }
+
+  // No trailing hyphen
+  if (!name.endsWith('-')) {
+    pass('name does not end with a hyphen');
+  } else {
+    fail('name trailing hyphen', `"${name}" must not end with a hyphen`);
+  }
+
+  // No consecutive hyphens
+  if (!name.includes('--')) {
+    pass('name has no consecutive hyphens');
+  } else {
+    fail('name consecutive hyphens', `"${name}" must not contain consecutive hyphens`);
+  }
+}
+
+// ─── Required field: description ─────────────────────────────────────────────
+console.log('\n── description ──');
+const desc = fm.description;
+
+if (!desc || typeof desc !== 'string' || desc.length === 0) {
+  fail('description', 'required field is missing or empty');
+} else {
+  pass('description is present and non-empty');
+
+  if (desc.length <= 1024) {
+    pass(`description length ${desc.length} is <= 1024 chars`);
+  } else {
+    fail('description length', `${desc.length} chars — must be <= 1024`);
+  }
+}
+
+// ─── Optional fields ──────────────────────────────────────────────────────────
+console.log('\n── optional fields ──');
+const KNOWN_OPTIONAL = ['license', 'compatibility', 'metadata', 'allowed-tools'];
+const KNOWN_FIELDS = ['name', 'description', ...KNOWN_OPTIONAL];
+
+const unknownFields = Object.keys(fm).filter((k) => !KNOWN_FIELDS.includes(k));
+if (unknownFields.length > 0) {
+  warn(`Unknown frontmatter fields (not in spec): ${unknownFields.join(', ')}`);
+} else {
+  pass('All frontmatter fields are spec-defined');
+}
+
+// metadata must be string key/value pairs
+if (fm.metadata !== undefined) {
+  if (typeof fm.metadata === 'object' && fm.metadata !== null) {
+    const nonStringValues = Object.entries(fm.metadata).filter(([, v]) => typeof v !== 'string');
+    if (nonStringValues.length === 0) {
+      pass('metadata values are all strings');
+    } else {
+      fail('metadata', `non-string values: ${nonStringValues.map(([k]) => k).join(', ')}`);
+    }
+  } else {
+    fail('metadata', 'must be a mapping of string keys to string values');
+  }
+} else {
+  pass('metadata field is absent (optional)');
+}
+
+// ─── Body: H1 heading ─────────────────────────────────────────────────────────
+console.log('\n── document body ──');
+const bodyStart = content.indexOf('---', 3) + 3;
+const body = content.slice(bodyStart);
+const h1 = body.match(/^# .+/m);
+if (h1) {
+  pass(`H1 heading found: "${h1[0].trim()}"`);
+} else {
+  warn('No H1 heading found — spec recommends using the first H1 as display name');
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`${GREEN}Passed: ${passed}${RESET}  ${failed > 0 ? RED : ''}Failed: ${failed}${RESET}`);
+
+if (failed > 0) {
+  console.log(`\n${RED}Validation errors:${RESET}`);
+  for (const e of errors) console.log(`  • ${e}`);
+  process.exit(1);
+} else {
+  console.log(`\n${GREEN}SKILL.md is valid ✓${RESET}`);
+}

--- a/gdex/trading/scripts/verify.js
+++ b/gdex/trading/scripts/verify.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Offline SDK smoke test for @gdexsdk/gdex-skill
+ * Run: node scripts/verify.js
+ *
+ * This script verifies the SDK can be imported and core utilities work
+ * without making any network requests.
+ */
+
+'use strict';
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const RESET = '\x1b[0m';
+
+let passed = 0;
+let failed = 0;
+
+function pass(label) {
+  console.log(`${GREEN}✓${RESET} ${label}`);
+  passed++;
+}
+
+function fail(label, err) {
+  console.log(`${RED}✗${RESET} ${label}`);
+  if (err) console.log(`  ${RED}${err.message || err}${RESET}`);
+  failed++;
+}
+
+function section(title) {
+  console.log(`\n${YELLOW}▶ ${title}${RESET}`);
+}
+
+async function run() {
+  console.log('GDEX Skill — Offline Smoke Test\n');
+
+  // ── 1. Import ──────────────────────────────────────────────────────────────
+  section('SDK Import');
+  let sdk;
+  try {
+    sdk = require('@gdexsdk/gdex-skill');
+    pass('require("@gdexsdk/gdex-skill") succeeded');
+  } catch (err) {
+    fail('require("@gdexsdk/gdex-skill") failed', err);
+    console.log(`\n${RED}Cannot continue — install dependencies first:${RESET}`);
+    console.log('  npm install\n');
+    process.exit(1);
+  }
+
+  const {
+    GdexSkill,
+    GdexApiClient,
+    ChainId,
+    getChainName,
+    getNativeToken,
+    formatUsd,
+    formatTokenAmount,
+    shortenAddress,
+    validateAddress,
+    validateAmount,
+    GdexAuthError,
+    GdexValidationError,
+    GdexApiError,
+    GdexNetworkError,
+  } = sdk;
+
+  // ── 2. GdexSkill instantiation ─────────────────────────────────────────────
+  section('GdexSkill Instantiation');
+  let skill;
+  try {
+    skill = new GdexSkill();
+    pass('GdexSkill() instantiated with defaults');
+  } catch (err) {
+    fail('GdexSkill() instantiation failed', err);
+  }
+
+  try {
+    const custom = new GdexSkill({ baseUrl: 'https://trade-api.gemach.io/v1', timeout: 5000 });
+    pass('GdexSkill({ baseUrl, timeout }) instantiated with custom config');
+  } catch (err) {
+    fail('GdexSkill({ baseUrl, timeout }) failed', err);
+  }
+
+  // ── 3. Auth state management ───────────────────────────────────────────────
+  section('Authentication State');
+  try {
+    if (skill && typeof skill.isAuthenticated === 'function') {
+      const before = skill.isAuthenticated();
+      if (before === false) {
+        pass('isAuthenticated() returns false before login');
+      } else {
+        fail('isAuthenticated() should be false before login');
+      }
+    } else {
+      fail('skill.isAuthenticated is not a function');
+    }
+  } catch (err) {
+    fail('isAuthenticated() threw', err);
+  }
+
+  try {
+    if (skill && typeof skill.logout === 'function') {
+      skill.logout();
+      pass('logout() can be called without error');
+    } else {
+      fail('skill.logout is not a function');
+    }
+  } catch (err) {
+    fail('logout() threw', err);
+  }
+
+  // ── 4. API key check ───────────────────────────────────────────────────────
+  section('Environment');
+  if (process.env.GDEX_API_KEY) {
+    pass('GDEX_API_KEY is set');
+  } else {
+    console.log(`${YELLOW}⚠${RESET}  GDEX_API_KEY not set — live trading will not work`);
+  }
+
+  if (process.env.CONTROL_WALLET_PRIVATE_KEY) {
+    pass('CONTROL_WALLET_PRIVATE_KEY is set');
+  } else {
+    console.log(`${YELLOW}⚠${RESET}  CONTROL_WALLET_PRIVATE_KEY not set — managed-custody trading will not work`);
+  }
+
+  // ── 5. Chain configuration ─────────────────────────────────────────────────
+  section('Chain Configuration');
+  const expectedChains = {
+    ETHEREUM: 1,
+    BASE: 8453,
+    ARBITRUM: 42161,
+    BSC: 56,
+    SOLANA: 622112261,
+  };
+
+  for (const [name, id] of Object.entries(expectedChains)) {
+    if (ChainId && ChainId[name] === id) {
+      pass(`ChainId.${name} === ${id}`);
+    } else {
+      fail(`ChainId.${name} should be ${id}, got ${ChainId ? ChainId[name] : 'N/A'}`);
+    }
+  }
+
+  if (typeof getChainName === 'function') {
+    try {
+      const name = getChainName(1);
+      pass(`getChainName(1) = "${name}"`);
+    } catch (err) {
+      fail('getChainName(1) threw', err);
+    }
+  } else {
+    fail('getChainName is not exported');
+  }
+
+  if (typeof getNativeToken === 'function') {
+    try {
+      const token = getNativeToken(1);
+      pass(`getNativeToken(1) = "${token}"`);
+    } catch (err) {
+      fail('getNativeToken(1) threw', err);
+    }
+  } else {
+    fail('getNativeToken is not exported');
+  }
+
+  // ── 6. Formatting utilities ────────────────────────────────────────────────
+  section('Formatting Utilities');
+  if (typeof formatUsd === 'function') {
+    try {
+      const result = formatUsd(1234.56);
+      pass(`formatUsd(1234.56) = "${result}"`);
+    } catch (err) {
+      fail('formatUsd() threw', err);
+    }
+  } else {
+    fail('formatUsd is not exported');
+  }
+
+  if (typeof formatTokenAmount === 'function') {
+    try {
+      const result = formatTokenAmount(1.5, 'ETH');
+      pass(`formatTokenAmount(1.5, "ETH") = "${result}"`);
+    } catch (err) {
+      fail('formatTokenAmount() threw', err);
+    }
+  } else {
+    fail('formatTokenAmount is not exported');
+  }
+
+  // ── 7. Error classes ───────────────────────────────────────────────────────
+  section('Error Classes');
+  const errorClasses = { GdexAuthError, GdexValidationError, GdexApiError, GdexNetworkError };
+  for (const [name, Cls] of Object.entries(errorClasses)) {
+    if (typeof Cls === 'function') {
+      try {
+        const err = new Cls('test');
+        if (err instanceof Error && err instanceof Cls) {
+          pass(`${name} is a proper Error subclass`);
+        } else {
+          fail(`${name} instance check failed`);
+        }
+      } catch (e) {
+        fail(`${name} constructor threw`, e);
+      }
+    } else {
+      fail(`${name} is not exported`);
+    }
+  }
+
+  // ── Summary ────────────────────────────────────────────────────────────────
+  console.log(`\n${'─'.repeat(40)}`);
+  console.log(`${GREEN}Passed: ${passed}${RESET}  ${failed > 0 ? RED : ''}Failed: ${failed}${RESET}`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+run().catch((err) => {
+  console.error(`${RED}Unexpected error:${RESET}`, err);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces the initial implementation of the GDEX Trading skill for Seren Desktop, integrating the GDEX Trading SDK and providing comprehensive documentation, configuration, and validation tooling. It enables AI agents to perform cross-chain DeFi trading operations and includes environment setup, usage instructions, and utility scripts for validation and testing.

**Skill Documentation and Usage:**

- Added `SKILL.md` with detailed frontmatter, sub-skill descriptions, usage guidance, authentication notes, and environment variable requirements for the GDEX Trading skill. This document explains supported chains, sub-skill purposes, installation, and critical integration notes.
- Added `README.md` with a quickstart guide, directory layout, supported chains, and instructions for setting up and testing the skill.

**Configuration and Environment:**

- Added `.env.example` template specifying required environment variables `GDEX_API_KEY` and `CONTROL_WALLET_PRIVATE_KEY` for live and managed-custody trading.
- Added `package.json` declaring the skill package and its dependency on `@gdexsdk/gdex-skill`.

**Validation and Testing Scripts:**

- Added `scripts/validate-skill.js`, a CLI tool to validate the `SKILL.md` frontmatter against the Seren Skills spec, enforcing naming, description, and metadata rules.
- Added `scripts/verify.js`, an offline smoke test script to verify SDK import, key utilities, error classes, and environment configuration without making network requests.