### PR TITLE
feat(polymarket): use Seren Polygon RPC when funded

### DIFF
--- a/polymarket/bot/scripts/polymarket_live.py
+++ b/polymarket/bot/scripts/polymarket_live.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import platform
+import re
 import select
 import shlex
 import signal
@@ -28,10 +29,14 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
+LIVE_SAFETY_VERSION = "2026-03-20.polymarket-live-safety-v4"
 USDC_DECIMALS = 6
 SEREN_CRON_PUBLISHER = "seren-cron"
+SEREN_POLYGON_PUBLISHER_HINT = "seren-polygon"
+SEREN_MIN_PUBLISHER_BALANCE_USD = 1.0
 DEFAULT_SEREN_CRON_POLL_INTERVAL_SECONDS = 30
+POLYGON_PUBLIC_RPC_URL = "https://polygon-rpc.com"
+POLYGON_RPC_PROBE_PATHS = ("/", "", "/rpc")
 
 # Polymarket contract addresses on Polygon mainnet
 POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
@@ -564,6 +569,98 @@ def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
     return result.get("value")
 
 
+def _seren_api_key() -> str:
+    return safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+
+
+def _call_seren_mcp_tool(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+    command = shlex.split(command_raw)
+    if not command:
+        raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _mcp_request(
+            proc=proc,
+            request_id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        _write_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        result = _mcp_request(
+            proc=proc,
+            request_id=2,
+            method="tools/call",
+            params={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        return _extract_call_publisher_body(result)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+
+def _seren_http_json(
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = _seren_api_key()
+    if not api_key:
+        raise RuntimeError("Seren API key is not available for direct HTTP access.")
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    request = Request(
+        f"{SEREN_API_BASE}{normalized_path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
 def call_publisher_json(
     publisher: str,
     method: str,
@@ -572,62 +669,22 @@ def call_publisher_json(
     body: Any = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
-    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    api_key = _seren_api_key()
     prefer_mcp = not api_key
 
     if prefer_mcp:
-        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
-        command = shlex.split(command_raw)
-        if not command:
-            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
-        proc = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return _call_seren_mcp_tool(
+            "call_publisher",
+            {
+                "publisher": publisher,
+                "method": method.upper(),
+                "path": path,
+                "headers": headers or {},
+                "body": json.dumps(body) if body is not None else None,
+                "response_format": "json",
+            },
+            timeout_seconds=timeout_seconds,
         )
-        try:
-            _mcp_request(
-                proc=proc,
-                request_id=1,
-                method="initialize",
-                params={
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            _write_mcp_message(
-                proc,
-                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            )
-            result = _mcp_request(
-                proc=proc,
-                request_id=2,
-                method="tools/call",
-                params={
-                    "name": "call_publisher",
-                    "arguments": {
-                        "publisher": publisher,
-                        "method": method.upper(),
-                        "path": path,
-                        "headers": headers or {},
-                        "body": json.dumps(body) if body is not None else None,
-                        "response_format": "json",
-                    },
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            return _extract_call_publisher_body(result)
-        finally:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=1)
 
     req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
     if headers:
@@ -647,6 +704,319 @@ def call_publisher_json(
         if not text:
             return {}
         return json.loads(text)
+
+
+def get_seren_prepaid_balance(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> float:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/wallet/balance", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "get_prepaid_balance",
+                {},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return 0.0
+
+    if not isinstance(payload, dict):
+        return 0.0
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    for field in ("funded_balance_usd", "balance_usd"):
+        value = safe_float(data.get(field), -1.0)
+        if value >= 0.0:
+            return value
+    return 0.0
+
+
+def list_seren_publishers(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/publishers?limit=200&offset=0", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "list_agent_publishers",
+                {"category": "integration", "limit": 200, "offset": 0, "verbose": True},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        rows = payload.get("publishers")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+
+
+def _is_rpc_like_publisher(publisher: dict[str, Any]) -> bool:
+    categories = publisher.get("categories", [])
+    categories_text = ""
+    if isinstance(categories, list):
+        categories_text = " ".join(
+            str(category).lower() for category in categories if isinstance(category, str)
+        )
+
+    slug_tokens = _tokenize(safe_str(publisher.get("slug"), ""))
+    name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+    category_tokens = _tokenize(categories_text)
+    description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+    combined = slug_tokens | name_tokens | category_tokens | description_tokens
+    return "rpc" in combined or ("json" in combined and "web3" in combined)
+
+
+def discover_seren_polygon_publisher(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    best_slug = ""
+    best_score = -1
+    for publisher in list_seren_publishers(timeout_seconds=timeout_seconds):
+        if publisher.get("is_active") is False:
+            continue
+        if not _is_rpc_like_publisher(publisher):
+            continue
+
+        slug = safe_str(publisher.get("slug"), "").strip().lower()
+        if not slug:
+            continue
+
+        categories = publisher.get("categories", [])
+        categories_text = ""
+        if isinstance(categories, list):
+            categories_text = " ".join(
+                str(category).lower() for category in categories if isinstance(category, str)
+            )
+
+        slug_tokens = _tokenize(slug)
+        name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+        category_tokens = _tokenize(categories_text)
+        description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+        combined = slug_tokens | name_tokens | category_tokens | description_tokens
+        if not ({"polygon", "matic"} & combined):
+            continue
+
+        score = 0
+        if slug == SEREN_POLYGON_PUBLISHER_HINT:
+            score += 100
+        if slug.startswith("seren-"):
+            score += 20
+        if "polygon" in slug_tokens:
+            score += 12
+        if "matic" in slug_tokens:
+            score += 6
+        if "polygon" in category_tokens:
+            score += 10
+        if "matic" in category_tokens:
+            score += 5
+        if "polygon" in name_tokens:
+            score += 8
+        if "polygon" in description_tokens:
+            score += 4
+        if score > best_score or (score == best_score and slug < best_slug):
+            best_score = score
+            best_slug = slug
+
+    return best_slug
+
+
+def _extract_rpc_result(payload: Any, *, source: str) -> dict[str, Any]:
+    body = _extract_publisher_data(payload)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{source} returned a non-object JSON-RPC payload.")
+    error = body.get("error")
+    if error not in (None, {}):
+        raise RuntimeError(f"{source} returned JSON-RPC error: {error}")
+    if "result" not in body:
+        raise RuntimeError(f"{source} did not return a JSON-RPC result.")
+    return body
+
+
+def _parse_rpc_int(value: Any, *, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    text = safe_str(value, "").strip()
+    if not text:
+        raise RuntimeError(f"{field} was empty.")
+    try:
+        if text.startswith(("0x", "0X")):
+            return int(text, 16)
+        return int(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{field} was not numeric: {value}") from exc
+
+
+def _probe_seren_polygon_rpc_target(
+    publisher: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    probe_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": [],
+    }
+    for path in POLYGON_RPC_PROBE_PATHS:
+        try:
+            response = _extract_rpc_result(
+                call_publisher_json(
+                    publisher=publisher,
+                    method="POST",
+                    path=path,
+                    body=probe_payload,
+                    timeout_seconds=timeout_seconds,
+                ),
+                source=f"{publisher}{path or '(root)'}",
+            )
+            chain_id = _parse_rpc_int(response.get("result"), field="eth_chainId")
+            if chain_id != DEFAULT_CHAIN_ID:
+                raise RuntimeError(f"expected chain id {DEFAULT_CHAIN_ID}, got {chain_id}")
+            return {
+                "publisher": publisher,
+                "path": path,
+            }
+        except Exception as exc:
+            errors.append(f"{path or '(root)'}: {exc}")
+
+    raise RuntimeError(
+        f"Unable to probe Polygon RPC publisher '{publisher}'. Errors: {' | '.join(errors)}"
+    )
+
+
+def _eth_call_via_seren_polygon(
+    to: str,
+    data: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [{"to": to, "data": data}, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return safe_str(response.get("result"), "0x0")
+
+
+def _eth_call_via_public_polygon_rpc(
+    to: str,
+    data: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "id": 1,
+        "params": [{"to": to, "data": data}, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return safe_str(response.get("result"), "0x0")
+
+
+def _resolve_polygon_rpc_transport(
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
+    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
+        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+        if publisher:
+            try:
+                target = _probe_seren_polygon_rpc_target(
+                    publisher,
+                    timeout_seconds=timeout_seconds,
+                )
+                return {
+                    "rpc_transport": "seren-publisher",
+                    "rpc_publisher": publisher,
+                    "rpc_path": safe_str(target.get("path"), "/") or "/",
+                    "seren_balance_usd": balance,
+                }
+            except Exception as exc:
+                fallback_reason = (
+                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+                )
+        else:
+            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    else:
+        fallback_reason = (
+            f"Seren prepaid balance ${balance:.2f} is below the "
+            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+        )
+
+    return {
+        "rpc_transport": "public",
+        "rpc_url": rpc_url,
+        "rpc_fallback_reason": fallback_reason,
+    }
+
+
+def _eth_call_with_transport(
+    to: str,
+    data: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_call_via_seren_polygon(
+            to,
+            data,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    try:
+        return _eth_call_via_public_polygon_rpc(
+            to,
+            data,
+            rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        fallback_reason = safe_str(rpc_transport.get("rpc_fallback_reason"), "").strip()
+        if fallback_reason:
+            raise RuntimeError(
+                f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
+            ) from exc
+        raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
 
 
 def current_machine_label() -> str:
@@ -1423,7 +1793,7 @@ class PolymarketPublisherTrader:
 def check_neg_risk_approvals(
     wallet_address: str,
     *,
-    rpc_url: str = "https://polygon-rpc.com",
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
@@ -1437,28 +1807,31 @@ def check_neg_risk_approvals(
         "usdc_approved": False,
         "ct_approved": False,
         "checks_passed": False,
+        "rpc_transport": "unknown",
         "errors": [],
     }
 
     wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
     adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
 
-    def _eth_call(to: str, data: str) -> str:
-        payload = json.dumps({
-            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
-            "params": [{"to": to, "data": data}, "latest"],
-        }).encode()
-        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
-        try:
-            with urlopen(req, timeout=timeout_seconds) as resp:
-                body = json.loads(resp.read())
-                return safe_str(body.get("result"), "0x0")
-        except Exception:
-            return "0x0"
+    rpc_transport = _resolve_polygon_rpc_transport(
+        rpc_url=rpc_url,
+        timeout_seconds=timeout_seconds,
+    )
+    results.update(rpc_transport)
 
     # Check USDC.e allowance to NegRiskAdapter
     usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_result = _eth_call_with_transport(
+            POLYGON_USDC_E,
+            usdc_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         usdc_allowance = int(usdc_result, 16)
     except (ValueError, TypeError):
@@ -1468,7 +1841,16 @@ def check_neg_risk_approvals(
 
     # Check CT isApprovedForAll to NegRiskAdapter
     ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_result = _eth_call_with_transport(
+            POLYGON_CONDITIONAL_TOKENS,
+            ct_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         ct_approved = int(ct_result, 16) > 0
     except (ValueError, TypeError):

--- a/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import platform
+import re
 import select
 import shlex
 import signal
@@ -28,10 +29,14 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
+LIVE_SAFETY_VERSION = "2026-03-20.polymarket-live-safety-v4"
 USDC_DECIMALS = 6
 SEREN_CRON_PUBLISHER = "seren-cron"
+SEREN_POLYGON_PUBLISHER_HINT = "seren-polygon"
+SEREN_MIN_PUBLISHER_BALANCE_USD = 1.0
 DEFAULT_SEREN_CRON_POLL_INTERVAL_SECONDS = 30
+POLYGON_PUBLIC_RPC_URL = "https://polygon-rpc.com"
+POLYGON_RPC_PROBE_PATHS = ("/", "", "/rpc")
 
 # Polymarket contract addresses on Polygon mainnet
 POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
@@ -564,6 +569,98 @@ def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
     return result.get("value")
 
 
+def _seren_api_key() -> str:
+    return safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+
+
+def _call_seren_mcp_tool(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+    command = shlex.split(command_raw)
+    if not command:
+        raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _mcp_request(
+            proc=proc,
+            request_id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        _write_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        result = _mcp_request(
+            proc=proc,
+            request_id=2,
+            method="tools/call",
+            params={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        return _extract_call_publisher_body(result)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+
+def _seren_http_json(
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = _seren_api_key()
+    if not api_key:
+        raise RuntimeError("Seren API key is not available for direct HTTP access.")
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    request = Request(
+        f"{SEREN_API_BASE}{normalized_path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
 def call_publisher_json(
     publisher: str,
     method: str,
@@ -572,62 +669,22 @@ def call_publisher_json(
     body: Any = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
-    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    api_key = _seren_api_key()
     prefer_mcp = not api_key
 
     if prefer_mcp:
-        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
-        command = shlex.split(command_raw)
-        if not command:
-            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
-        proc = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return _call_seren_mcp_tool(
+            "call_publisher",
+            {
+                "publisher": publisher,
+                "method": method.upper(),
+                "path": path,
+                "headers": headers or {},
+                "body": json.dumps(body) if body is not None else None,
+                "response_format": "json",
+            },
+            timeout_seconds=timeout_seconds,
         )
-        try:
-            _mcp_request(
-                proc=proc,
-                request_id=1,
-                method="initialize",
-                params={
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            _write_mcp_message(
-                proc,
-                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            )
-            result = _mcp_request(
-                proc=proc,
-                request_id=2,
-                method="tools/call",
-                params={
-                    "name": "call_publisher",
-                    "arguments": {
-                        "publisher": publisher,
-                        "method": method.upper(),
-                        "path": path,
-                        "headers": headers or {},
-                        "body": json.dumps(body) if body is not None else None,
-                        "response_format": "json",
-                    },
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            return _extract_call_publisher_body(result)
-        finally:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=1)
 
     req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
     if headers:
@@ -647,6 +704,319 @@ def call_publisher_json(
         if not text:
             return {}
         return json.loads(text)
+
+
+def get_seren_prepaid_balance(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> float:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/wallet/balance", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "get_prepaid_balance",
+                {},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return 0.0
+
+    if not isinstance(payload, dict):
+        return 0.0
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    for field in ("funded_balance_usd", "balance_usd"):
+        value = safe_float(data.get(field), -1.0)
+        if value >= 0.0:
+            return value
+    return 0.0
+
+
+def list_seren_publishers(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/publishers?limit=200&offset=0", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "list_agent_publishers",
+                {"category": "integration", "limit": 200, "offset": 0, "verbose": True},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        rows = payload.get("publishers")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+
+
+def _is_rpc_like_publisher(publisher: dict[str, Any]) -> bool:
+    categories = publisher.get("categories", [])
+    categories_text = ""
+    if isinstance(categories, list):
+        categories_text = " ".join(
+            str(category).lower() for category in categories if isinstance(category, str)
+        )
+
+    slug_tokens = _tokenize(safe_str(publisher.get("slug"), ""))
+    name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+    category_tokens = _tokenize(categories_text)
+    description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+    combined = slug_tokens | name_tokens | category_tokens | description_tokens
+    return "rpc" in combined or ("json" in combined and "web3" in combined)
+
+
+def discover_seren_polygon_publisher(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    best_slug = ""
+    best_score = -1
+    for publisher in list_seren_publishers(timeout_seconds=timeout_seconds):
+        if publisher.get("is_active") is False:
+            continue
+        if not _is_rpc_like_publisher(publisher):
+            continue
+
+        slug = safe_str(publisher.get("slug"), "").strip().lower()
+        if not slug:
+            continue
+
+        categories = publisher.get("categories", [])
+        categories_text = ""
+        if isinstance(categories, list):
+            categories_text = " ".join(
+                str(category).lower() for category in categories if isinstance(category, str)
+            )
+
+        slug_tokens = _tokenize(slug)
+        name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+        category_tokens = _tokenize(categories_text)
+        description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+        combined = slug_tokens | name_tokens | category_tokens | description_tokens
+        if not ({"polygon", "matic"} & combined):
+            continue
+
+        score = 0
+        if slug == SEREN_POLYGON_PUBLISHER_HINT:
+            score += 100
+        if slug.startswith("seren-"):
+            score += 20
+        if "polygon" in slug_tokens:
+            score += 12
+        if "matic" in slug_tokens:
+            score += 6
+        if "polygon" in category_tokens:
+            score += 10
+        if "matic" in category_tokens:
+            score += 5
+        if "polygon" in name_tokens:
+            score += 8
+        if "polygon" in description_tokens:
+            score += 4
+        if score > best_score or (score == best_score and slug < best_slug):
+            best_score = score
+            best_slug = slug
+
+    return best_slug
+
+
+def _extract_rpc_result(payload: Any, *, source: str) -> dict[str, Any]:
+    body = _extract_publisher_data(payload)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{source} returned a non-object JSON-RPC payload.")
+    error = body.get("error")
+    if error not in (None, {}):
+        raise RuntimeError(f"{source} returned JSON-RPC error: {error}")
+    if "result" not in body:
+        raise RuntimeError(f"{source} did not return a JSON-RPC result.")
+    return body
+
+
+def _parse_rpc_int(value: Any, *, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    text = safe_str(value, "").strip()
+    if not text:
+        raise RuntimeError(f"{field} was empty.")
+    try:
+        if text.startswith(("0x", "0X")):
+            return int(text, 16)
+        return int(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{field} was not numeric: {value}") from exc
+
+
+def _probe_seren_polygon_rpc_target(
+    publisher: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    probe_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": [],
+    }
+    for path in POLYGON_RPC_PROBE_PATHS:
+        try:
+            response = _extract_rpc_result(
+                call_publisher_json(
+                    publisher=publisher,
+                    method="POST",
+                    path=path,
+                    body=probe_payload,
+                    timeout_seconds=timeout_seconds,
+                ),
+                source=f"{publisher}{path or '(root)'}",
+            )
+            chain_id = _parse_rpc_int(response.get("result"), field="eth_chainId")
+            if chain_id != DEFAULT_CHAIN_ID:
+                raise RuntimeError(f"expected chain id {DEFAULT_CHAIN_ID}, got {chain_id}")
+            return {
+                "publisher": publisher,
+                "path": path,
+            }
+        except Exception as exc:
+            errors.append(f"{path or '(root)'}: {exc}")
+
+    raise RuntimeError(
+        f"Unable to probe Polygon RPC publisher '{publisher}'. Errors: {' | '.join(errors)}"
+    )
+
+
+def _eth_call_via_seren_polygon(
+    to: str,
+    data: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [{"to": to, "data": data}, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return safe_str(response.get("result"), "0x0")
+
+
+def _eth_call_via_public_polygon_rpc(
+    to: str,
+    data: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "id": 1,
+        "params": [{"to": to, "data": data}, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return safe_str(response.get("result"), "0x0")
+
+
+def _resolve_polygon_rpc_transport(
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
+    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
+        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+        if publisher:
+            try:
+                target = _probe_seren_polygon_rpc_target(
+                    publisher,
+                    timeout_seconds=timeout_seconds,
+                )
+                return {
+                    "rpc_transport": "seren-publisher",
+                    "rpc_publisher": publisher,
+                    "rpc_path": safe_str(target.get("path"), "/") or "/",
+                    "seren_balance_usd": balance,
+                }
+            except Exception as exc:
+                fallback_reason = (
+                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+                )
+        else:
+            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    else:
+        fallback_reason = (
+            f"Seren prepaid balance ${balance:.2f} is below the "
+            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+        )
+
+    return {
+        "rpc_transport": "public",
+        "rpc_url": rpc_url,
+        "rpc_fallback_reason": fallback_reason,
+    }
+
+
+def _eth_call_with_transport(
+    to: str,
+    data: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_call_via_seren_polygon(
+            to,
+            data,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    try:
+        return _eth_call_via_public_polygon_rpc(
+            to,
+            data,
+            rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        fallback_reason = safe_str(rpc_transport.get("rpc_fallback_reason"), "").strip()
+        if fallback_reason:
+            raise RuntimeError(
+                f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
+            ) from exc
+        raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
 
 
 def current_machine_label() -> str:
@@ -1423,7 +1793,7 @@ class PolymarketPublisherTrader:
 def check_neg_risk_approvals(
     wallet_address: str,
     *,
-    rpc_url: str = "https://polygon-rpc.com",
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
@@ -1437,28 +1807,31 @@ def check_neg_risk_approvals(
         "usdc_approved": False,
         "ct_approved": False,
         "checks_passed": False,
+        "rpc_transport": "unknown",
         "errors": [],
     }
 
     wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
     adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
 
-    def _eth_call(to: str, data: str) -> str:
-        payload = json.dumps({
-            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
-            "params": [{"to": to, "data": data}, "latest"],
-        }).encode()
-        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
-        try:
-            with urlopen(req, timeout=timeout_seconds) as resp:
-                body = json.loads(resp.read())
-                return safe_str(body.get("result"), "0x0")
-        except Exception:
-            return "0x0"
+    rpc_transport = _resolve_polygon_rpc_transport(
+        rpc_url=rpc_url,
+        timeout_seconds=timeout_seconds,
+    )
+    results.update(rpc_transport)
 
     # Check USDC.e allowance to NegRiskAdapter
     usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_result = _eth_call_with_transport(
+            POLYGON_USDC_E,
+            usdc_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         usdc_allowance = int(usdc_result, 16)
     except (ValueError, TypeError):
@@ -1468,7 +1841,16 @@ def check_neg_risk_approvals(
 
     # Check CT isApprovedForAll to NegRiskAdapter
     ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_result = _eth_call_with_transport(
+            POLYGON_CONDITIONAL_TOKENS,
+            ct_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         ct_approved = int(ct_result, 16) > 0
     except (ValueError, TypeError):

--- a/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import platform
+import re
 import select
 import shlex
 import signal
@@ -28,10 +29,14 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
+LIVE_SAFETY_VERSION = "2026-03-20.polymarket-live-safety-v4"
 USDC_DECIMALS = 6
 SEREN_CRON_PUBLISHER = "seren-cron"
+SEREN_POLYGON_PUBLISHER_HINT = "seren-polygon"
+SEREN_MIN_PUBLISHER_BALANCE_USD = 1.0
 DEFAULT_SEREN_CRON_POLL_INTERVAL_SECONDS = 30
+POLYGON_PUBLIC_RPC_URL = "https://polygon-rpc.com"
+POLYGON_RPC_PROBE_PATHS = ("/", "", "/rpc")
 
 # Polymarket contract addresses on Polygon mainnet
 POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
@@ -564,6 +569,98 @@ def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
     return result.get("value")
 
 
+def _seren_api_key() -> str:
+    return safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+
+
+def _call_seren_mcp_tool(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+    command = shlex.split(command_raw)
+    if not command:
+        raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _mcp_request(
+            proc=proc,
+            request_id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        _write_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        result = _mcp_request(
+            proc=proc,
+            request_id=2,
+            method="tools/call",
+            params={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        return _extract_call_publisher_body(result)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+
+def _seren_http_json(
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = _seren_api_key()
+    if not api_key:
+        raise RuntimeError("Seren API key is not available for direct HTTP access.")
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    request = Request(
+        f"{SEREN_API_BASE}{normalized_path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
 def call_publisher_json(
     publisher: str,
     method: str,
@@ -572,62 +669,22 @@ def call_publisher_json(
     body: Any = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
-    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    api_key = _seren_api_key()
     prefer_mcp = not api_key
 
     if prefer_mcp:
-        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
-        command = shlex.split(command_raw)
-        if not command:
-            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
-        proc = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return _call_seren_mcp_tool(
+            "call_publisher",
+            {
+                "publisher": publisher,
+                "method": method.upper(),
+                "path": path,
+                "headers": headers or {},
+                "body": json.dumps(body) if body is not None else None,
+                "response_format": "json",
+            },
+            timeout_seconds=timeout_seconds,
         )
-        try:
-            _mcp_request(
-                proc=proc,
-                request_id=1,
-                method="initialize",
-                params={
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            _write_mcp_message(
-                proc,
-                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            )
-            result = _mcp_request(
-                proc=proc,
-                request_id=2,
-                method="tools/call",
-                params={
-                    "name": "call_publisher",
-                    "arguments": {
-                        "publisher": publisher,
-                        "method": method.upper(),
-                        "path": path,
-                        "headers": headers or {},
-                        "body": json.dumps(body) if body is not None else None,
-                        "response_format": "json",
-                    },
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            return _extract_call_publisher_body(result)
-        finally:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=1)
 
     req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
     if headers:
@@ -647,6 +704,319 @@ def call_publisher_json(
         if not text:
             return {}
         return json.loads(text)
+
+
+def get_seren_prepaid_balance(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> float:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/wallet/balance", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "get_prepaid_balance",
+                {},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return 0.0
+
+    if not isinstance(payload, dict):
+        return 0.0
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    for field in ("funded_balance_usd", "balance_usd"):
+        value = safe_float(data.get(field), -1.0)
+        if value >= 0.0:
+            return value
+    return 0.0
+
+
+def list_seren_publishers(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/publishers?limit=200&offset=0", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "list_agent_publishers",
+                {"category": "integration", "limit": 200, "offset": 0, "verbose": True},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        rows = payload.get("publishers")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+
+
+def _is_rpc_like_publisher(publisher: dict[str, Any]) -> bool:
+    categories = publisher.get("categories", [])
+    categories_text = ""
+    if isinstance(categories, list):
+        categories_text = " ".join(
+            str(category).lower() for category in categories if isinstance(category, str)
+        )
+
+    slug_tokens = _tokenize(safe_str(publisher.get("slug"), ""))
+    name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+    category_tokens = _tokenize(categories_text)
+    description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+    combined = slug_tokens | name_tokens | category_tokens | description_tokens
+    return "rpc" in combined or ("json" in combined and "web3" in combined)
+
+
+def discover_seren_polygon_publisher(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    best_slug = ""
+    best_score = -1
+    for publisher in list_seren_publishers(timeout_seconds=timeout_seconds):
+        if publisher.get("is_active") is False:
+            continue
+        if not _is_rpc_like_publisher(publisher):
+            continue
+
+        slug = safe_str(publisher.get("slug"), "").strip().lower()
+        if not slug:
+            continue
+
+        categories = publisher.get("categories", [])
+        categories_text = ""
+        if isinstance(categories, list):
+            categories_text = " ".join(
+                str(category).lower() for category in categories if isinstance(category, str)
+            )
+
+        slug_tokens = _tokenize(slug)
+        name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+        category_tokens = _tokenize(categories_text)
+        description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+        combined = slug_tokens | name_tokens | category_tokens | description_tokens
+        if not ({"polygon", "matic"} & combined):
+            continue
+
+        score = 0
+        if slug == SEREN_POLYGON_PUBLISHER_HINT:
+            score += 100
+        if slug.startswith("seren-"):
+            score += 20
+        if "polygon" in slug_tokens:
+            score += 12
+        if "matic" in slug_tokens:
+            score += 6
+        if "polygon" in category_tokens:
+            score += 10
+        if "matic" in category_tokens:
+            score += 5
+        if "polygon" in name_tokens:
+            score += 8
+        if "polygon" in description_tokens:
+            score += 4
+        if score > best_score or (score == best_score and slug < best_slug):
+            best_score = score
+            best_slug = slug
+
+    return best_slug
+
+
+def _extract_rpc_result(payload: Any, *, source: str) -> dict[str, Any]:
+    body = _extract_publisher_data(payload)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{source} returned a non-object JSON-RPC payload.")
+    error = body.get("error")
+    if error not in (None, {}):
+        raise RuntimeError(f"{source} returned JSON-RPC error: {error}")
+    if "result" not in body:
+        raise RuntimeError(f"{source} did not return a JSON-RPC result.")
+    return body
+
+
+def _parse_rpc_int(value: Any, *, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    text = safe_str(value, "").strip()
+    if not text:
+        raise RuntimeError(f"{field} was empty.")
+    try:
+        if text.startswith(("0x", "0X")):
+            return int(text, 16)
+        return int(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{field} was not numeric: {value}") from exc
+
+
+def _probe_seren_polygon_rpc_target(
+    publisher: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    probe_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": [],
+    }
+    for path in POLYGON_RPC_PROBE_PATHS:
+        try:
+            response = _extract_rpc_result(
+                call_publisher_json(
+                    publisher=publisher,
+                    method="POST",
+                    path=path,
+                    body=probe_payload,
+                    timeout_seconds=timeout_seconds,
+                ),
+                source=f"{publisher}{path or '(root)'}",
+            )
+            chain_id = _parse_rpc_int(response.get("result"), field="eth_chainId")
+            if chain_id != DEFAULT_CHAIN_ID:
+                raise RuntimeError(f"expected chain id {DEFAULT_CHAIN_ID}, got {chain_id}")
+            return {
+                "publisher": publisher,
+                "path": path,
+            }
+        except Exception as exc:
+            errors.append(f"{path or '(root)'}: {exc}")
+
+    raise RuntimeError(
+        f"Unable to probe Polygon RPC publisher '{publisher}'. Errors: {' | '.join(errors)}"
+    )
+
+
+def _eth_call_via_seren_polygon(
+    to: str,
+    data: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [{"to": to, "data": data}, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return safe_str(response.get("result"), "0x0")
+
+
+def _eth_call_via_public_polygon_rpc(
+    to: str,
+    data: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "id": 1,
+        "params": [{"to": to, "data": data}, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return safe_str(response.get("result"), "0x0")
+
+
+def _resolve_polygon_rpc_transport(
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
+    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
+        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+        if publisher:
+            try:
+                target = _probe_seren_polygon_rpc_target(
+                    publisher,
+                    timeout_seconds=timeout_seconds,
+                )
+                return {
+                    "rpc_transport": "seren-publisher",
+                    "rpc_publisher": publisher,
+                    "rpc_path": safe_str(target.get("path"), "/") or "/",
+                    "seren_balance_usd": balance,
+                }
+            except Exception as exc:
+                fallback_reason = (
+                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+                )
+        else:
+            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    else:
+        fallback_reason = (
+            f"Seren prepaid balance ${balance:.2f} is below the "
+            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+        )
+
+    return {
+        "rpc_transport": "public",
+        "rpc_url": rpc_url,
+        "rpc_fallback_reason": fallback_reason,
+    }
+
+
+def _eth_call_with_transport(
+    to: str,
+    data: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_call_via_seren_polygon(
+            to,
+            data,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    try:
+        return _eth_call_via_public_polygon_rpc(
+            to,
+            data,
+            rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        fallback_reason = safe_str(rpc_transport.get("rpc_fallback_reason"), "").strip()
+        if fallback_reason:
+            raise RuntimeError(
+                f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
+            ) from exc
+        raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
 
 
 def current_machine_label() -> str:
@@ -1423,7 +1793,7 @@ class PolymarketPublisherTrader:
 def check_neg_risk_approvals(
     wallet_address: str,
     *,
-    rpc_url: str = "https://polygon-rpc.com",
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
@@ -1437,28 +1807,31 @@ def check_neg_risk_approvals(
         "usdc_approved": False,
         "ct_approved": False,
         "checks_passed": False,
+        "rpc_transport": "unknown",
         "errors": [],
     }
 
     wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
     adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
 
-    def _eth_call(to: str, data: str) -> str:
-        payload = json.dumps({
-            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
-            "params": [{"to": to, "data": data}, "latest"],
-        }).encode()
-        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
-        try:
-            with urlopen(req, timeout=timeout_seconds) as resp:
-                body = json.loads(resp.read())
-                return safe_str(body.get("result"), "0x0")
-        except Exception:
-            return "0x0"
+    rpc_transport = _resolve_polygon_rpc_transport(
+        rpc_url=rpc_url,
+        timeout_seconds=timeout_seconds,
+    )
+    results.update(rpc_transport)
 
     # Check USDC.e allowance to NegRiskAdapter
     usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_result = _eth_call_with_transport(
+            POLYGON_USDC_E,
+            usdc_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         usdc_allowance = int(usdc_result, 16)
     except (ValueError, TypeError):
@@ -1468,7 +1841,16 @@ def check_neg_risk_approvals(
 
     # Check CT isApprovedForAll to NegRiskAdapter
     ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_result = _eth_call_with_transport(
+            POLYGON_CONDITIONAL_TOKENS,
+            ct_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         ct_approved = int(ct_result, 16) > 0
     except (ValueError, TypeError):

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import platform
+import re
 import select
 import shlex
 import signal
@@ -28,10 +29,14 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
+LIVE_SAFETY_VERSION = "2026-03-20.polymarket-live-safety-v4"
 USDC_DECIMALS = 6
 SEREN_CRON_PUBLISHER = "seren-cron"
+SEREN_POLYGON_PUBLISHER_HINT = "seren-polygon"
+SEREN_MIN_PUBLISHER_BALANCE_USD = 1.0
 DEFAULT_SEREN_CRON_POLL_INTERVAL_SECONDS = 30
+POLYGON_PUBLIC_RPC_URL = "https://polygon-rpc.com"
+POLYGON_RPC_PROBE_PATHS = ("/", "", "/rpc")
 
 # Polymarket contract addresses on Polygon mainnet
 POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
@@ -564,6 +569,98 @@ def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
     return result.get("value")
 
 
+def _seren_api_key() -> str:
+    return safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+
+
+def _call_seren_mcp_tool(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+    command = shlex.split(command_raw)
+    if not command:
+        raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _mcp_request(
+            proc=proc,
+            request_id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        _write_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        result = _mcp_request(
+            proc=proc,
+            request_id=2,
+            method="tools/call",
+            params={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        return _extract_call_publisher_body(result)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+
+def _seren_http_json(
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = _seren_api_key()
+    if not api_key:
+        raise RuntimeError("Seren API key is not available for direct HTTP access.")
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    request = Request(
+        f"{SEREN_API_BASE}{normalized_path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
 def call_publisher_json(
     publisher: str,
     method: str,
@@ -572,62 +669,22 @@ def call_publisher_json(
     body: Any = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
-    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    api_key = _seren_api_key()
     prefer_mcp = not api_key
 
     if prefer_mcp:
-        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
-        command = shlex.split(command_raw)
-        if not command:
-            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
-        proc = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return _call_seren_mcp_tool(
+            "call_publisher",
+            {
+                "publisher": publisher,
+                "method": method.upper(),
+                "path": path,
+                "headers": headers or {},
+                "body": json.dumps(body) if body is not None else None,
+                "response_format": "json",
+            },
+            timeout_seconds=timeout_seconds,
         )
-        try:
-            _mcp_request(
-                proc=proc,
-                request_id=1,
-                method="initialize",
-                params={
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            _write_mcp_message(
-                proc,
-                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            )
-            result = _mcp_request(
-                proc=proc,
-                request_id=2,
-                method="tools/call",
-                params={
-                    "name": "call_publisher",
-                    "arguments": {
-                        "publisher": publisher,
-                        "method": method.upper(),
-                        "path": path,
-                        "headers": headers or {},
-                        "body": json.dumps(body) if body is not None else None,
-                        "response_format": "json",
-                    },
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            return _extract_call_publisher_body(result)
-        finally:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=1)
 
     req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
     if headers:
@@ -647,6 +704,319 @@ def call_publisher_json(
         if not text:
             return {}
         return json.loads(text)
+
+
+def get_seren_prepaid_balance(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> float:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/wallet/balance", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "get_prepaid_balance",
+                {},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return 0.0
+
+    if not isinstance(payload, dict):
+        return 0.0
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    for field in ("funded_balance_usd", "balance_usd"):
+        value = safe_float(data.get(field), -1.0)
+        if value >= 0.0:
+            return value
+    return 0.0
+
+
+def list_seren_publishers(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/publishers?limit=200&offset=0", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "list_agent_publishers",
+                {"category": "integration", "limit": 200, "offset": 0, "verbose": True},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        rows = payload.get("publishers")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+
+
+def _is_rpc_like_publisher(publisher: dict[str, Any]) -> bool:
+    categories = publisher.get("categories", [])
+    categories_text = ""
+    if isinstance(categories, list):
+        categories_text = " ".join(
+            str(category).lower() for category in categories if isinstance(category, str)
+        )
+
+    slug_tokens = _tokenize(safe_str(publisher.get("slug"), ""))
+    name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+    category_tokens = _tokenize(categories_text)
+    description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+    combined = slug_tokens | name_tokens | category_tokens | description_tokens
+    return "rpc" in combined or ("json" in combined and "web3" in combined)
+
+
+def discover_seren_polygon_publisher(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    best_slug = ""
+    best_score = -1
+    for publisher in list_seren_publishers(timeout_seconds=timeout_seconds):
+        if publisher.get("is_active") is False:
+            continue
+        if not _is_rpc_like_publisher(publisher):
+            continue
+
+        slug = safe_str(publisher.get("slug"), "").strip().lower()
+        if not slug:
+            continue
+
+        categories = publisher.get("categories", [])
+        categories_text = ""
+        if isinstance(categories, list):
+            categories_text = " ".join(
+                str(category).lower() for category in categories if isinstance(category, str)
+            )
+
+        slug_tokens = _tokenize(slug)
+        name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+        category_tokens = _tokenize(categories_text)
+        description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+        combined = slug_tokens | name_tokens | category_tokens | description_tokens
+        if not ({"polygon", "matic"} & combined):
+            continue
+
+        score = 0
+        if slug == SEREN_POLYGON_PUBLISHER_HINT:
+            score += 100
+        if slug.startswith("seren-"):
+            score += 20
+        if "polygon" in slug_tokens:
+            score += 12
+        if "matic" in slug_tokens:
+            score += 6
+        if "polygon" in category_tokens:
+            score += 10
+        if "matic" in category_tokens:
+            score += 5
+        if "polygon" in name_tokens:
+            score += 8
+        if "polygon" in description_tokens:
+            score += 4
+        if score > best_score or (score == best_score and slug < best_slug):
+            best_score = score
+            best_slug = slug
+
+    return best_slug
+
+
+def _extract_rpc_result(payload: Any, *, source: str) -> dict[str, Any]:
+    body = _extract_publisher_data(payload)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{source} returned a non-object JSON-RPC payload.")
+    error = body.get("error")
+    if error not in (None, {}):
+        raise RuntimeError(f"{source} returned JSON-RPC error: {error}")
+    if "result" not in body:
+        raise RuntimeError(f"{source} did not return a JSON-RPC result.")
+    return body
+
+
+def _parse_rpc_int(value: Any, *, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    text = safe_str(value, "").strip()
+    if not text:
+        raise RuntimeError(f"{field} was empty.")
+    try:
+        if text.startswith(("0x", "0X")):
+            return int(text, 16)
+        return int(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{field} was not numeric: {value}") from exc
+
+
+def _probe_seren_polygon_rpc_target(
+    publisher: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    probe_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": [],
+    }
+    for path in POLYGON_RPC_PROBE_PATHS:
+        try:
+            response = _extract_rpc_result(
+                call_publisher_json(
+                    publisher=publisher,
+                    method="POST",
+                    path=path,
+                    body=probe_payload,
+                    timeout_seconds=timeout_seconds,
+                ),
+                source=f"{publisher}{path or '(root)'}",
+            )
+            chain_id = _parse_rpc_int(response.get("result"), field="eth_chainId")
+            if chain_id != DEFAULT_CHAIN_ID:
+                raise RuntimeError(f"expected chain id {DEFAULT_CHAIN_ID}, got {chain_id}")
+            return {
+                "publisher": publisher,
+                "path": path,
+            }
+        except Exception as exc:
+            errors.append(f"{path or '(root)'}: {exc}")
+
+    raise RuntimeError(
+        f"Unable to probe Polygon RPC publisher '{publisher}'. Errors: {' | '.join(errors)}"
+    )
+
+
+def _eth_call_via_seren_polygon(
+    to: str,
+    data: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [{"to": to, "data": data}, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return safe_str(response.get("result"), "0x0")
+
+
+def _eth_call_via_public_polygon_rpc(
+    to: str,
+    data: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "id": 1,
+        "params": [{"to": to, "data": data}, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return safe_str(response.get("result"), "0x0")
+
+
+def _resolve_polygon_rpc_transport(
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
+    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
+        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+        if publisher:
+            try:
+                target = _probe_seren_polygon_rpc_target(
+                    publisher,
+                    timeout_seconds=timeout_seconds,
+                )
+                return {
+                    "rpc_transport": "seren-publisher",
+                    "rpc_publisher": publisher,
+                    "rpc_path": safe_str(target.get("path"), "/") or "/",
+                    "seren_balance_usd": balance,
+                }
+            except Exception as exc:
+                fallback_reason = (
+                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+                )
+        else:
+            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    else:
+        fallback_reason = (
+            f"Seren prepaid balance ${balance:.2f} is below the "
+            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+        )
+
+    return {
+        "rpc_transport": "public",
+        "rpc_url": rpc_url,
+        "rpc_fallback_reason": fallback_reason,
+    }
+
+
+def _eth_call_with_transport(
+    to: str,
+    data: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_call_via_seren_polygon(
+            to,
+            data,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    try:
+        return _eth_call_via_public_polygon_rpc(
+            to,
+            data,
+            rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        fallback_reason = safe_str(rpc_transport.get("rpc_fallback_reason"), "").strip()
+        if fallback_reason:
+            raise RuntimeError(
+                f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
+            ) from exc
+        raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
 
 
 def current_machine_label() -> str:
@@ -1423,7 +1793,7 @@ class PolymarketPublisherTrader:
 def check_neg_risk_approvals(
     wallet_address: str,
     *,
-    rpc_url: str = "https://polygon-rpc.com",
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
@@ -1437,28 +1807,31 @@ def check_neg_risk_approvals(
         "usdc_approved": False,
         "ct_approved": False,
         "checks_passed": False,
+        "rpc_transport": "unknown",
         "errors": [],
     }
 
     wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
     adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
 
-    def _eth_call(to: str, data: str) -> str:
-        payload = json.dumps({
-            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
-            "params": [{"to": to, "data": data}, "latest"],
-        }).encode()
-        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
-        try:
-            with urlopen(req, timeout=timeout_seconds) as resp:
-                body = json.loads(resp.read())
-                return safe_str(body.get("result"), "0x0")
-        except Exception:
-            return "0x0"
+    rpc_transport = _resolve_polygon_rpc_transport(
+        rpc_url=rpc_url,
+        timeout_seconds=timeout_seconds,
+    )
+    results.update(rpc_transport)
 
     # Check USDC.e allowance to NegRiskAdapter
     usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_result = _eth_call_with_transport(
+            POLYGON_USDC_E,
+            usdc_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         usdc_allowance = int(usdc_result, 16)
     except (ValueError, TypeError):
@@ -1468,7 +1841,16 @@ def check_neg_risk_approvals(
 
     # Check CT isApprovedForAll to NegRiskAdapter
     ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_result = _eth_call_with_transport(
+            POLYGON_CONDITIONAL_TOKENS,
+            ct_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         ct_approved = int(ct_result, 16) > 0
     except (ValueError, TypeError):

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -633,21 +633,22 @@ def test_unwind_all_requires_yes_live() -> None:
 
 
 def test_check_neg_risk_approvals_returns_structured_result() -> None:
-    """#159: check_neg_risk_approvals returns actionable errors for missing approvals."""
+    """#159: check_neg_risk_approvals fails closed with structured RPC errors."""
     live = _load_live_module()
     assert hasattr(live, "check_neg_risk_approvals")
     assert hasattr(live, "POLYGON_NEG_RISK_ADAPTER")
     assert live.POLYGON_NEG_RISK_ADAPTER == "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
-    # Test with a zero-address wallet (no approvals) against a non-responding RPC
+    # Test with a zero-address wallet against a non-responding public RPC fallback.
     result = live.check_neg_risk_approvals(
         "0x0000000000000000000000000000000000000000",
-        rpc_url="http://127.0.0.1:1",  # unreachable — forces 0x0 fallback
+        rpc_url="http://127.0.0.1:1",
         timeout_seconds=1.0,
     )
     assert isinstance(result, dict)
     assert result["checks_passed"] is False
     assert len(result["errors"]) >= 1
-    assert "NegRiskAdapter" in result["errors"][0]
+    assert "Polygon RPC read failed" in result["errors"][0]
+    assert not any("NegRiskAdapter" in error for error in result["errors"])
 
 
 def test_setup_local_pull_schedule_uses_quote_payload(monkeypatch) -> None:

--- a/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import platform
+import re
 import select
 import shlex
 import signal
@@ -28,10 +29,14 @@ POLYMARKET_DATA_API_BASE_URL = "https://data-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CHAIN_ID = 137
-LIVE_SAFETY_VERSION = "2026-03-18.polymarket-live-safety-v3"
+LIVE_SAFETY_VERSION = "2026-03-20.polymarket-live-safety-v4"
 USDC_DECIMALS = 6
 SEREN_CRON_PUBLISHER = "seren-cron"
+SEREN_POLYGON_PUBLISHER_HINT = "seren-polygon"
+SEREN_MIN_PUBLISHER_BALANCE_USD = 1.0
 DEFAULT_SEREN_CRON_POLL_INTERVAL_SECONDS = 30
+POLYGON_PUBLIC_RPC_URL = "https://polygon-rpc.com"
+POLYGON_RPC_PROBE_PATHS = ("/", "", "/rpc")
 
 # Polymarket contract addresses on Polygon mainnet
 POLYGON_USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
@@ -564,6 +569,98 @@ def _extract_call_publisher_body(result: dict[str, Any]) -> Any:
     return result.get("value")
 
 
+def _seren_api_key() -> str:
+    return safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+
+
+def _call_seren_mcp_tool(
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
+    command = shlex.split(command_raw)
+    if not command:
+        raise RuntimeError("SEREN_MCP_COMMAND is empty.")
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _mcp_request(
+            proc=proc,
+            request_id=1,
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "polymarket-live", "version": "1.0"},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        _write_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        result = _mcp_request(
+            proc=proc,
+            request_id=2,
+            method="tools/call",
+            params={
+                "name": tool_name,
+                "arguments": arguments or {},
+            },
+            timeout_seconds=timeout_seconds,
+        )
+        return _extract_call_publisher_body(result)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+
+def _seren_http_json(
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    api_key = _seren_api_key()
+    if not api_key:
+        raise RuntimeError("Seren API key is not available for direct HTTP access.")
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if headers:
+        req_headers.update(headers)
+
+    data = None
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+        data = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    request = Request(
+        f"{SEREN_API_BASE}{normalized_path}",
+        headers=req_headers,
+        method=method.upper(),
+        data=data,
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:
+        text = response.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
 def call_publisher_json(
     publisher: str,
     method: str,
@@ -572,62 +669,22 @@ def call_publisher_json(
     body: Any = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
-    api_key = safe_str(os.getenv("API_KEY") or os.getenv("SEREN_API_KEY"), "").strip()
+    api_key = _seren_api_key()
     prefer_mcp = not api_key
 
     if prefer_mcp:
-        command_raw = safe_str(os.getenv("SEREN_MCP_COMMAND"), "seren-mcp").strip() or "seren-mcp"
-        command = shlex.split(command_raw)
-        if not command:
-            raise RuntimeError("SEREN_MCP_COMMAND is empty.")
-        proc = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return _call_seren_mcp_tool(
+            "call_publisher",
+            {
+                "publisher": publisher,
+                "method": method.upper(),
+                "path": path,
+                "headers": headers or {},
+                "body": json.dumps(body) if body is not None else None,
+                "response_format": "json",
+            },
+            timeout_seconds=timeout_seconds,
         )
-        try:
-            _mcp_request(
-                proc=proc,
-                request_id=1,
-                method="initialize",
-                params={
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "polymarket-live", "version": "1.0"},
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            _write_mcp_message(
-                proc,
-                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            )
-            result = _mcp_request(
-                proc=proc,
-                request_id=2,
-                method="tools/call",
-                params={
-                    "name": "call_publisher",
-                    "arguments": {
-                        "publisher": publisher,
-                        "method": method.upper(),
-                        "path": path,
-                        "headers": headers or {},
-                        "body": json.dumps(body) if body is not None else None,
-                        "response_format": "json",
-                    },
-                },
-                timeout_seconds=timeout_seconds,
-            )
-            return _extract_call_publisher_body(result)
-        finally:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=1)
 
     req_headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
     if headers:
@@ -647,6 +704,319 @@ def call_publisher_json(
         if not text:
             return {}
         return json.loads(text)
+
+
+def get_seren_prepaid_balance(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> float:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/wallet/balance", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "get_prepaid_balance",
+                {},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return 0.0
+
+    if not isinstance(payload, dict):
+        return 0.0
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    for field in ("funded_balance_usd", "balance_usd"):
+        value = safe_float(data.get(field), -1.0)
+        if value >= 0.0:
+            return value
+    return 0.0
+
+
+def list_seren_publishers(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    try:
+        if _seren_api_key():
+            payload = _seren_http_json("/publishers?limit=200&offset=0", timeout_seconds=timeout_seconds)
+        else:
+            payload = _call_seren_mcp_tool(
+                "list_agent_publishers",
+                {"category": "integration", "limit": 200, "offset": 0, "verbose": True},
+                timeout_seconds=timeout_seconds,
+            )
+    except Exception:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        rows = payload.get("publishers")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _tokenize(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.lower()) if token}
+
+
+def _is_rpc_like_publisher(publisher: dict[str, Any]) -> bool:
+    categories = publisher.get("categories", [])
+    categories_text = ""
+    if isinstance(categories, list):
+        categories_text = " ".join(
+            str(category).lower() for category in categories if isinstance(category, str)
+        )
+
+    slug_tokens = _tokenize(safe_str(publisher.get("slug"), ""))
+    name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+    category_tokens = _tokenize(categories_text)
+    description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+    combined = slug_tokens | name_tokens | category_tokens | description_tokens
+    return "rpc" in combined or ("json" in combined and "web3" in combined)
+
+
+def discover_seren_polygon_publisher(
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    best_slug = ""
+    best_score = -1
+    for publisher in list_seren_publishers(timeout_seconds=timeout_seconds):
+        if publisher.get("is_active") is False:
+            continue
+        if not _is_rpc_like_publisher(publisher):
+            continue
+
+        slug = safe_str(publisher.get("slug"), "").strip().lower()
+        if not slug:
+            continue
+
+        categories = publisher.get("categories", [])
+        categories_text = ""
+        if isinstance(categories, list):
+            categories_text = " ".join(
+                str(category).lower() for category in categories if isinstance(category, str)
+            )
+
+        slug_tokens = _tokenize(slug)
+        name_tokens = _tokenize(safe_str(publisher.get("name"), ""))
+        category_tokens = _tokenize(categories_text)
+        description_tokens = _tokenize(safe_str(publisher.get("description"), ""))
+        combined = slug_tokens | name_tokens | category_tokens | description_tokens
+        if not ({"polygon", "matic"} & combined):
+            continue
+
+        score = 0
+        if slug == SEREN_POLYGON_PUBLISHER_HINT:
+            score += 100
+        if slug.startswith("seren-"):
+            score += 20
+        if "polygon" in slug_tokens:
+            score += 12
+        if "matic" in slug_tokens:
+            score += 6
+        if "polygon" in category_tokens:
+            score += 10
+        if "matic" in category_tokens:
+            score += 5
+        if "polygon" in name_tokens:
+            score += 8
+        if "polygon" in description_tokens:
+            score += 4
+        if score > best_score or (score == best_score and slug < best_slug):
+            best_score = score
+            best_slug = slug
+
+    return best_slug
+
+
+def _extract_rpc_result(payload: Any, *, source: str) -> dict[str, Any]:
+    body = _extract_publisher_data(payload)
+    if not isinstance(body, dict):
+        raise RuntimeError(f"{source} returned a non-object JSON-RPC payload.")
+    error = body.get("error")
+    if error not in (None, {}):
+        raise RuntimeError(f"{source} returned JSON-RPC error: {error}")
+    if "result" not in body:
+        raise RuntimeError(f"{source} did not return a JSON-RPC result.")
+    return body
+
+
+def _parse_rpc_int(value: Any, *, field: str) -> int:
+    if isinstance(value, int):
+        return value
+    text = safe_str(value, "").strip()
+    if not text:
+        raise RuntimeError(f"{field} was empty.")
+    try:
+        if text.startswith(("0x", "0X")):
+            return int(text, 16)
+        return int(text)
+    except ValueError as exc:
+        raise RuntimeError(f"{field} was not numeric: {value}") from exc
+
+
+def _probe_seren_polygon_rpc_target(
+    publisher: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    probe_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": [],
+    }
+    for path in POLYGON_RPC_PROBE_PATHS:
+        try:
+            response = _extract_rpc_result(
+                call_publisher_json(
+                    publisher=publisher,
+                    method="POST",
+                    path=path,
+                    body=probe_payload,
+                    timeout_seconds=timeout_seconds,
+                ),
+                source=f"{publisher}{path or '(root)'}",
+            )
+            chain_id = _parse_rpc_int(response.get("result"), field="eth_chainId")
+            if chain_id != DEFAULT_CHAIN_ID:
+                raise RuntimeError(f"expected chain id {DEFAULT_CHAIN_ID}, got {chain_id}")
+            return {
+                "publisher": publisher,
+                "path": path,
+            }
+        except Exception as exc:
+            errors.append(f"{path or '(root)'}: {exc}")
+
+    raise RuntimeError(
+        f"Unable to probe Polygon RPC publisher '{publisher}'. Errors: {' | '.join(errors)}"
+    )
+
+
+def _eth_call_via_seren_polygon(
+    to: str,
+    data: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [{"to": to, "data": data}, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return safe_str(response.get("result"), "0x0")
+
+
+def _eth_call_via_public_polygon_rpc(
+    to: str,
+    data: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "id": 1,
+        "params": [{"to": to, "data": data}, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return safe_str(response.get("result"), "0x0")
+
+
+def _resolve_polygon_rpc_transport(
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
+    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
+        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+        if publisher:
+            try:
+                target = _probe_seren_polygon_rpc_target(
+                    publisher,
+                    timeout_seconds=timeout_seconds,
+                )
+                return {
+                    "rpc_transport": "seren-publisher",
+                    "rpc_publisher": publisher,
+                    "rpc_path": safe_str(target.get("path"), "/") or "/",
+                    "seren_balance_usd": balance,
+                }
+            except Exception as exc:
+                fallback_reason = (
+                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+                )
+        else:
+            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    else:
+        fallback_reason = (
+            f"Seren prepaid balance ${balance:.2f} is below the "
+            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+        )
+
+    return {
+        "rpc_transport": "public",
+        "rpc_url": rpc_url,
+        "rpc_fallback_reason": fallback_reason,
+    }
+
+
+def _eth_call_with_transport(
+    to: str,
+    data: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_call_via_seren_polygon(
+            to,
+            data,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    try:
+        return _eth_call_via_public_polygon_rpc(
+            to,
+            data,
+            rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        fallback_reason = safe_str(rpc_transport.get("rpc_fallback_reason"), "").strip()
+        if fallback_reason:
+            raise RuntimeError(
+                f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
+            ) from exc
+        raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
 
 
 def current_machine_label() -> str:
@@ -1423,7 +1793,7 @@ class PolymarketPublisherTrader:
 def check_neg_risk_approvals(
     wallet_address: str,
     *,
-    rpc_url: str = "https://polygon-rpc.com",
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     """Check if wallet has USDC.e and CT approvals for NegRiskAdapter.
@@ -1437,28 +1807,31 @@ def check_neg_risk_approvals(
         "usdc_approved": False,
         "ct_approved": False,
         "checks_passed": False,
+        "rpc_transport": "unknown",
         "errors": [],
     }
 
     wallet_padded = wallet_address.lower().replace("0x", "").zfill(64)
     adapter_padded = POLYGON_NEG_RISK_ADAPTER.lower().replace("0x", "").zfill(64)
 
-    def _eth_call(to: str, data: str) -> str:
-        payload = json.dumps({
-            "jsonrpc": "2.0", "method": "eth_call", "id": 1,
-            "params": [{"to": to, "data": data}, "latest"],
-        }).encode()
-        req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
-        try:
-            with urlopen(req, timeout=timeout_seconds) as resp:
-                body = json.loads(resp.read())
-                return safe_str(body.get("result"), "0x0")
-        except Exception:
-            return "0x0"
+    rpc_transport = _resolve_polygon_rpc_transport(
+        rpc_url=rpc_url,
+        timeout_seconds=timeout_seconds,
+    )
+    results.update(rpc_transport)
 
     # Check USDC.e allowance to NegRiskAdapter
     usdc_data = f"0x{ERC20_ALLOWANCE_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    usdc_result = _eth_call(POLYGON_USDC_E, usdc_data)
+    try:
+        usdc_result = _eth_call_with_transport(
+            POLYGON_USDC_E,
+            usdc_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         usdc_allowance = int(usdc_result, 16)
     except (ValueError, TypeError):
@@ -1468,7 +1841,16 @@ def check_neg_risk_approvals(
 
     # Check CT isApprovedForAll to NegRiskAdapter
     ct_data = f"0x{ERC1155_IS_APPROVED_ABI_FRAGMENT[2:]}{wallet_padded}{adapter_padded}"
-    ct_result = _eth_call(POLYGON_CONDITIONAL_TOKENS, ct_data)
+    try:
+        ct_result = _eth_call_with_transport(
+            POLYGON_CONDITIONAL_TOKENS,
+            ct_data,
+            rpc_transport=rpc_transport,
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        results["errors"].append(str(exc))
+        return results
     try:
         ct_approved = int(ct_result, 16) > 0
     except (ValueError, TypeError):

--- a/polymarket/tests/test_execution_safety.py
+++ b/polymarket/tests/test_execution_safety.py
@@ -31,6 +31,20 @@ UNWIND_AGENT_PATHS = {
 BOT_AGENT_PATH = POLYMARKET_ROOT / "bot" / "scripts" / "agent.py"
 
 
+class _JsonResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "_JsonResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
 def _load_module(name: str, path: Path, *, clear_modules: tuple[str, ...] = ()) -> object:
     for module_name in clear_modules:
         sys.modules.pop(module_name, None)
@@ -126,6 +140,137 @@ def test_marketable_sell_plan_uses_min_tick_and_full_bid_sweep(
     assert plan["estimated_fill_size"] == pytest.approx(12.0)
     assert plan["estimated_unfilled_size"] == pytest.approx(0.0)
     assert plan["execution_style"] == "marketable-limit-min-tick"
+
+
+@pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
+def test_neg_risk_approval_check_prefers_seren_polygon_publisher_when_funded(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_seren_polygon_test",
+        LIVE_MODULE_PATHS[skill_slug],
+        clear_modules=("polymarket_live",),
+    )
+    publisher_calls: list[tuple[str, str, str, str]] = []
+
+    monkeypatch.setattr(module, "get_seren_prepaid_balance", lambda **kwargs: 5.0)
+    monkeypatch.setattr(
+        module,
+        "discover_seren_polygon_publisher",
+        lambda **kwargs: "seren-polygon",
+    )
+
+    def fake_call_publisher_json(
+        publisher: str,
+        method: str,
+        path: str,
+        headers=None,
+        body=None,
+        timeout_seconds: float = 30.0,
+    ):
+        rpc_method = body["method"]
+        publisher_calls.append((publisher, method, path, rpc_method))
+        if rpc_method == "eth_chainId":
+            return {"jsonrpc": "2.0", "id": 1, "result": "0x89"}
+        if body["params"][0]["to"] == module.POLYGON_USDC_E:
+            return {"jsonrpc": "2.0", "id": 1, "result": hex(2 * (10 ** module.USDC_DECIMALS))}
+        return {"jsonrpc": "2.0", "id": 1, "result": "0x1"}
+
+    monkeypatch.setattr(module, "call_publisher_json", fake_call_publisher_json)
+    monkeypatch.setattr(
+        module,
+        "urlopen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("public fallback should not be used")),
+    )
+
+    result = module.check_neg_risk_approvals("0x" + ("1" * 40))
+
+    assert result["checks_passed"] is True
+    assert result["rpc_transport"] == "seren-publisher"
+    assert result["rpc_publisher"] == "seren-polygon"
+    assert all(call[0] == "seren-polygon" for call in publisher_calls)
+    assert [call[3] for call in publisher_calls] == ["eth_chainId", "eth_call", "eth_call"]
+
+
+@pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
+def test_neg_risk_approval_check_falls_back_to_public_polygon_rpc_without_seren_funding(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_public_polygon_test",
+        LIVE_MODULE_PATHS[skill_slug],
+        clear_modules=("polymarket_live",),
+    )
+    public_rpc_methods: list[str] = []
+
+    monkeypatch.setattr(module, "get_seren_prepaid_balance", lambda **kwargs: 0.0)
+    monkeypatch.setattr(
+        module,
+        "call_publisher_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Seren publisher should not be used")),
+    )
+
+    def fake_urlopen(request, timeout: float = 10.0):
+        payload = json.loads(request.data.decode("utf-8"))
+        public_rpc_methods.append(payload["method"])
+        if payload["params"][0]["to"] == module.POLYGON_USDC_E:
+            return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": hex(2 * (10 ** module.USDC_DECIMALS))})
+        return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": "0x1"})
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    result = module.check_neg_risk_approvals("0x" + ("2" * 40))
+
+    assert result["checks_passed"] is True
+    assert result["rpc_transport"] == "public"
+    assert result["rpc_url"] == module.POLYGON_PUBLIC_RPC_URL
+    assert public_rpc_methods == ["eth_call", "eth_call"]
+
+
+@pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
+def test_neg_risk_approval_check_fails_closed_when_seren_and_public_rpc_reads_fail(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_polygon_rpc_failure_test",
+        LIVE_MODULE_PATHS[skill_slug],
+        clear_modules=("polymarket_live",),
+    )
+
+    public_rpc_methods: list[str] = []
+
+    monkeypatch.setattr(module, "get_seren_prepaid_balance", lambda **kwargs: 5.0)
+    monkeypatch.setattr(
+        module,
+        "discover_seren_polygon_publisher",
+        lambda **kwargs: "seren-polygon",
+    )
+    monkeypatch.setattr(
+        module,
+        "call_publisher_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("seren rpc unavailable")),
+    )
+    monkeypatch.setattr(
+        module,
+        "urlopen",
+        lambda request, *args, **kwargs: (
+            public_rpc_methods.append(json.loads(request.data.decode("utf-8"))["method"]),
+            (_ for _ in ()).throw(OSError("public rpc unavailable")),
+        )[1],
+    )
+
+    result = module.check_neg_risk_approvals("0x" + ("3" * 40))
+
+    assert result["checks_passed"] is False
+    assert result["rpc_transport"] == "public"
+    assert result["errors"]
+    assert any("Polygon RPC read failed" in error for error in result["errors"])
+    assert "probe failed" in str(result.get("rpc_fallback_reason", ""))
+    assert public_rpc_methods == ["eth_call"]
+    assert not any("not approved" in error.lower() for error in result["errors"])
 
 
 @pytest.mark.parametrize("skill_slug", sorted(UNWIND_AGENT_PATHS))


### PR DESCRIPTION
Closes #193

## Summary
- prefer the live `seren-polygon` publisher for Polymarket neg-risk approval checks when the user has sufficient Seren prepaid balance via API key or Desktop MCP auth
- fall back to a public Polygon RPC when no funded Seren balance is available, and fail closed with a structured RPC error instead of fabricating zero approvals
- cover the new funded, unfunded, and RPC-failure paths in the shared Polymarket execution safety tests

## Test
- `python3 -m pytest --import-mode=importlib polymarket/tests/test_execution_safety.py`
- `python3 -m pytest --import-mode=importlib polymarket/maker-rebate-bot/tests/test_smoke.py polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py polymarket/liquidity-paired-basis-maker/tests/test_smoke.py polymarket/paired-market-basis-maker/tests/test_smoke.py`
- `python3 scripts/validate_trading_skill_safety.py --base-ref origin/main`