### PR TITLE
fix: add Polymarket execution safety guardrails

### DIFF
--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -13,8 +13,8 @@ Autonomous trading agent for prediction markets integrating the Seren ecosystem.
 **READ THIS BEFORE USING**
 
 ### Geographic Restrictions - CRITICAL
-⚠️ **Polymarket is BLOCKED in the United States** following their 2022 CFTC settlement.
-⚠️ **Using VPNs or other methods to circumvent geographic restrictions may violate laws**.
+⚠️ **Polymarket access depends on jurisdiction, account eligibility, and current network environment**.
+⚠️ **If the current environment cannot reach the CLOB API, stop and surface the restriction instead of suggesting workarounds or bypasses**.
 ⚠️ **You are responsible for verifying that prediction market trading is legal in your jurisdiction**.
 
 ### Regulatory Status
@@ -138,6 +138,30 @@ python3 scripts/run_local_pull_runner.py --config config.json
 - Always confirm user has adequate budget before suggesting live mode
 - Emphasize paper trading first
 - Live trading requires a schedule created with `--live`
+
+## Trade Execution Contract
+
+When the user gives a direct exit instruction (`sell`, `close`, `exit`, `unwind`, `flatten`), execute the exit path immediately.
+Do not editorialize or argue against recovering remaining funds.
+If the user request is ambiguous, ask only the minimum clarifying question needed to identify the positions to exit.
+
+## CLOB Execution Rules
+
+- `py-clob-client` via `DirectClobTrader` from `scripts/polymarket_live.py` is the canonical live execution path.
+- For immediate sells, fetch the live order book, use the market `tick_size`, and submit a marketable sell priced at that market's minimum tick.
+- Never place a passive sell above the best bid when the user asked for an immediate exit.
+- Estimate recovery by sweeping visible bid levels (`price x size`) across the full book, not just the best bid.
+- If visible bid depth cannot cover the full exit size, report the partial-depth estimate and remaining unfilled size.
+
+## Pre-Trade Checklist (Mandatory)
+
+Before any live buy, sell, or unwind:
+
+1. Fetch the live order book for every token involved.
+2. Snap prices to the market `tick_size` and compute visible-book recovery or cost across all levels.
+3. Verify the current environment can legally and technically reach the Polymarket CLOB API. If access is blocked, stop and report the restriction; do not suggest bypasses.
+4. Verify `py-clob-client` is installed and `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY`, `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` are loaded.
+5. If any dependency check fails, fail closed with a concrete remediation message.
 
 ## Overview
 

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -142,15 +142,23 @@ class PolymarketClient:
         order_type: str = 'GTC',
     ) -> Dict:
         """Place an order via py-clob-client (local EIP-712 signing)."""
+        del order_type
+        from polymarket_live import fetch_book, fetch_fee_rate_bps, snap_price
+
         trader = self._require_trader()
+        book = fetch_book(token_id)
+        tick_size = str(book.get("tick_size", "0.01"))
+        neg_risk = bool(book.get("neg_risk", False))
+        fee_rate_bps = fetch_fee_rate_bps(token_id)
+        snapped_price = snap_price(price, tick_size, side)
         return trader.create_order(
             token_id=token_id,
             side=side,
-            price=price,
+            price=snapped_price,
             size=size,
-            tick_size="0.01",
-            neg_risk=False,
-            fee_rate_bps=0,
+            tick_size=tick_size,
+            neg_risk=neg_risk,
+            fee_rate_bps=fee_rate_bps,
         )
 
     def cancel_order(self, order_id: str) -> Dict:

--- a/polymarket/bot/scripts/polymarket_live.py
+++ b/polymarket/bot/scripts/polymarket_live.py
@@ -228,6 +228,90 @@ def parse_book_payload(payload: Any) -> dict[str, Any]:
     }
 
 
+def _book_levels(payload: Any, side: str) -> list[tuple[float, float]]:
+    if isinstance(payload, dict):
+        key = "asks" if side.upper() == "BUY" else "bids"
+        payload = payload.get(key)
+    if not isinstance(payload, list):
+        return []
+
+    levels: list[tuple[float, float]] = []
+    for level in payload:
+        if isinstance(level, dict):
+            price = safe_float(level.get("price"), 0.0)
+            size = safe_float(
+                level.get(
+                    "size",
+                    level.get("quantity", level.get("amount", level.get("shares", 0.0))),
+                ),
+                0.0,
+            )
+        elif isinstance(level, (list, tuple)) and len(level) >= 2:
+            price = safe_float(level[0], 0.0)
+            size = safe_float(level[1], 0.0)
+        else:
+            price = 0.0
+            size = 0.0
+        if price > 0.0 and size > 0.0:
+            levels.append((price, size))
+    return levels
+
+
+def estimate_book_fill_value(payload: Any, *, side: str, size: float) -> dict[str, float]:
+    requested_size = max(0.0, size)
+    remaining = requested_size
+    gross_value = 0.0
+    filled_size = 0.0
+    for level_price, level_size in _book_levels(payload, side):
+        take_size = min(remaining, level_size)
+        gross_value += take_size * level_price
+        filled_size += take_size
+        remaining -= take_size
+        if remaining <= 1e-9:
+            break
+    average_price = gross_value / filled_size if filled_size > 0.0 else 0.0
+    return {
+        "requested_size": round(requested_size, 6),
+        "fillable_size": round(filled_size, 6),
+        "unfilled_size": round(max(0.0, remaining), 6),
+        "gross_value": round(gross_value, 6),
+        "average_price": round(average_price, 6),
+    }
+
+
+def build_marketable_sell_order(
+    token_id: str,
+    shares: float,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+    tick_size = safe_str(book.get("tick_size"), "0.01")
+    tick_price = snap_price(safe_float(tick_size, 0.01), tick_size, "SELL")
+    best_bid = safe_float(book.get("best_bid"), 0.0)
+    best_ask = safe_float(book.get("best_ask"), 0.0)
+    estimate = estimate_book_fill_value(book.get("raw"), side="SELL", size=shares)
+    if best_bid <= 0.0 or estimate["fillable_size"] <= 0.0:
+        raise RuntimeError(
+            "no_bid_liquidity: order book has no executable bids for an immediate exit."
+        )
+    return {
+        "token_id": token_id,
+        "shares": round(max(0.0, shares), 6),
+        "price": tick_price,
+        "tick_size": tick_size,
+        "neg_risk": bool(book.get("neg_risk", False)),
+        "fee_rate_bps": fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds),
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "estimated_exit_value_usd": estimate["gross_value"],
+        "estimated_fill_size": estimate["fillable_size"],
+        "estimated_unfilled_size": estimate["unfilled_size"],
+        "estimated_average_price": estimate["average_price"],
+        "execution_style": "marketable-limit-min-tick",
+    }
+
+
 def extract_token_id(raw_market: dict[str, Any]) -> str:
     token_ids = json_to_list(raw_market.get("clobTokenIds"))
     if token_ids:
@@ -2433,34 +2517,45 @@ def sell_held_inventory(
         if shares <= 0 or token_id in covered_token_ids:
             continue
         try:
-            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
-            ask_price = safe_float(book.get("best_ask"), 0.0)
-            tick_size = safe_str(book.get("tick_size"), "0.01")
-            neg_risk = bool(book.get("neg_risk", False))
-            if ask_price <= 0.0:
-                continue
-            ask_price = snap_price(ask_price, tick_size, "SELL")
-            size = shares
-            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            sell_plan = build_marketable_sell_order(
+                token_id,
+                shares,
+                timeout_seconds=timeout_seconds,
+            )
             response = trader.create_order(
                 token_id=token_id,
                 side="SELL",
-                price=ask_price,
-                size=size,
-                tick_size=tick_size,
-                neg_risk=neg_risk,
-                fee_rate_bps=fee_rate_bps,
+                price=sell_plan["price"],
+                size=shares,
+                tick_size=sell_plan["tick_size"],
+                neg_risk=sell_plan["neg_risk"],
+                fee_rate_bps=sell_plan["fee_rate_bps"],
             )
             sells.append(
                 {
                     "token_id": token_id,
                     "side": "SELL",
-                    "price": ask_price,
-                    "size": round(size, 6),
+                    "price": sell_plan["price"],
+                    "size": round(shares, 6),
+                    "best_bid": sell_plan["best_bid"],
+                    "best_ask": sell_plan["best_ask"],
+                    "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                    "estimated_fill_size": sell_plan["estimated_fill_size"],
+                    "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                    "estimated_average_price": sell_plan["estimated_average_price"],
+                    "execution_style": sell_plan["execution_style"],
                     "source": "held-inventory-unwind",
                     "response": response,
                 }
             )
-        except Exception:
-            continue
+        except Exception as exc:
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "size": round(shares, 6),
+                    "source": "held-inventory-unwind",
+                    "error": str(exc),
+                }
+            )
     return sells

--- a/polymarket/bot/scripts/test_polymarket_client_auth.py
+++ b/polymarket/bot/scripts/test_polymarket_client_auth.py
@@ -43,3 +43,31 @@ class TestPolymarketClientInit:
         seren = _mock_seren()
         client = PolymarketClient(seren_client=seren, dry_run=True)
         assert client.get_balance() == 0.0
+
+    def test_place_order_uses_live_book_tick_size_and_fee_metadata(self, monkeypatch):
+        seren = _mock_seren()
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+
+        captured: dict[str, object] = {}
+
+        class FakeTrader:
+            def create_order(self, **kwargs):
+                captured.update(kwargs)
+                return {"orderID": "ORDER-123"}
+
+        client._trader = FakeTrader()
+
+        monkeypatch.setattr(
+            "polymarket_live.fetch_book",
+            lambda token_id: {"tick_size": "0.001", "neg_risk": True},
+        )
+        monkeypatch.setattr("polymarket_live.fetch_fee_rate_bps", lambda token_id: 13)
+        monkeypatch.setattr("polymarket_live.snap_price", lambda price, tick_size, side: 0.457)
+
+        result = client.place_order(token_id="TOKEN-1", side="SELL", size=5.0, price=0.4567)
+
+        assert result["orderID"] == "ORDER-123"
+        assert captured["price"] == 0.457
+        assert captured["tick_size"] == "0.001"
+        assert captured["neg_risk"] is True
+        assert captured["fee_rate_bps"] == 13

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -41,6 +41,40 @@ Live execution requires both:
 - `--yes-live` on the CLI
 - `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
+## Trade Execution Contract
+
+When the user gives a direct exit instruction (`sell`, `close`, `exit`, `unwind`, `flatten`), execute the exit path immediately.
+Do not editorialize or argue against recovering remaining funds.
+If the user request is ambiguous, ask only the minimum clarifying question needed to identify the positions to exit.
+
+## CLOB Exit Rules
+
+- `py-clob-client` via `DirectClobTrader` is the canonical live execution path.
+- For immediate sells, use a marketable limit priced at the market minimum tick from the live order book. Do not hardcode `$0.001`; use the current `tick_size`.
+- Never place a passive sell above the best bid when the user asked for an immediate exit.
+- Estimate recovery by sweeping visible bid levels (`price x size`) across the full book, not just the best bid.
+- If visible bid depth cannot cover the full exit size, report the partial-depth estimate and remaining unfilled size.
+
+## Pre-Trade Checklist (Mandatory)
+
+Before any live buy, sell, or unwind:
+
+1. Fetch the live order book for every token involved.
+2. Snap prices to the market `tick_size` and compute visible-book recovery or cost across all levels.
+3. Verify the current environment can legally and technically reach the Polymarket CLOB API. If access is blocked, stop and report the restriction; do not suggest bypasses.
+4. Verify `py-clob-client` is installed and `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY`, `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` are loaded.
+5. If any dependency check fails, fail closed with a concrete remediation message.
+
+## Emergency Exit
+
+Immediately liquidate held inventory with:
+
+```bash
+python3 scripts/agent.py --config config.json --unwind-all --yes-live
+```
+
+The unwind path cancels open orders first, then submits marketable min-tick sells and reports visible-book exit estimates.
+
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -26,6 +26,7 @@ if str(_SCRIPT_DIR) not in sys.path:
 from polymarket_live import (
     DEFAULT_STALE_ORDER_MAX_AGE_SECONDS,
     DEFAULT_UNWIND_BEFORE_RESOLUTION_SECONDS,
+    build_marketable_sell_order,
     cancel_stale_orders,
     positions_by_key,
     DirectClobTrader,
@@ -2004,11 +2005,31 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
             if shares <= 0:
                 continue
             try:
-                from polymarket_live import fetch_midpoint
-                mid = fetch_midpoint(token_id, fallback_mid=0.5)
-                sell_price = round(max(0.01, mid * 0.95), 4)
-                response = trader.create_order(token_id=token_id, side="SELL", price=sell_price, size=shares, tick_size="0.01", neg_risk=False, fee_rate_bps=0)
-                sell_results.append({"token_id": token_id, "shares": shares, "price": sell_price, "response": response})
+                sell_plan = build_marketable_sell_order(token_id, shares)
+                response = trader.create_order(
+                    token_id=token_id,
+                    side="SELL",
+                    price=sell_plan["price"],
+                    size=shares,
+                    tick_size=sell_plan["tick_size"],
+                    neg_risk=sell_plan["neg_risk"],
+                    fee_rate_bps=sell_plan["fee_rate_bps"],
+                )
+                sell_results.append(
+                    {
+                        "token_id": token_id,
+                        "shares": round(shares, 6),
+                        "price": sell_plan["price"],
+                        "best_bid": sell_plan["best_bid"],
+                        "best_ask": sell_plan["best_ask"],
+                        "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                        "estimated_fill_size": sell_plan["estimated_fill_size"],
+                        "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                        "estimated_average_price": sell_plan["estimated_average_price"],
+                        "execution_style": sell_plan["execution_style"],
+                        "response": response,
+                    }
+                )
             except Exception as sell_exc:
                 sell_results.append({"token_id": token_id, "shares": shares, "error": str(sell_exc)})
         results["sell_results"] = sell_results

--- a/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
@@ -228,6 +228,90 @@ def parse_book_payload(payload: Any) -> dict[str, Any]:
     }
 
 
+def _book_levels(payload: Any, side: str) -> list[tuple[float, float]]:
+    if isinstance(payload, dict):
+        key = "asks" if side.upper() == "BUY" else "bids"
+        payload = payload.get(key)
+    if not isinstance(payload, list):
+        return []
+
+    levels: list[tuple[float, float]] = []
+    for level in payload:
+        if isinstance(level, dict):
+            price = safe_float(level.get("price"), 0.0)
+            size = safe_float(
+                level.get(
+                    "size",
+                    level.get("quantity", level.get("amount", level.get("shares", 0.0))),
+                ),
+                0.0,
+            )
+        elif isinstance(level, (list, tuple)) and len(level) >= 2:
+            price = safe_float(level[0], 0.0)
+            size = safe_float(level[1], 0.0)
+        else:
+            price = 0.0
+            size = 0.0
+        if price > 0.0 and size > 0.0:
+            levels.append((price, size))
+    return levels
+
+
+def estimate_book_fill_value(payload: Any, *, side: str, size: float) -> dict[str, float]:
+    requested_size = max(0.0, size)
+    remaining = requested_size
+    gross_value = 0.0
+    filled_size = 0.0
+    for level_price, level_size in _book_levels(payload, side):
+        take_size = min(remaining, level_size)
+        gross_value += take_size * level_price
+        filled_size += take_size
+        remaining -= take_size
+        if remaining <= 1e-9:
+            break
+    average_price = gross_value / filled_size if filled_size > 0.0 else 0.0
+    return {
+        "requested_size": round(requested_size, 6),
+        "fillable_size": round(filled_size, 6),
+        "unfilled_size": round(max(0.0, remaining), 6),
+        "gross_value": round(gross_value, 6),
+        "average_price": round(average_price, 6),
+    }
+
+
+def build_marketable_sell_order(
+    token_id: str,
+    shares: float,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+    tick_size = safe_str(book.get("tick_size"), "0.01")
+    tick_price = snap_price(safe_float(tick_size, 0.01), tick_size, "SELL")
+    best_bid = safe_float(book.get("best_bid"), 0.0)
+    best_ask = safe_float(book.get("best_ask"), 0.0)
+    estimate = estimate_book_fill_value(book.get("raw"), side="SELL", size=shares)
+    if best_bid <= 0.0 or estimate["fillable_size"] <= 0.0:
+        raise RuntimeError(
+            "no_bid_liquidity: order book has no executable bids for an immediate exit."
+        )
+    return {
+        "token_id": token_id,
+        "shares": round(max(0.0, shares), 6),
+        "price": tick_price,
+        "tick_size": tick_size,
+        "neg_risk": bool(book.get("neg_risk", False)),
+        "fee_rate_bps": fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds),
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "estimated_exit_value_usd": estimate["gross_value"],
+        "estimated_fill_size": estimate["fillable_size"],
+        "estimated_unfilled_size": estimate["unfilled_size"],
+        "estimated_average_price": estimate["average_price"],
+        "execution_style": "marketable-limit-min-tick",
+    }
+
+
 def extract_token_id(raw_market: dict[str, Any]) -> str:
     token_ids = json_to_list(raw_market.get("clobTokenIds"))
     if token_ids:
@@ -2433,34 +2517,45 @@ def sell_held_inventory(
         if shares <= 0 or token_id in covered_token_ids:
             continue
         try:
-            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
-            ask_price = safe_float(book.get("best_ask"), 0.0)
-            tick_size = safe_str(book.get("tick_size"), "0.01")
-            neg_risk = bool(book.get("neg_risk", False))
-            if ask_price <= 0.0:
-                continue
-            ask_price = snap_price(ask_price, tick_size, "SELL")
-            size = shares
-            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            sell_plan = build_marketable_sell_order(
+                token_id,
+                shares,
+                timeout_seconds=timeout_seconds,
+            )
             response = trader.create_order(
                 token_id=token_id,
                 side="SELL",
-                price=ask_price,
-                size=size,
-                tick_size=tick_size,
-                neg_risk=neg_risk,
-                fee_rate_bps=fee_rate_bps,
+                price=sell_plan["price"],
+                size=shares,
+                tick_size=sell_plan["tick_size"],
+                neg_risk=sell_plan["neg_risk"],
+                fee_rate_bps=sell_plan["fee_rate_bps"],
             )
             sells.append(
                 {
                     "token_id": token_id,
                     "side": "SELL",
-                    "price": ask_price,
-                    "size": round(size, 6),
+                    "price": sell_plan["price"],
+                    "size": round(shares, 6),
+                    "best_bid": sell_plan["best_bid"],
+                    "best_ask": sell_plan["best_ask"],
+                    "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                    "estimated_fill_size": sell_plan["estimated_fill_size"],
+                    "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                    "estimated_average_price": sell_plan["estimated_average_price"],
+                    "execution_style": sell_plan["execution_style"],
                     "source": "held-inventory-unwind",
                     "response": response,
                 }
             )
-        except Exception:
-            continue
+        except Exception as exc:
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "size": round(shares, 6),
+                    "source": "held-inventory-unwind",
+                    "error": str(exc),
+                }
+            )
     return sells

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -41,6 +41,40 @@ Live execution requires both:
 - `--yes-live` on the CLI
 - `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
+## Trade Execution Contract
+
+When the user gives a direct exit instruction (`sell`, `close`, `exit`, `unwind`, `flatten`), execute the exit path immediately.
+Do not editorialize or argue against recovering remaining funds.
+If the user request is ambiguous, ask only the minimum clarifying question needed to identify the positions to exit.
+
+## CLOB Exit Rules
+
+- `py-clob-client` via `DirectClobTrader` is the canonical live execution path.
+- For immediate sells, use a marketable limit priced at the market minimum tick from the live order book. Do not hardcode `$0.001`; use the current `tick_size`.
+- Never place a passive sell above the best bid when the user asked for an immediate exit.
+- Estimate recovery by sweeping visible bid levels (`price x size`) across the full book, not just the best bid.
+- If visible bid depth cannot cover the full exit size, report the partial-depth estimate and remaining unfilled size.
+
+## Pre-Trade Checklist (Mandatory)
+
+Before any live buy, sell, or unwind:
+
+1. Fetch the live order book for every token involved.
+2. Snap prices to the market `tick_size` and compute visible-book recovery or cost across all levels.
+3. Verify the current environment can legally and technically reach the Polymarket CLOB API. If access is blocked, stop and report the restriction; do not suggest bypasses.
+4. Verify `py-clob-client` is installed and `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY`, `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` are loaded.
+5. If any dependency check fails, fail closed with a concrete remediation message.
+
+## Emergency Exit
+
+Immediately liquidate held inventory with:
+
+```bash
+python3 scripts/agent.py --config config.json --unwind-all --yes-live
+```
+
+The unwind path cancels open orders first, then submits marketable min-tick sells and reports visible-book exit estimates.
+
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -26,6 +26,7 @@ if str(_SCRIPT_DIR) not in sys.path:
 from polymarket_live import (
     DEFAULT_STALE_ORDER_MAX_AGE_SECONDS,
     DEFAULT_UNWIND_BEFORE_RESOLUTION_SECONDS,
+    build_marketable_sell_order,
     cancel_stale_orders,
     positions_by_key,
     DirectClobTrader,
@@ -2065,11 +2066,31 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
             if shares <= 0:
                 continue
             try:
-                from polymarket_live import fetch_midpoint
-                mid = fetch_midpoint(token_id, fallback_mid=0.5)
-                sell_price = round(max(0.01, mid * 0.95), 4)
-                response = trader.create_order(token_id=token_id, side="SELL", price=sell_price, size=shares, tick_size="0.01", neg_risk=False, fee_rate_bps=0)
-                sell_results.append({"token_id": token_id, "shares": shares, "price": sell_price, "response": response})
+                sell_plan = build_marketable_sell_order(token_id, shares)
+                response = trader.create_order(
+                    token_id=token_id,
+                    side="SELL",
+                    price=sell_plan["price"],
+                    size=shares,
+                    tick_size=sell_plan["tick_size"],
+                    neg_risk=sell_plan["neg_risk"],
+                    fee_rate_bps=sell_plan["fee_rate_bps"],
+                )
+                sell_results.append(
+                    {
+                        "token_id": token_id,
+                        "shares": round(shares, 6),
+                        "price": sell_plan["price"],
+                        "best_bid": sell_plan["best_bid"],
+                        "best_ask": sell_plan["best_ask"],
+                        "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                        "estimated_fill_size": sell_plan["estimated_fill_size"],
+                        "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                        "estimated_average_price": sell_plan["estimated_average_price"],
+                        "execution_style": sell_plan["execution_style"],
+                        "response": response,
+                    }
+                )
             except Exception as sell_exc:
                 sell_results.append({"token_id": token_id, "shares": shares, "error": str(sell_exc)})
         results["sell_results"] = sell_results

--- a/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
@@ -228,6 +228,90 @@ def parse_book_payload(payload: Any) -> dict[str, Any]:
     }
 
 
+def _book_levels(payload: Any, side: str) -> list[tuple[float, float]]:
+    if isinstance(payload, dict):
+        key = "asks" if side.upper() == "BUY" else "bids"
+        payload = payload.get(key)
+    if not isinstance(payload, list):
+        return []
+
+    levels: list[tuple[float, float]] = []
+    for level in payload:
+        if isinstance(level, dict):
+            price = safe_float(level.get("price"), 0.0)
+            size = safe_float(
+                level.get(
+                    "size",
+                    level.get("quantity", level.get("amount", level.get("shares", 0.0))),
+                ),
+                0.0,
+            )
+        elif isinstance(level, (list, tuple)) and len(level) >= 2:
+            price = safe_float(level[0], 0.0)
+            size = safe_float(level[1], 0.0)
+        else:
+            price = 0.0
+            size = 0.0
+        if price > 0.0 and size > 0.0:
+            levels.append((price, size))
+    return levels
+
+
+def estimate_book_fill_value(payload: Any, *, side: str, size: float) -> dict[str, float]:
+    requested_size = max(0.0, size)
+    remaining = requested_size
+    gross_value = 0.0
+    filled_size = 0.0
+    for level_price, level_size in _book_levels(payload, side):
+        take_size = min(remaining, level_size)
+        gross_value += take_size * level_price
+        filled_size += take_size
+        remaining -= take_size
+        if remaining <= 1e-9:
+            break
+    average_price = gross_value / filled_size if filled_size > 0.0 else 0.0
+    return {
+        "requested_size": round(requested_size, 6),
+        "fillable_size": round(filled_size, 6),
+        "unfilled_size": round(max(0.0, remaining), 6),
+        "gross_value": round(gross_value, 6),
+        "average_price": round(average_price, 6),
+    }
+
+
+def build_marketable_sell_order(
+    token_id: str,
+    shares: float,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+    tick_size = safe_str(book.get("tick_size"), "0.01")
+    tick_price = snap_price(safe_float(tick_size, 0.01), tick_size, "SELL")
+    best_bid = safe_float(book.get("best_bid"), 0.0)
+    best_ask = safe_float(book.get("best_ask"), 0.0)
+    estimate = estimate_book_fill_value(book.get("raw"), side="SELL", size=shares)
+    if best_bid <= 0.0 or estimate["fillable_size"] <= 0.0:
+        raise RuntimeError(
+            "no_bid_liquidity: order book has no executable bids for an immediate exit."
+        )
+    return {
+        "token_id": token_id,
+        "shares": round(max(0.0, shares), 6),
+        "price": tick_price,
+        "tick_size": tick_size,
+        "neg_risk": bool(book.get("neg_risk", False)),
+        "fee_rate_bps": fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds),
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "estimated_exit_value_usd": estimate["gross_value"],
+        "estimated_fill_size": estimate["fillable_size"],
+        "estimated_unfilled_size": estimate["unfilled_size"],
+        "estimated_average_price": estimate["average_price"],
+        "execution_style": "marketable-limit-min-tick",
+    }
+
+
 def extract_token_id(raw_market: dict[str, Any]) -> str:
     token_ids = json_to_list(raw_market.get("clobTokenIds"))
     if token_ids:
@@ -2433,34 +2517,45 @@ def sell_held_inventory(
         if shares <= 0 or token_id in covered_token_ids:
             continue
         try:
-            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
-            ask_price = safe_float(book.get("best_ask"), 0.0)
-            tick_size = safe_str(book.get("tick_size"), "0.01")
-            neg_risk = bool(book.get("neg_risk", False))
-            if ask_price <= 0.0:
-                continue
-            ask_price = snap_price(ask_price, tick_size, "SELL")
-            size = shares
-            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            sell_plan = build_marketable_sell_order(
+                token_id,
+                shares,
+                timeout_seconds=timeout_seconds,
+            )
             response = trader.create_order(
                 token_id=token_id,
                 side="SELL",
-                price=ask_price,
-                size=size,
-                tick_size=tick_size,
-                neg_risk=neg_risk,
-                fee_rate_bps=fee_rate_bps,
+                price=sell_plan["price"],
+                size=shares,
+                tick_size=sell_plan["tick_size"],
+                neg_risk=sell_plan["neg_risk"],
+                fee_rate_bps=sell_plan["fee_rate_bps"],
             )
             sells.append(
                 {
                     "token_id": token_id,
                     "side": "SELL",
-                    "price": ask_price,
-                    "size": round(size, 6),
+                    "price": sell_plan["price"],
+                    "size": round(shares, 6),
+                    "best_bid": sell_plan["best_bid"],
+                    "best_ask": sell_plan["best_ask"],
+                    "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                    "estimated_fill_size": sell_plan["estimated_fill_size"],
+                    "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                    "estimated_average_price": sell_plan["estimated_average_price"],
+                    "execution_style": sell_plan["execution_style"],
                     "source": "held-inventory-unwind",
                     "response": response,
                 }
             )
-        except Exception:
-            continue
+        except Exception as exc:
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "size": round(shares, 6),
+                    "source": "held-inventory-unwind",
+                    "error": str(exc),
+                }
+            )
     return sells

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -37,6 +37,40 @@ Live execution also requires:
 - `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) for EIP-712 order signing
 - `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` for authenticated submission
 
+## Trade Execution Contract
+
+When the user gives a direct exit instruction (`sell`, `close`, `exit`, `unwind`, `flatten`), execute the exit path immediately.
+Do not editorialize or argue against recovering remaining funds.
+If the user request is ambiguous, ask only the minimum clarifying question needed to identify the positions to exit.
+
+## CLOB Exit Rules
+
+- `py-clob-client` via `DirectClobTrader` is the canonical live execution path.
+- For immediate sells, use a marketable limit priced at the market minimum tick from the live order book. Do not hardcode `$0.001`; use the current `tick_size`.
+- Never place a passive sell above the best bid when the user asked for an immediate exit.
+- Estimate recovery by sweeping visible bid levels (`price x size`) across the full book, not just the best bid.
+- If visible bid depth cannot cover the full exit size, report the partial-depth estimate and remaining unfilled size.
+
+## Pre-Trade Checklist (Mandatory)
+
+Before any live buy, sell, or unwind:
+
+1. Fetch the live order book for every token involved.
+2. Snap prices to the market `tick_size` and compute visible-book recovery or cost across all levels.
+3. Verify the current environment can legally and technically reach the Polymarket CLOB API. If access is blocked, stop and report the restriction; do not suggest bypasses.
+4. Verify `py-clob-client` is installed and `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY`, `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` are loaded.
+5. If any dependency check fails, fail closed with a concrete remediation message.
+
+## Emergency Exit
+
+Immediately liquidate held inventory with:
+
+```bash
+python3 scripts/agent.py --config config.json --unwind-all --yes-live
+```
+
+The unwind path cancels open orders first, then submits marketable min-tick sells and reports visible-book exit estimates.
+
 ## Runtime Files
 
 - `scripts/agent.py` - rebate-aware quoting engine with risk guards

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -25,6 +25,7 @@ if str(_SCRIPT_DIR) not in sys.path:
 from polymarket_live import (
     DEFAULT_STALE_ORDER_MAX_AGE_SECONDS,
     DEFAULT_UNWIND_BEFORE_RESOLUTION_SECONDS,
+    build_marketable_sell_order,
     DirectClobTrader,
     cancel_stale_orders,
     execute_single_market_quotes,
@@ -2346,19 +2347,31 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
             if shares <= 0:
                 continue
             try:
-                from polymarket_live import fetch_midpoint
-                mid = fetch_midpoint(token_id, fallback_mid=0.5)
-                sell_price = round(max(0.01, mid * 0.95), 4)
+                sell_plan = build_marketable_sell_order(token_id, shares)
                 response = trader.create_order(
                     token_id=token_id,
                     side="SELL",
-                    price=sell_price,
+                    price=sell_plan["price"],
                     size=shares,
-                    tick_size="0.01",
-                    neg_risk=False,
-                    fee_rate_bps=0,
+                    tick_size=sell_plan["tick_size"],
+                    neg_risk=sell_plan["neg_risk"],
+                    fee_rate_bps=sell_plan["fee_rate_bps"],
                 )
-                sell_results.append({"token_id": token_id, "shares": shares, "price": sell_price, "response": response})
+                sell_results.append(
+                    {
+                        "token_id": token_id,
+                        "shares": round(shares, 6),
+                        "price": sell_plan["price"],
+                        "best_bid": sell_plan["best_bid"],
+                        "best_ask": sell_plan["best_ask"],
+                        "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                        "estimated_fill_size": sell_plan["estimated_fill_size"],
+                        "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                        "estimated_average_price": sell_plan["estimated_average_price"],
+                        "execution_style": sell_plan["execution_style"],
+                        "response": response,
+                    }
+                )
             except Exception as sell_exc:
                 sell_results.append({"token_id": token_id, "shares": shares, "error": str(sell_exc)})
         results["sell_results"] = sell_results

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -228,6 +228,90 @@ def parse_book_payload(payload: Any) -> dict[str, Any]:
     }
 
 
+def _book_levels(payload: Any, side: str) -> list[tuple[float, float]]:
+    if isinstance(payload, dict):
+        key = "asks" if side.upper() == "BUY" else "bids"
+        payload = payload.get(key)
+    if not isinstance(payload, list):
+        return []
+
+    levels: list[tuple[float, float]] = []
+    for level in payload:
+        if isinstance(level, dict):
+            price = safe_float(level.get("price"), 0.0)
+            size = safe_float(
+                level.get(
+                    "size",
+                    level.get("quantity", level.get("amount", level.get("shares", 0.0))),
+                ),
+                0.0,
+            )
+        elif isinstance(level, (list, tuple)) and len(level) >= 2:
+            price = safe_float(level[0], 0.0)
+            size = safe_float(level[1], 0.0)
+        else:
+            price = 0.0
+            size = 0.0
+        if price > 0.0 and size > 0.0:
+            levels.append((price, size))
+    return levels
+
+
+def estimate_book_fill_value(payload: Any, *, side: str, size: float) -> dict[str, float]:
+    requested_size = max(0.0, size)
+    remaining = requested_size
+    gross_value = 0.0
+    filled_size = 0.0
+    for level_price, level_size in _book_levels(payload, side):
+        take_size = min(remaining, level_size)
+        gross_value += take_size * level_price
+        filled_size += take_size
+        remaining -= take_size
+        if remaining <= 1e-9:
+            break
+    average_price = gross_value / filled_size if filled_size > 0.0 else 0.0
+    return {
+        "requested_size": round(requested_size, 6),
+        "fillable_size": round(filled_size, 6),
+        "unfilled_size": round(max(0.0, remaining), 6),
+        "gross_value": round(gross_value, 6),
+        "average_price": round(average_price, 6),
+    }
+
+
+def build_marketable_sell_order(
+    token_id: str,
+    shares: float,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+    tick_size = safe_str(book.get("tick_size"), "0.01")
+    tick_price = snap_price(safe_float(tick_size, 0.01), tick_size, "SELL")
+    best_bid = safe_float(book.get("best_bid"), 0.0)
+    best_ask = safe_float(book.get("best_ask"), 0.0)
+    estimate = estimate_book_fill_value(book.get("raw"), side="SELL", size=shares)
+    if best_bid <= 0.0 or estimate["fillable_size"] <= 0.0:
+        raise RuntimeError(
+            "no_bid_liquidity: order book has no executable bids for an immediate exit."
+        )
+    return {
+        "token_id": token_id,
+        "shares": round(max(0.0, shares), 6),
+        "price": tick_price,
+        "tick_size": tick_size,
+        "neg_risk": bool(book.get("neg_risk", False)),
+        "fee_rate_bps": fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds),
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "estimated_exit_value_usd": estimate["gross_value"],
+        "estimated_fill_size": estimate["fillable_size"],
+        "estimated_unfilled_size": estimate["unfilled_size"],
+        "estimated_average_price": estimate["average_price"],
+        "execution_style": "marketable-limit-min-tick",
+    }
+
+
 def extract_token_id(raw_market: dict[str, Any]) -> str:
     token_ids = json_to_list(raw_market.get("clobTokenIds"))
     if token_ids:
@@ -2433,34 +2517,45 @@ def sell_held_inventory(
         if shares <= 0 or token_id in covered_token_ids:
             continue
         try:
-            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
-            ask_price = safe_float(book.get("best_ask"), 0.0)
-            tick_size = safe_str(book.get("tick_size"), "0.01")
-            neg_risk = bool(book.get("neg_risk", False))
-            if ask_price <= 0.0:
-                continue
-            ask_price = snap_price(ask_price, tick_size, "SELL")
-            size = shares
-            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            sell_plan = build_marketable_sell_order(
+                token_id,
+                shares,
+                timeout_seconds=timeout_seconds,
+            )
             response = trader.create_order(
                 token_id=token_id,
                 side="SELL",
-                price=ask_price,
-                size=size,
-                tick_size=tick_size,
-                neg_risk=neg_risk,
-                fee_rate_bps=fee_rate_bps,
+                price=sell_plan["price"],
+                size=shares,
+                tick_size=sell_plan["tick_size"],
+                neg_risk=sell_plan["neg_risk"],
+                fee_rate_bps=sell_plan["fee_rate_bps"],
             )
             sells.append(
                 {
                     "token_id": token_id,
                     "side": "SELL",
-                    "price": ask_price,
-                    "size": round(size, 6),
+                    "price": sell_plan["price"],
+                    "size": round(shares, 6),
+                    "best_bid": sell_plan["best_bid"],
+                    "best_ask": sell_plan["best_ask"],
+                    "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                    "estimated_fill_size": sell_plan["estimated_fill_size"],
+                    "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                    "estimated_average_price": sell_plan["estimated_average_price"],
+                    "execution_style": sell_plan["execution_style"],
                     "source": "held-inventory-unwind",
                     "response": response,
                 }
             )
-        except Exception:
-            continue
+        except Exception as exc:
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "size": round(shares, 6),
+                    "source": "held-inventory-unwind",
+                    "error": str(exc),
+                }
+            )
     return sells

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -41,6 +41,40 @@ Live execution requires both:
 - `--yes-live` on the CLI
 - `POLY_PRIVATE_KEY` (or `WALLET_PRIVATE_KEY`) plus `POLY_API_KEY` / `POLY_PASSPHRASE` / `POLY_SECRET`
 
+## Trade Execution Contract
+
+When the user gives a direct exit instruction (`sell`, `close`, `exit`, `unwind`, `flatten`), execute the exit path immediately.
+Do not editorialize or argue against recovering remaining funds.
+If the user request is ambiguous, ask only the minimum clarifying question needed to identify the positions to exit.
+
+## CLOB Exit Rules
+
+- `py-clob-client` via `DirectClobTrader` is the canonical live execution path.
+- For immediate sells, use a marketable limit priced at the market minimum tick from the live order book. Do not hardcode `$0.001`; use the current `tick_size`.
+- Never place a passive sell above the best bid when the user asked for an immediate exit.
+- Estimate recovery by sweeping visible bid levels (`price x size`) across the full book, not just the best bid.
+- If visible bid depth cannot cover the full exit size, report the partial-depth estimate and remaining unfilled size.
+
+## Pre-Trade Checklist (Mandatory)
+
+Before any live buy, sell, or unwind:
+
+1. Fetch the live order book for every token involved.
+2. Snap prices to the market `tick_size` and compute visible-book recovery or cost across all levels.
+3. Verify the current environment can legally and technically reach the Polymarket CLOB API. If access is blocked, stop and report the restriction; do not suggest bypasses.
+4. Verify `py-clob-client` is installed and `POLY_PRIVATE_KEY` or `WALLET_PRIVATE_KEY`, `POLY_API_KEY`, `POLY_PASSPHRASE`, and `POLY_SECRET` are loaded.
+5. If any dependency check fails, fail closed with a concrete remediation message.
+
+## Emergency Exit
+
+Immediately liquidate held inventory with:
+
+```bash
+python3 scripts/agent.py --config config.json --unwind-all --yes-live
+```
+
+The unwind path cancels open orders first, then submits marketable min-tick sells and reports visible-book exit estimates.
+
 ## Runtime Files
 
 - `scripts/agent.py` - basis backtest + paired trade-intent runtime

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -26,6 +26,7 @@ if str(_SCRIPT_DIR) not in sys.path:
 from polymarket_live import (
     DEFAULT_STALE_ORDER_MAX_AGE_SECONDS,
     DEFAULT_UNWIND_BEFORE_RESOLUTION_SECONDS,
+    build_marketable_sell_order,
     cancel_stale_orders,
     positions_by_key,
     DirectClobTrader,
@@ -2004,11 +2005,31 @@ def run_unwind_all(config: dict[str, Any]) -> dict[str, Any]:
             if shares <= 0:
                 continue
             try:
-                from polymarket_live import fetch_midpoint
-                mid = fetch_midpoint(token_id, fallback_mid=0.5)
-                sell_price = round(max(0.01, mid * 0.95), 4)
-                response = trader.create_order(token_id=token_id, side="SELL", price=sell_price, size=shares, tick_size="0.01", neg_risk=False, fee_rate_bps=0)
-                sell_results.append({"token_id": token_id, "shares": shares, "price": sell_price, "response": response})
+                sell_plan = build_marketable_sell_order(token_id, shares)
+                response = trader.create_order(
+                    token_id=token_id,
+                    side="SELL",
+                    price=sell_plan["price"],
+                    size=shares,
+                    tick_size=sell_plan["tick_size"],
+                    neg_risk=sell_plan["neg_risk"],
+                    fee_rate_bps=sell_plan["fee_rate_bps"],
+                )
+                sell_results.append(
+                    {
+                        "token_id": token_id,
+                        "shares": round(shares, 6),
+                        "price": sell_plan["price"],
+                        "best_bid": sell_plan["best_bid"],
+                        "best_ask": sell_plan["best_ask"],
+                        "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                        "estimated_fill_size": sell_plan["estimated_fill_size"],
+                        "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                        "estimated_average_price": sell_plan["estimated_average_price"],
+                        "execution_style": sell_plan["execution_style"],
+                        "response": response,
+                    }
+                )
             except Exception as sell_exc:
                 sell_results.append({"token_id": token_id, "shares": shares, "error": str(sell_exc)})
         results["sell_results"] = sell_results

--- a/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
@@ -228,6 +228,90 @@ def parse_book_payload(payload: Any) -> dict[str, Any]:
     }
 
 
+def _book_levels(payload: Any, side: str) -> list[tuple[float, float]]:
+    if isinstance(payload, dict):
+        key = "asks" if side.upper() == "BUY" else "bids"
+        payload = payload.get(key)
+    if not isinstance(payload, list):
+        return []
+
+    levels: list[tuple[float, float]] = []
+    for level in payload:
+        if isinstance(level, dict):
+            price = safe_float(level.get("price"), 0.0)
+            size = safe_float(
+                level.get(
+                    "size",
+                    level.get("quantity", level.get("amount", level.get("shares", 0.0))),
+                ),
+                0.0,
+            )
+        elif isinstance(level, (list, tuple)) and len(level) >= 2:
+            price = safe_float(level[0], 0.0)
+            size = safe_float(level[1], 0.0)
+        else:
+            price = 0.0
+            size = 0.0
+        if price > 0.0 and size > 0.0:
+            levels.append((price, size))
+    return levels
+
+
+def estimate_book_fill_value(payload: Any, *, side: str, size: float) -> dict[str, float]:
+    requested_size = max(0.0, size)
+    remaining = requested_size
+    gross_value = 0.0
+    filled_size = 0.0
+    for level_price, level_size in _book_levels(payload, side):
+        take_size = min(remaining, level_size)
+        gross_value += take_size * level_price
+        filled_size += take_size
+        remaining -= take_size
+        if remaining <= 1e-9:
+            break
+    average_price = gross_value / filled_size if filled_size > 0.0 else 0.0
+    return {
+        "requested_size": round(requested_size, 6),
+        "fillable_size": round(filled_size, 6),
+        "unfilled_size": round(max(0.0, remaining), 6),
+        "gross_value": round(gross_value, 6),
+        "average_price": round(average_price, 6),
+    }
+
+
+def build_marketable_sell_order(
+    token_id: str,
+    shares: float,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    book = fetch_book(token_id, timeout_seconds=timeout_seconds)
+    tick_size = safe_str(book.get("tick_size"), "0.01")
+    tick_price = snap_price(safe_float(tick_size, 0.01), tick_size, "SELL")
+    best_bid = safe_float(book.get("best_bid"), 0.0)
+    best_ask = safe_float(book.get("best_ask"), 0.0)
+    estimate = estimate_book_fill_value(book.get("raw"), side="SELL", size=shares)
+    if best_bid <= 0.0 or estimate["fillable_size"] <= 0.0:
+        raise RuntimeError(
+            "no_bid_liquidity: order book has no executable bids for an immediate exit."
+        )
+    return {
+        "token_id": token_id,
+        "shares": round(max(0.0, shares), 6),
+        "price": tick_price,
+        "tick_size": tick_size,
+        "neg_risk": bool(book.get("neg_risk", False)),
+        "fee_rate_bps": fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds),
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "estimated_exit_value_usd": estimate["gross_value"],
+        "estimated_fill_size": estimate["fillable_size"],
+        "estimated_unfilled_size": estimate["unfilled_size"],
+        "estimated_average_price": estimate["average_price"],
+        "execution_style": "marketable-limit-min-tick",
+    }
+
+
 def extract_token_id(raw_market: dict[str, Any]) -> str:
     token_ids = json_to_list(raw_market.get("clobTokenIds"))
     if token_ids:
@@ -2433,34 +2517,45 @@ def sell_held_inventory(
         if shares <= 0 or token_id in covered_token_ids:
             continue
         try:
-            book = fetch_book(token_id, timeout_seconds=timeout_seconds)
-            ask_price = safe_float(book.get("best_ask"), 0.0)
-            tick_size = safe_str(book.get("tick_size"), "0.01")
-            neg_risk = bool(book.get("neg_risk", False))
-            if ask_price <= 0.0:
-                continue
-            ask_price = snap_price(ask_price, tick_size, "SELL")
-            size = shares
-            fee_rate_bps = fetch_fee_rate_bps(token_id, timeout_seconds=timeout_seconds)
+            sell_plan = build_marketable_sell_order(
+                token_id,
+                shares,
+                timeout_seconds=timeout_seconds,
+            )
             response = trader.create_order(
                 token_id=token_id,
                 side="SELL",
-                price=ask_price,
-                size=size,
-                tick_size=tick_size,
-                neg_risk=neg_risk,
-                fee_rate_bps=fee_rate_bps,
+                price=sell_plan["price"],
+                size=shares,
+                tick_size=sell_plan["tick_size"],
+                neg_risk=sell_plan["neg_risk"],
+                fee_rate_bps=sell_plan["fee_rate_bps"],
             )
             sells.append(
                 {
                     "token_id": token_id,
                     "side": "SELL",
-                    "price": ask_price,
-                    "size": round(size, 6),
+                    "price": sell_plan["price"],
+                    "size": round(shares, 6),
+                    "best_bid": sell_plan["best_bid"],
+                    "best_ask": sell_plan["best_ask"],
+                    "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                    "estimated_fill_size": sell_plan["estimated_fill_size"],
+                    "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                    "estimated_average_price": sell_plan["estimated_average_price"],
+                    "execution_style": sell_plan["execution_style"],
                     "source": "held-inventory-unwind",
                     "response": response,
                 }
             )
-        except Exception:
-            continue
+        except Exception as exc:
+            sells.append(
+                {
+                    "token_id": token_id,
+                    "side": "SELL",
+                    "size": round(shares, 6),
+                    "source": "held-inventory-unwind",
+                    "error": str(exc),
+                }
+            )
     return sells

--- a/polymarket/tests/test_execution_safety.py
+++ b/polymarket/tests/test_execution_safety.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+POLYMARKET_ROOT = Path(__file__).resolve().parents[1]
+
+LIVE_MODULE_PATHS = {
+    "polymarket-bot": POLYMARKET_ROOT / "bot" / "scripts" / "polymarket_live.py",
+    "polymarket-maker-rebate-bot": POLYMARKET_ROOT / "maker-rebate-bot" / "scripts" / "polymarket_live.py",
+    "liquidity-paired-basis-maker": POLYMARKET_ROOT / "liquidity-paired-basis-maker" / "scripts" / "polymarket_live.py",
+    "high-throughput-paired-basis-maker": POLYMARKET_ROOT / "high-throughput-paired-basis-maker" / "scripts" / "polymarket_live.py",
+    "paired-market-basis-maker": POLYMARKET_ROOT / "paired-market-basis-maker" / "scripts" / "polymarket_live.py",
+}
+
+UNWIND_AGENT_PATHS = {
+    "polymarket-maker-rebate-bot": POLYMARKET_ROOT / "maker-rebate-bot" / "scripts" / "agent.py",
+    "liquidity-paired-basis-maker": POLYMARKET_ROOT / "liquidity-paired-basis-maker" / "scripts" / "agent.py",
+    "high-throughput-paired-basis-maker": POLYMARKET_ROOT / "high-throughput-paired-basis-maker" / "scripts" / "agent.py",
+    "paired-market-basis-maker": POLYMARKET_ROOT / "paired-market-basis-maker" / "scripts" / "agent.py",
+}
+
+
+def _load_module(name: str, path: Path, *, clear_modules: tuple[str, ...] = ()) -> object:
+    for module_name in clear_modules:
+        sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
+def test_marketable_sell_plan_uses_min_tick_and_full_bid_sweep(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_live_test",
+        LIVE_MODULE_PATHS[skill_slug],
+        clear_modules=("polymarket_live",),
+    )
+
+    monkeypatch.setattr(
+        module,
+        "fetch_book",
+        lambda token_id, timeout_seconds=30.0: {
+            "best_bid": 0.35,
+            "best_ask": 0.36,
+            "tick_size": "0.01",
+            "neg_risk": False,
+            "raw": {
+                "bids": [
+                    {"price": "0.35", "size": "10"},
+                    {"price": "0.30", "size": "5"},
+                ],
+                "asks": [],
+            },
+        },
+    )
+    monkeypatch.setattr(module, "fetch_fee_rate_bps", lambda token_id, timeout_seconds=30.0: 7)
+
+    plan = module.build_marketable_sell_order("TOKEN-1", 12.0, timeout_seconds=1.0)
+
+    assert plan["price"] == pytest.approx(0.01)
+    assert plan["tick_size"] == "0.01"
+    assert plan["best_bid"] == pytest.approx(0.35)
+    assert plan["estimated_exit_value_usd"] == pytest.approx(4.1)
+    assert plan["estimated_fill_size"] == pytest.approx(12.0)
+    assert plan["estimated_unfilled_size"] == pytest.approx(0.0)
+    assert plan["execution_style"] == "marketable-limit-min-tick"
+
+
+@pytest.mark.parametrize("skill_slug", sorted(UNWIND_AGENT_PATHS))
+def test_unwind_all_requires_yes_live_confirmation(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_agent_test",
+        UNWIND_AGENT_PATHS[skill_slug],
+        clear_modules=("polymarket_live", "pair_stateful_replay"),
+    )
+
+    monkeypatch.setattr(
+        module,
+        "parse_args",
+        lambda: argparse.Namespace(
+            config="config.json",
+            run_type="trade",
+            yes_live=False,
+            unwind_all=True,
+            markets_file=None,
+            backtest_file=None,
+            backtest_days=None,
+            allow_negative_backtest=False,
+        ),
+    )
+    monkeypatch.setattr(module, "load_config", lambda path: {})
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        exit_code = module.main()
+    payload = json.loads(stdout.getvalue())
+
+    assert exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "unwind_confirmation_required"
+
+
+@pytest.mark.parametrize("skill_slug", sorted(UNWIND_AGENT_PATHS))
+def test_unwind_all_uses_marketable_sell_plan(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_agent_unwind_test",
+        UNWIND_AGENT_PATHS[skill_slug],
+        clear_modules=("polymarket_live", "pair_stateful_replay"),
+    )
+    captured_order: dict[str, object] = {}
+
+    class FakeTrader:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def cancel_all(self) -> dict[str, object]:
+            return {"cancelled": True}
+
+        def get_positions(self) -> list[dict[str, object]]:
+            return [{"asset_id": "TOKEN-1", "size": 3.0}]
+
+        def create_order(self, **kwargs) -> dict[str, object]:
+            captured_order.update(kwargs)
+            return {"orderID": "ORDER-1"}
+
+    monkeypatch.setattr(module, "DirectClobTrader", FakeTrader)
+    monkeypatch.setattr(module, "positions_by_key", lambda raw_positions: {"TOKEN-1": 3.0})
+    monkeypatch.setattr(
+        module,
+        "build_marketable_sell_order",
+        lambda token_id, shares: {
+            "price": 0.01,
+            "tick_size": "0.01",
+            "neg_risk": False,
+            "fee_rate_bps": 7,
+            "best_bid": 0.35,
+            "best_ask": 0.36,
+            "estimated_exit_value_usd": 1.02,
+            "estimated_fill_size": 3.0,
+            "estimated_unfilled_size": 0.0,
+            "estimated_average_price": 0.34,
+            "execution_style": "marketable-limit-min-tick",
+        },
+    )
+
+    result = module.run_unwind_all(config={})
+
+    assert result["status"] == "ok"
+    assert captured_order["price"] == pytest.approx(0.01)
+    assert captured_order["tick_size"] == "0.01"
+    assert captured_order["fee_rate_bps"] == 7
+    assert result["sell_results"][0]["estimated_exit_value_usd"] == pytest.approx(1.02)
+    assert result["sell_results"][0]["execution_style"] == "marketable-limit-min-tick"


### PR DESCRIPTION
Closes #172

## Summary
- add explicit execution contracts, CLOB exit rules, pre-trade checklists, and emergency exit guidance to the five affected Polymarket skills
- replace passive/heuristic unwind pricing with marketable min-tick sell plans that estimate visible-book recovery across bid depth
- add focused regression coverage for live exit pricing, unwind confirmation guards, and live book metadata in the bot client

## Testing
- pytest polymarket/tests/test_execution_safety.py polymarket/bot/scripts/test_polymarket_client_auth.py
- pytest --import-mode=importlib polymarket/maker-rebate-bot/tests/test_smoke.py polymarket/liquidity-paired-basis-maker/tests/test_smoke.py polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py polymarket/paired-market-basis-maker/tests/test_smoke.py