### PR TITLE
fix: harden polymarket maker rebate adverse selection guards

### DIFF
--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -21,9 +21,10 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 2. `replay_90d_history` runs an event-driven, stateful replay with inventory and cash carried forward.
 3. `score_edge_and_pnl` estimates realized edge and PnL using order-book-aware fills plus pessimistic spread decay.
 4. `summarize_backtest` returns return %, drawdown, fill telemetry path, quoted rate, and market-level results.
-5. `filter_markets` removes markets near resolution or outside quality thresholds.
-6. `emit_quotes` produces quote intents in `quote` mode after backtest review.
-7. `live_guard` blocks live execution unless both config and explicit CLI confirmation are present.
+5. `filter_markets` removes markets outside the default safe band (`$0.30-$0.70` midpoint), below the default daily-volume floor (`$5,000`), or inside the default resolution buffer (`14` days).
+6. `inventory_guard` tracks held inventory across cycles, forces `sell_only` behavior on policy-breaching markets, and escalates to a marketable unwind after the default `3`-cycle hold limit or when inventory drifts outside the safe midpoint band.
+7. `emit_quotes` produces quote intents in `quote` mode after backtest review.
+8. `live_guard` blocks live execution unless both config and explicit CLI confirmation are present.
 
 ## Execution Modes
 
@@ -99,6 +100,7 @@ If you are already running inside Seren Desktop, the runtime can use injected au
 > **Live market data only.** Always leave `"markets": []` and `"state": {"inventory": {}}` empty in your config.json.
 > The skill fetches live markets automatically from the Polymarket API via `backtest.gamma_markets_url`.
 > Never add placeholder or example market IDs (e.g. `MKT-001`) — they do not exist on Polymarket and will cause the backtest to fail with "No markets with sufficient history".
+> Leave `"state.inventory_cycles": {}` empty as well. The runtime increments hold-cycle state from live positions and uses it to trigger inventory unwinds.
 
 ## Run Quote Mode (After Backtest Review)
 
@@ -143,9 +145,11 @@ To enable, set `predictions_enabled: true` in the `backtest` section of your `co
 - Live quote cycles cancel stale orders, fetch fresh market snapshots, and then poll open orders/positions after requoting.
 - Backtests are estimates and can materially differ from live outcomes.
 - Replay enforces the same market, total, and position caps used by quote mode.
+- Replay now blocks new exposure outside the default `0.30-0.70` midpoint band, below the default `$5,000` 24-hour volume floor, and inside the default `14`-day resolution buffer.
+- Held inventory is not allowed to drift indefinitely. The runtime persists hold cycles, switches policy-breaching inventory to `sell_only`, and forces a marketable unwind once the configured hold limit is reached or the midpoint drifts outside the safe band.
 - Backtests emit JSONL quote/fill telemetry for later calibration when `backtest.telemetry_path` is set.
 - Quotes are blocked when estimated edge is negative.
-- Markets close to resolution are excluded.
+- New entries close to resolution are excluded.
 - Position and notional caps are enforced before orders are emitted.
 - This strategy can lose money during fast information updates, gaps, liquidity changes, or rebate policy changes.
 

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -44,7 +44,11 @@
   "strategy": {
     "bankroll_usd": 1000,
     "markets_max": 12,
-    "min_seconds_to_resolution": 21600,
+    "min_seconds_to_resolution": 1209600,
+    "min_mid_price": 0.3,
+    "max_mid_price": 0.7,
+    "min_daily_volume_usd": 5000,
+    "max_inventory_hold_cycles": 3,
     "min_edge_bps": 2,
     "default_rebate_bps": 3,
     "expected_unwind_cost_bps": 1.5,
@@ -59,9 +63,10 @@
     "inventory_skew_strength_bps": 25
   },
   "state": {
-    "_note": "Leave inventory/live_risk empty. The skill populates these from live order, position, and cash state.",
+    "_note": "Leave inventory/live_risk/inventory_cycles empty. The skill populates these from live order, position, and cash state.",
     "inventory": {},
-    "live_risk": {}
+    "live_risk": {},
+    "inventory_cycles": {}
   },
   "cron": {
     "runner_name": "",

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -62,7 +62,11 @@ MISSING_RUNTIME_AUTH_ERROR = (
 class StrategyParams:
     bankroll_usd: float = 1000.0
     markets_max: int = 12
-    min_seconds_to_resolution: int = 6 * 60 * 60
+    min_seconds_to_resolution: int = 14 * 24 * 60 * 60
+    min_mid_price: float = 0.30
+    max_mid_price: float = 0.70
+    min_daily_volume_usd: float = 5000.0
+    max_inventory_hold_cycles: int = 3
     min_edge_bps: float = 2.0
     default_rebate_bps: float = 3.0
     expected_unwind_cost_bps: float = 1.5
@@ -304,7 +308,14 @@ def to_params(config: dict[str, Any]) -> StrategyParams:
     return StrategyParams(
         bankroll_usd=_safe_float(strategy.get("bankroll_usd"), 1000.0),
         markets_max=_safe_int(strategy.get("markets_max"), 12),
-        min_seconds_to_resolution=_safe_int(strategy.get("min_seconds_to_resolution"), 21600),
+        min_seconds_to_resolution=_safe_int(
+            strategy.get("min_seconds_to_resolution"),
+            14 * 24 * 60 * 60,
+        ),
+        min_mid_price=clamp(_safe_float(strategy.get("min_mid_price"), 0.30), 0.001, 0.999),
+        max_mid_price=clamp(_safe_float(strategy.get("max_mid_price"), 0.70), 0.001, 0.999),
+        min_daily_volume_usd=max(0.0, _safe_float(strategy.get("min_daily_volume_usd"), 5000.0)),
+        max_inventory_hold_cycles=max(1, _safe_int(strategy.get("max_inventory_hold_cycles"), 3)),
         min_edge_bps=_safe_float(strategy.get("min_edge_bps"), 2.0),
         default_rebate_bps=_safe_float(strategy.get("default_rebate_bps"), 3.0),
         expected_unwind_cost_bps=_safe_float(strategy.get("expected_unwind_cost_bps"), 1.5),
@@ -404,21 +415,137 @@ def expected_edge_bps(spread_bps: float, rebate_bps: float, p: StrategyParams) -
     return half_spread_capture + rebate_bps - p.expected_unwind_cost_bps - p.adverse_selection_bps
 
 
-def should_skip_market(market: dict[str, Any], p: StrategyParams) -> tuple[bool, str]:
-    ttl = _safe_int(market.get("seconds_to_resolution"), 0)
-    if ttl < p.min_seconds_to_resolution:
-        return True, "near_resolution"
+def _mid_price_in_band(mid_price: float, p: StrategyParams) -> bool:
+    return p.min_mid_price <= mid_price <= p.max_mid_price
 
+
+def _market_daily_volume_usd(market: dict[str, Any]) -> float | None:
+    for key in ("volume24hr", "daily_volume_usd", "volume_24h_usd"):
+        if key in market and market.get(key) is not None:
+            return max(0.0, _safe_float(market.get(key), 0.0))
+    return None
+
+
+def _is_inventory_exit_market(market: dict[str, Any]) -> bool:
+    return bool(market.get("sell_only", False)) or bool(market.get("force_unwind", False))
+
+
+def should_skip_market(market: dict[str, Any], p: StrategyParams) -> tuple[bool, str]:
     mid = _safe_float(market.get("mid_price"), -1.0)
-    if mid <= 0.01 or mid >= 0.99:
-        return True, "extreme_probability"
+    if not (0.0 < mid < 1.0):
+        return True, "invalid_mid_price"
 
     bid = _safe_float(market.get("best_bid"), -1.0)
     ask = _safe_float(market.get("best_ask"), -1.0)
     if not (0.0 <= bid <= 1.0 and 0.0 <= ask <= 1.0 and bid <= ask):
         return True, "invalid_book"
 
+    if _is_inventory_exit_market(market):
+        return False, ""
+
+    ttl = _safe_int(market.get("seconds_to_resolution"), 0)
+    if ttl < p.min_seconds_to_resolution:
+        return True, "near_resolution"
+
+    daily_volume = _market_daily_volume_usd(market)
+    if daily_volume is not None and daily_volume < p.min_daily_volume_usd:
+        return True, "low_daily_volume"
+
+    if not _mid_price_in_band(mid, p):
+        return True, "outside_price_band"
+
     return False, ""
+
+
+def _build_inventory_cycle_state(
+    *,
+    prior_state: Any,
+    raw_positions: Any,
+    markets: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    previous = prior_state if isinstance(prior_state, dict) else {}
+    sizes = positions_by_key(raw_positions)
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    market_by_token: dict[str, dict[str, Any]] = {}
+    for market in markets:
+        token_id = _safe_str(market.get("token_id"), _safe_str(market.get("market_id"), "")).strip()
+        if token_id:
+            market_by_token[token_id] = market
+
+    next_state: dict[str, dict[str, Any]] = {}
+    for token_id, shares in sizes.items():
+        if shares <= 0:
+            continue
+        market = market_by_token.get(token_id, {})
+        prior = previous.get(token_id, {}) if isinstance(previous.get(token_id), dict) else {}
+        record: dict[str, Any] = {
+            "token_id": token_id,
+            "market_id": _safe_str(market.get("market_id"), _safe_str(prior.get("market_id"), token_id)),
+            "question": _safe_str(market.get("question"), _safe_str(prior.get("question"), token_id)),
+            "cycles_held": _safe_int(prior.get("cycles_held"), 0) + 1,
+            "shares": round(shares, 6),
+            "first_seen_at": _safe_str(prior.get("first_seen_at"), now_iso),
+            "last_seen_at": now_iso,
+        }
+        mid_price = _safe_float(market.get("mid_price"), -1.0)
+        if 0.0 < mid_price < 1.0:
+            record["mid_price"] = round(mid_price, 6)
+        seconds_to_resolution = _safe_int(market.get("seconds_to_resolution"), -1)
+        if seconds_to_resolution >= 0:
+            record["seconds_to_resolution"] = seconds_to_resolution
+        daily_volume = _market_daily_volume_usd(market)
+        if daily_volume is not None:
+            record["volume24hr"] = round(daily_volume, 4)
+        next_state[token_id] = record
+    return next_state
+
+
+def _apply_held_inventory_policy(
+    *,
+    markets: list[dict[str, Any]],
+    raw_positions: Any,
+    inventory_cycles: dict[str, dict[str, Any]],
+    params: StrategyParams,
+) -> list[dict[str, Any]]:
+    sizes = positions_by_key(raw_positions)
+    updated: list[dict[str, Any]] = []
+    for market in markets:
+        token_id = _safe_str(market.get("token_id"), _safe_str(market.get("market_id"), "")).strip()
+        market_id = _safe_str(market.get("market_id"), token_id).strip()
+        shares = sizes.get(token_id, sizes.get(market_id, 0.0))
+        if shares <= 0:
+            updated.append(market)
+            continue
+
+        enriched = dict(market)
+        cycle_record = inventory_cycles.get(token_id, {})
+        cycles_held = _safe_int(cycle_record.get("cycles_held"), 0)
+        seconds_to_resolution = _safe_int(market.get("seconds_to_resolution"), 0)
+        mid_price = _safe_float(market.get("mid_price"), -1.0)
+        daily_volume = _market_daily_volume_usd(market)
+
+        sell_only_reasons: list[str] = []
+        force_unwind_reason = ""
+        if bool(market.get("sell_only", False)):
+            sell_only_reasons.append(_safe_str(market.get("sell_only_reason"), "resolution_unwind"))
+        if seconds_to_resolution < params.min_seconds_to_resolution:
+            sell_only_reasons.append("near_resolution")
+        if daily_volume is not None and daily_volume < params.min_daily_volume_usd:
+            sell_only_reasons.append("low_daily_volume")
+        if cycles_held >= params.max_inventory_hold_cycles:
+            force_unwind_reason = "inventory_hold_limit"
+        elif 0.0 < mid_price < 1.0 and not _mid_price_in_band(mid_price, params):
+            force_unwind_reason = "outside_price_band"
+
+        if sell_only_reasons:
+            enriched["sell_only"] = True
+            enriched["sell_only_reason"] = ",".join(sorted(set(sell_only_reasons)))
+        if force_unwind_reason:
+            enriched["sell_only"] = True
+            enriched["force_unwind"] = True
+            enriched["force_unwind_reason"] = force_unwind_reason
+        updated.append(enriched)
+    return updated
 
 
 def _parse_iso_ts(value: Any) -> int | None:
@@ -986,6 +1113,7 @@ def _load_markets_from_fixture(
                 "token_id": _safe_str(raw.get("token_id"), market_id),
                 "end_ts": _safe_int(raw.get("end_ts"), _parse_iso_ts(raw.get("endDate")) or 0),
                 "rebate_bps": _safe_float(raw.get("rebate_bps"), 0.0),
+                "volume24hr": _safe_float(raw.get("volume24hr"), 0.0),
                 "history": history,
                 "orderbooks": orderbooks,
                 "orderbook_mode": orderbook_mode,
@@ -1081,11 +1209,15 @@ def _fetch_live_markets(
         token_id = _safe_str(token_ids[0], "")
         if not token_id:
             continue
-        # Parse mid-price from outcomePrices for ranking
-        outcome_prices = _json_to_list(market.get("outcomePrices"))
-        mid_price = _safe_float(outcome_prices[0] if outcome_prices else None, 0.5)
+        mid_price = _extract_live_mid_price(market)
+        if not (0.0 < mid_price < 1.0):
+            continue
         spread = _safe_float(market.get("spread"), 1.0)
         volume24hr = _safe_float(market.get("volume24hr"), 0.0)
+        if volume24hr < strategy_params.min_daily_volume_usd:
+            continue
+        if not _mid_price_in_band(mid_price, strategy_params):
+            continue
         # Score: prefer price near 0.5 (two-way flow), high volume, tight spread
         price_score = 1.0 - abs(mid_price - 0.5) * 2.0  # 1.0 at 0.50, 0.0 at 0.0/1.0
         spread_score = max(0.0, 1.0 - spread * 10.0)     # penalise wide spreads
@@ -1206,7 +1338,12 @@ def _fetch_live_quote_markets(config: dict[str, Any]) -> list[dict[str, Any]]:
             continue
 
         mid_price = _extract_live_mid_price(market)
-        if not (0.01 < mid_price < 0.99):
+        if not (0.0 < mid_price < 1.0):
+            continue
+        volume24hr = _safe_float(market.get("volume24hr"), 0.0)
+        if volume24hr < strategy_params.min_daily_volume_usd:
+            continue
+        if not _mid_price_in_band(mid_price, strategy_params):
             continue
 
         best_bid, best_ask = _extract_live_book(market, mid_price)
@@ -1223,6 +1360,7 @@ def _fetch_live_quote_markets(config: dict[str, Any]) -> list[dict[str, Any]]:
                 "seconds_to_resolution": seconds_to_resolution,
                 "volatility_bps": round(volatility_bps, 3),
                 "rebate_bps": _safe_float(market.get("rebate_bps"), strategy_params.default_rebate_bps),
+                "volume24hr": round(volume24hr, 4),
                 "source": "live-seren-publisher",
             }
         )
@@ -1338,6 +1476,54 @@ def _build_quote_plan(
     )
 
 
+def _build_inventory_exit_quote_plan(
+    *,
+    market_id: str,
+    mid_price: float,
+    volatility_bps: float,
+    rebate_bps: float,
+    inventory_notional: float,
+    strategy_params: StrategyParams,
+    exit_reason: str,
+    target_notional_usd: float,
+) -> QuotePlan:
+    if inventory_notional <= 0.0 or target_notional_usd <= 0.0:
+        return QuotePlan(
+            status="skipped",
+            market_id=market_id,
+            reason="no_inventory_to_unwind",
+            edge_bps=0.0,
+            spread_bps=0.0,
+            rebate_bps=round(rebate_bps, 3),
+            inventory_notional_usd=round(inventory_notional, 2),
+        )
+    spread_bps = compute_spread_bps(volatility_bps, strategy_params)
+    inventory_ratio = 0.0
+    if strategy_params.max_position_notional_usd > 0:
+        inventory_ratio = clamp(
+            inventory_notional / strategy_params.max_position_notional_usd,
+            -1.0,
+            1.0,
+        )
+    skew_bps = -inventory_ratio * strategy_params.inventory_skew_strength_bps
+    half_spread_prob = (spread_bps / 2.0) / 10000.0
+    skew_prob = skew_bps / 10000.0
+    ask_price = clamp(mid_price + half_spread_prob + skew_prob, 0.001, 0.999)
+    return QuotePlan(
+        status="quoted",
+        market_id=market_id,
+        edge_bps=round(expected_edge_bps(spread_bps, rebate_bps, strategy_params), 3),
+        spread_bps=round(spread_bps, 3),
+        rebate_bps=round(rebate_bps, 3),
+        bid_price=0.0,
+        ask_price=round(ask_price, 4),
+        bid_notional_usd=0.0,
+        ask_notional_usd=round(target_notional_usd, 2),
+        inventory_notional_usd=round(inventory_notional, 2),
+        reason=exit_reason,
+    )
+
+
 def _liquidation_equity(
     *,
     cash_usd: float,
@@ -1446,6 +1632,28 @@ def _simulate_market_backtest(
     if rebate_bps <= 0:
         rebate_bps = strategy_params.default_rebate_bps
     end_ts = _safe_int(market.get("end_ts"), 0)
+    market_volume = _market_daily_volume_usd(market)
+    if market_volume is not None and market_volume < strategy_params.min_daily_volume_usd:
+        return {
+            "market_id": market["market_id"],
+            "question": market["question"],
+            "considered_points": 0,
+            "quoted_points": 0,
+            "skipped_points": 1,
+            "fill_events": 0,
+            "filled_notional_usd": 0.0,
+            "pnl_usd": 0.0,
+            "equity_curve": [capital],
+            "telemetry": [
+                {
+                    "market_id": market["market_id"],
+                    "status": "skipped",
+                    "reason": "low_daily_volume",
+                    "volume24hr": round(market_volume, 4),
+                }
+            ],
+            "orderbook_mode": market.get("orderbook_mode", "unknown"),
+        }
     moves_bps = [abs((history[i][1] - history[i - 1][1]) * 10000.0) for i in range(1, len(history))]
 
     # Compute prediction-based directional skew (positive = lean bid/buy, negative = lean ask/sell)
@@ -1470,6 +1678,7 @@ def _simulate_market_backtest(
     filled_notional = 0.0
     telemetry: list[dict[str, Any]] = []
     equity_curve = [capital]
+    holding_cycles = 0
 
     for i in range(window, len(history) - 1):
         t, mid_price = history[i]
@@ -1491,16 +1700,55 @@ def _simulate_market_backtest(
             "inventory_notional_before_usd": round(position_shares * mid_price, 6),
             "orderbook_mode": market.get("orderbook_mode", "unknown"),
         }
-        if end_ts and end_ts - t < strategy_params.min_seconds_to_resolution:
+        breach_near_resolution = bool(end_ts and end_ts - t < strategy_params.min_seconds_to_resolution)
+        breach_price_band = not _mid_price_in_band(mid_price, strategy_params)
+        if position_shares > 1e-9:
+            holding_cycles += 1
+        else:
+            holding_cycles = 0
+        record["holding_cycles_before"] = holding_cycles
+        if (breach_price_band or holding_cycles >= strategy_params.max_inventory_hold_cycles) and position_shares > 1e-9:
+            previous_equity = _liquidation_equity(
+                cash_usd=cash_usd,
+                position_shares=position_shares,
+                mark_price=mid_price,
+                unwind_cost_bps=strategy_params.expected_unwind_cost_bps,
+            )
+            shares_to_sell = position_shares
+            fill_notional = shares_to_sell * max(current_book.best_bid, 0.001)
+            cash_usd += fill_notional
+            cash_usd -= fill_notional * strategy_params.expected_unwind_cost_bps / 10000.0
+            position_shares = 0.0
+            holding_cycles = 0
+            fill_events += 1
+            filled_notional += fill_notional
+            equity_after = max(0.0, cash_usd)
+            equity_curve.append(equity_after)
+            record.update(
+                {
+                    "status": "forced_unwind",
+                    "reason": "outside_price_band" if breach_price_band else "inventory_hold_limit",
+                    "fill_side": "sell",
+                    "fill_fraction": 1.0,
+                    "fill_notional_usd": round(fill_notional, 6),
+                    "inventory_notional_after_usd": 0.0,
+                    "equity_before_usd": round(previous_equity, 6),
+                    "equity_after_usd": round(equity_after, 6),
+                    "event_pnl_usd": round(equity_after - previous_equity, 6),
+                }
+            )
+            telemetry.append(record)
+            continue
+        if breach_near_resolution and position_shares <= 1e-9:
             skipped += 1
             record["status"] = "skipped"
             record["reason"] = "near_resolution"
             telemetry.append(record)
             continue
-        if mid_price <= 0.01 or mid_price >= 0.99:
+        if breach_price_band and position_shares <= 1e-9:
             skipped += 1
             record["status"] = "skipped"
-            record["reason"] = "extreme_probability"
+            record["reason"] = "outside_price_band"
             telemetry.append(record)
             continue
 
@@ -1542,10 +1790,19 @@ def _simulate_market_backtest(
             continue
 
         quoted += 1
+        sell_only = breach_near_resolution or (market_volume is not None and market_volume < strategy_params.min_daily_volume_usd)
+        bid_notional_usd = 0.0 if sell_only else quote_plan.bid_notional_usd
+        ask_notional_usd = min(
+            quote_plan.ask_notional_usd,
+            max(0.0, position_shares) * max(quote_plan.ask_price, 0.0),
+        )
+        record["sell_only"] = sell_only
+        record["bid_notional_usd"] = round(bid_notional_usd, 6)
+        record["ask_notional_usd"] = round(ask_notional_usd, 6)
         side: str | None = None
-        if next_price < mid_price and quote_plan.bid_notional_usd > 0.0:
+        if next_price < mid_price and bid_notional_usd > 0.0:
             side = "buy"
-        elif next_price > mid_price and quote_plan.ask_notional_usd > 0.0:
+        elif next_price > mid_price and ask_notional_usd > 0.0:
             side = "sell"
 
         previous_equity = _liquidation_equity(
@@ -1561,7 +1818,7 @@ def _simulate_market_backtest(
             fill_fraction = _fill_fraction(
                 side="buy",
                 quote_price=quote_plan.bid_price,
-                quote_notional=quote_plan.bid_notional_usd,
+                quote_notional=bid_notional_usd,
                 current_book=current_book,
                 next_book=next_book,
                 next_mid=next_price,
@@ -1569,13 +1826,13 @@ def _simulate_market_backtest(
                 backtest_params=backtest_params,
                 strategy_params=strategy_params,
             )
-            fill_notional = quote_plan.bid_notional_usd * fill_fraction
+            fill_notional = bid_notional_usd * fill_fraction
             fill_price = quote_plan.bid_price
         elif side == "sell":
             fill_fraction = _fill_fraction(
                 side="sell",
                 quote_price=quote_plan.ask_price,
-                quote_notional=quote_plan.ask_notional_usd,
+                quote_notional=ask_notional_usd,
                 current_book=current_book,
                 next_book=next_book,
                 next_mid=next_price,
@@ -1583,7 +1840,7 @@ def _simulate_market_backtest(
                 backtest_params=backtest_params,
                 strategy_params=strategy_params,
             )
-            fill_notional = quote_plan.ask_notional_usd * fill_fraction
+            fill_notional = ask_notional_usd * fill_fraction
             fill_price = quote_plan.ask_price
 
         if fill_notional > 0.0 and side is not None:
@@ -2092,15 +2349,40 @@ def quote_market(
     mid = _safe_float(market.get("mid_price"), 0.5)
     vol_bps = _safe_float(market.get("volatility_bps"), p.min_spread_bps)
     rebate_bps = _safe_float(market.get("rebate_bps"), p.default_rebate_bps)
-    quote_plan = _build_quote_plan(
-        market_id=market_id,
-        mid_price=mid,
-        volatility_bps=vol_bps,
-        rebate_bps=rebate_bps,
-        inventory_notional=inventory_notional,
-        outstanding_notional=outstanding_notional,
-        strategy_params=p,
-    )
+    sell_only = bool(market.get("sell_only", False))
+    force_unwind = bool(market.get("force_unwind", False))
+    if force_unwind:
+        quote_plan = _build_inventory_exit_quote_plan(
+            market_id=market_id,
+            mid_price=mid,
+            volatility_bps=vol_bps,
+            rebate_bps=rebate_bps,
+            inventory_notional=max(0.0, inventory_notional),
+            strategy_params=p,
+            exit_reason=_safe_str(market.get("force_unwind_reason"), "inventory_force_unwind"),
+            target_notional_usd=max(0.0, inventory_notional),
+        )
+    elif sell_only:
+        quote_plan = _build_inventory_exit_quote_plan(
+            market_id=market_id,
+            mid_price=mid,
+            volatility_bps=vol_bps,
+            rebate_bps=rebate_bps,
+            inventory_notional=max(0.0, inventory_notional),
+            strategy_params=p,
+            exit_reason=_safe_str(market.get("sell_only_reason"), "inventory_exit_only"),
+            target_notional_usd=min(max(0.0, inventory_notional), p.base_order_notional_usd),
+        )
+    else:
+        quote_plan = _build_quote_plan(
+            market_id=market_id,
+            mid_price=mid,
+            volatility_bps=vol_bps,
+            rebate_bps=rebate_bps,
+            inventory_notional=inventory_notional,
+            outstanding_notional=outstanding_notional,
+            strategy_params=p,
+        )
     if quote_plan.status != "quoted":
         return {
             "market_id": market_id,
@@ -2121,6 +2403,13 @@ def quote_market(
         "bid_price": quote_plan.bid_price,
         "ask_price": quote_plan.ask_price,
         "inventory_notional_usd": quote_plan.inventory_notional_usd,
+        "sell_only": sell_only or force_unwind,
+        "force_unwind": force_unwind,
+        "policy_action": (
+            _safe_str(market.get("force_unwind_reason"), "")
+            if force_unwind
+            else _safe_str(market.get("sell_only_reason"), "")
+        ),
     }
 
 
@@ -2159,6 +2448,9 @@ def run_once(
             live_markets = load_live_single_markets(
                 markets_max=params.markets_max,
                 min_seconds_to_resolution=params.min_seconds_to_resolution,
+                min_mid_price=params.min_mid_price,
+                max_mid_price=params.max_mid_price,
+                min_daily_volume_usd=params.min_daily_volume_usd,
                 volatility_window_points=backtest_params.volatility_window_points,
                 min_history_points=max(24, backtest_params.volatility_window_points * 4),
                 min_liquidity_usd=backtest_params.min_liquidity_usd,
@@ -2185,8 +2477,14 @@ def run_once(
     inventory_notional_by_market = {
         str(k): _safe_float(v, 0.0) for k, v in inventory.items()
     }
+    prior_inventory_cycles = (
+        config.get("state", {}).get("inventory_cycles", {})
+        if isinstance(config.get("state", {}), dict)
+        else {}
+    )
     live_trader: DirectClobTrader | None = None
     stale_cleanup: dict[str, Any] | None = None
+    raw_positions: Any = []
     if live_mode:
         try:
             live_trader = DirectClobTrader(
@@ -2217,6 +2515,17 @@ def run_once(
             inventory_notional_by_market = single_market_inventory_notional(
                 raw_positions=raw_positions,
                 markets=markets,
+            )
+            inventory_cycles_state = _build_inventory_cycle_state(
+                prior_state=prior_inventory_cycles,
+                raw_positions=raw_positions,
+                markets=markets,
+            )
+            markets = _apply_held_inventory_policy(
+                markets=markets,
+                raw_positions=raw_positions,
+                inventory_cycles=inventory_cycles_state,
+                params=params,
             )
         except Exception as exc:
             return {
@@ -2249,7 +2558,8 @@ def run_once(
             p=params,
         )
         if proposal.get("status") == "quoted":
-            outstanding_notional += float(proposal["quote_notional_usd"])
+            if not proposal.get("sell_only", False):
+                outstanding_notional += float(proposal["quote_notional_usd"])
             proposals.append(proposal)
             selected += 1
         else:
@@ -2303,8 +2613,21 @@ def run_once(
             "inventory": live_execution.get("updated_inventory", {}),
             "live_risk": live_execution.get("live_risk", {}),
         }
+        latest_positions = live_execution.get("positions", raw_positions)
+        payload["state"]["inventory_cycles"] = _build_inventory_cycle_state(
+            prior_state=prior_inventory_cycles,
+            raw_positions=latest_positions,
+            markets=markets,
+        )
         payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
         payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
+        payload["strategy_summary"]["forced_unwinds"] = len(
+            [
+                order
+                for order in live_execution.get("orders_submitted", [])
+                if isinstance(order, dict) and order.get("source") == "forced_inventory_unwind"
+            ]
+        )
         if isinstance(live_execution.get("live_risk"), dict):
             payload["strategy_summary"]["current_equity_usd"] = _safe_float(
                 live_execution["live_risk"].get("current_equity_usd"),

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -101,6 +101,10 @@ def clamp(value: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, value))
 
 
+def mid_price_in_band(mid_price: float, min_mid_price: float, max_mid_price: float) -> bool:
+    return min_mid_price <= mid_price <= max_mid_price
+
+
 def parse_iso_ts(value: Any) -> int | None:
     raw = safe_str(value, "")
     if not raw:
@@ -1392,6 +1396,9 @@ def load_live_single_markets(
     *,
     markets_max: int,
     min_seconds_to_resolution: int,
+    min_mid_price: float,
+    max_mid_price: float,
+    min_daily_volume_usd: float,
     volatility_window_points: int,
     min_history_points: int,
     min_liquidity_usd: float,
@@ -1431,6 +1438,9 @@ def load_live_single_markets(
             ttl = max(0, end_ts - now_ts)
             if ttl < min_seconds_to_resolution:
                 continue
+            volume24hr = safe_float(raw_market.get("volume24hr"), 0.0)
+            if volume24hr < min_daily_volume_usd:
+                continue
 
             history = fetch_history(
                 token_id=token_id,
@@ -1447,6 +1457,8 @@ def load_live_single_markets(
             best_bid = safe_float(book.get("best_bid"), 0.0)
             best_ask = safe_float(book.get("best_ask"), 0.0)
             if not (0.0 <= best_bid <= 1.0 and 0.0 <= best_ask <= 1.0 and best_bid <= best_ask):
+                continue
+            if not mid_price_in_band(midpoint, min_mid_price, max_mid_price):
                 continue
 
             volatility_bps = history_volatility_bps(history, volatility_window_points)
@@ -1474,6 +1486,7 @@ def load_live_single_markets(
                     "news_shock_score": round(shock_score, 4),
                     "breaking_news": False,
                     "liquidity": round(liquidity, 4),
+                    "volume24hr": round(volume24hr, 4),
                 }
             )
             if len(selected) >= markets_max:
@@ -2437,6 +2450,65 @@ def execute_single_market_quotes(
             bid_price = snap_price(safe_float(quote.get("bid_price"), 0.0), tick_size, "BUY")
             ask_price = snap_price(safe_float(quote.get("ask_price"), 0.0), tick_size, "SELL")
             sell_only = bool(market.get("sell_only", False)) or bool(quote.get("sell_only", False))
+            force_unwind = bool(market.get("force_unwind", False)) or bool(quote.get("force_unwind", False))
+
+            if force_unwind:
+                available_shares = max(0.0, position_sizes.get(token_id, 0.0))
+                if available_shares <= 0.0:
+                    skips.append(
+                        {
+                            "market_id": market["market_id"],
+                            "reason": "no_inventory_to_force_unwind",
+                            "available_shares": 0.0,
+                        }
+                    )
+                    continue
+                try:
+                    sell_plan = build_marketable_sell_order(token_id, available_shares)
+                    response = _invoke_trader_call(
+                        f"force_unwind_sell:{market['market_id']}",
+                        lambda: trader.create_order(
+                            token_id=token_id,
+                            side="SELL",
+                            price=sell_plan["price"],
+                            size=available_shares,
+                            tick_size=sell_plan["tick_size"],
+                            neg_risk=sell_plan["neg_risk"],
+                            fee_rate_bps=sell_plan["fee_rate_bps"],
+                        ),
+                        execution_settings,
+                    )
+                    placements.append(
+                        {
+                            "market_id": market["market_id"],
+                            "token_id": token_id,
+                            "side": "SELL",
+                            "price": sell_plan["price"],
+                            "size": round(available_shares, 6),
+                            "best_bid": sell_plan["best_bid"],
+                            "best_ask": sell_plan["best_ask"],
+                            "estimated_exit_value_usd": sell_plan["estimated_exit_value_usd"],
+                            "estimated_fill_size": sell_plan["estimated_fill_size"],
+                            "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                            "estimated_average_price": sell_plan["estimated_average_price"],
+                            "execution_style": sell_plan["execution_style"],
+                            "response": response,
+                            "source": "forced_inventory_unwind",
+                            "reason": safe_str(
+                                quote.get("policy_action"),
+                                safe_str(market.get("force_unwind_reason"), "force_unwind"),
+                            ),
+                        }
+                    )
+                except Exception as order_exc:
+                    skips.append(
+                        {
+                            "market_id": market["market_id"],
+                            "reason": "force_unwind_failed",
+                            "error": str(order_exc),
+                        }
+                    )
+                continue
 
             if bid_price > 0.0 and bid_notional > 0.0 and not sell_only:
                 remaining_cash_usd = available_cash_usd - bid_notional

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -92,6 +92,7 @@ def _base_backtest_payload(now_ts: int, telemetry_path: Path) -> dict:
                 "question": "Synthetic stateful market",
                 "token_id": "TEST-STATEFUL",
                 "rebate_bps": 3,
+                "volume24hr": 25000,
                 "end_ts": now_ts + (14 * 24 * 3600),
                 "history": history,
                 "orderbooks": orderbooks,
@@ -148,6 +149,30 @@ def test_quote_mode_fetches_live_markets_when_config_markets_is_empty(monkeypatc
         fetched_urls.append(url)
         return [
             {
+                "id": "LIVE-MKT-0",
+                "question": "Will event zero happen?",
+                "clobTokenIds": ["TOKEN-0"],
+                "outcomePrices": ["0.12", "0.88"],
+                "bestBid": 0.11,
+                "bestAsk": 0.13,
+                "liquidity": 550000,
+                "volume24hr": 100000,
+                "rebate_bps": 2.5,
+                "endDate": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now_ts + 86400)),
+            },
+            {
+                "id": "LIVE-MKT-LOW",
+                "question": "Will thin event happen?",
+                "clobTokenIds": ["TOKEN-LOW"],
+                "outcomePrices": ["0.51", "0.49"],
+                "bestBid": 0.5,
+                "bestAsk": 0.52,
+                "liquidity": 500000,
+                "volume24hr": 1200,
+                "rebate_bps": 2.5,
+                "endDate": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now_ts + 86400)),
+            },
+            {
                 "id": "LIVE-MKT-1",
                 "question": "Will event A happen?",
                 "clobTokenIds": ["TOKEN-1"],
@@ -180,6 +205,9 @@ def test_quote_mode_fetches_live_markets_when_config_markets_is_empty(monkeypatc
         "strategy": {
             "markets_max": 2,
             "min_seconds_to_resolution": 60,
+            "min_mid_price": 0.30,
+            "max_mid_price": 0.70,
+            "min_daily_volume_usd": 5000,
             "min_spread_bps": 20,
         },
         "markets": [],
@@ -325,7 +353,13 @@ def test_config_example_uses_seren_polymarket_publisher_urls() -> None:
     agent = _load_agent_module()
     payload = json.loads(CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
     backtest = payload.get("backtest", {})
+    strategy = payload.get("strategy", {})
+    defaults = agent.to_params({})
     assert agent.to_backtest_params({}).bankroll_usd == backtest.get("bankroll_usd") == 100
+    assert defaults.min_mid_price == strategy.get("min_mid_price") == 0.30
+    assert defaults.max_mid_price == strategy.get("max_mid_price") == 0.70
+    assert defaults.min_daily_volume_usd == strategy.get("min_daily_volume_usd") == 5000
+    assert defaults.max_inventory_hold_cycles == strategy.get("max_inventory_hold_cycles") == 3
     assert agent.to_optimization_params({}).max_iterations == backtest["optimization"]["max_iterations"] == 15
     assert backtest.get("gamma_markets_url", "").startswith(
         "https://api.serendb.com/publishers/polymarket-data/"
@@ -433,6 +467,7 @@ def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> No
                 "seconds_to_resolution": 86400,
                 "volatility_bps": 50,
                 "rebate_bps": 2.5,
+                "volume24hr": 12000,
                 "tick_size": "0.01",
                 "neg_risk": False,
             }
@@ -448,10 +483,11 @@ def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> No
             }
         )
         return {
-            "orders_submitted": [{"id": "ORDER-1"}, {"id": "ORDER-2"}],
+            "orders_submitted": [{"id": "ORDER-1", "source": "forced_inventory_unwind"}],
             "open_order_ids": ["ORDER-1"],
             "updated_inventory": {"LIVE-MKT-1": 12.5},
             "live_risk": {"peak_equity_usd": 1000.0, "current_equity_usd": 980.0, "drawdown_pct": 2.0},
+            "positions": [{"asset_id": "TOKEN-LIVE-1", "size": 4.0}],
         }
 
     monkeypatch.setattr(agent, "DirectClobTrader", FakeTrader)
@@ -476,6 +512,10 @@ def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> No
                 "bankroll_usd": 1000,
                 "markets_max": 1,
                 "min_seconds_to_resolution": 60,
+                "min_mid_price": 0.30,
+                "max_mid_price": 0.70,
+                "min_daily_volume_usd": 5000,
+                "max_inventory_hold_cycles": 3,
                 "min_edge_bps": 2,
                 "default_rebate_bps": 3,
                 "expected_unwind_cost_bps": 1.5,
@@ -489,7 +529,10 @@ def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> No
                 "max_position_notional_usd": 150,
                 "inventory_skew_strength_bps": 25,
             },
-            "state": {"inventory": {"CONFIG-MKT": 1.0}},
+            "state": {
+                "inventory": {"CONFIG-MKT": 1.0},
+                "inventory_cycles": {"TOKEN-LIVE-1": {"cycles_held": 2}},
+            },
         },
         markets=[
             {
@@ -507,17 +550,25 @@ def test_live_quote_mode_uses_live_market_loader_and_executor(monkeypatch) -> No
     assert result["status"] == "ok"
     assert result["mode"] == "live"
     assert result["market_source"] == "live-seren-publisher"
-    assert result["state"] == {
-        "inventory": {"LIVE-MKT-1": 12.5},
-        "live_risk": {"peak_equity_usd": 1000.0, "current_equity_usd": 980.0, "drawdown_pct": 2.0},
+    assert result["state"]["inventory"] == {"LIVE-MKT-1": 12.5}
+    assert result["state"]["live_risk"] == {
+        "peak_equity_usd": 1000.0,
+        "current_equity_usd": 980.0,
+        "drawdown_pct": 2.0,
     }
-    assert result["strategy_summary"]["orders_submitted"] == 2
+    assert result["state"]["inventory_cycles"]["TOKEN-LIVE-1"]["cycles_held"] == 3
+    assert result["strategy_summary"]["orders_submitted"] == 1
     assert result["strategy_summary"]["open_orders"] == 1
+    assert result["strategy_summary"]["forced_unwinds"] == 1
     assert result["strategy_summary"]["current_equity_usd"] == 980.0
     assert result["strategy_summary"]["drawdown_pct"] == 2.0
     assert load_calls and load_calls[0]["markets_max"] == 1
+    assert load_calls[0]["min_mid_price"] == 0.30
+    assert load_calls[0]["max_mid_price"] == 0.70
+    assert load_calls[0]["min_daily_volume_usd"] == 5000
     assert execute_calls and execute_calls[0]["client_name"] == "polymarket-maker-rebate-bot"
     assert execute_calls[0]["quotes"][0]["market_id"] == "LIVE-MKT-1"
+    assert execute_calls[0]["quotes"][0]["force_unwind"] is True
 
 
 def test_persist_runtime_state_updates_config_file(tmp_path: Path) -> None:
@@ -620,6 +671,83 @@ def test_cancel_stale_orders_detects_old_orders() -> None:
     assert result["stale_count"] == 1
     assert "old-order-1" in trader.cancelled
     assert "fresh-order-1" not in trader.cancelled
+
+
+def test_backtest_force_unwinds_after_hold_limit_and_never_shorts_inventory() -> None:
+    agent = _load_agent_module()
+    now_ts = int(time.time())
+    history = []
+    orderbooks = {}
+    for idx, price in enumerate([0.55, 0.54, 0.53, 0.52, 0.51, 0.50, 0.49, 0.48]):
+        ts = now_ts - ((8 - idx) * 3600)
+        history.append((ts, price))
+        orderbooks[ts] = agent.OrderBookSnapshot(
+            t=ts,
+            best_bid=round(price - 0.001, 6),
+            best_ask=round(price + 0.001, 6),
+            bid_size_usd=500.0,
+            ask_size_usd=500.0,
+        )
+
+    strategy = agent.StrategyParams(
+        bankroll_usd=100.0,
+        markets_max=1,
+        min_seconds_to_resolution=60,
+        min_mid_price=0.30,
+        max_mid_price=0.70,
+        min_daily_volume_usd=5000.0,
+        max_inventory_hold_cycles=1,
+        min_edge_bps=0.0,
+        default_rebate_bps=3.0,
+        expected_unwind_cost_bps=1.5,
+        adverse_selection_bps=1.0,
+        min_spread_bps=20.0,
+        max_spread_bps=20.0,
+        volatility_spread_multiplier=0.0,
+        base_order_notional_usd=40.0,
+        max_notional_per_market_usd=120.0,
+        max_total_notional_usd=120.0,
+        max_position_notional_usd=120.0,
+        inventory_skew_strength_bps=25.0,
+    )
+    backtest = agent.BacktestParams(
+        bankroll_usd=100.0,
+        days=90,
+        fidelity_minutes=60,
+        participation_rate=1.0,
+        volatility_window_points=3,
+        min_liquidity_usd=0.0,
+        markets_fetch_limit=5,
+        min_history_points=4,
+        require_orderbook_history=False,
+        spread_decay_bps=10000.0,
+        join_best_queue_factor=1.0,
+        off_best_queue_factor=1.0,
+        synthetic_orderbook_half_spread_bps=18.0,
+        synthetic_orderbook_depth_usd=500.0,
+    )
+    result = agent._simulate_market_backtest(
+        {
+            "market_id": "TEST-HOLD-LIMIT",
+            "question": "Synthetic unwind market",
+            "volume24hr": 10000.0,
+            "rebate_bps": 3.0,
+            "end_ts": now_ts + (20 * 24 * 3600),
+            "history": history,
+            "orderbooks": orderbooks,
+            "orderbook_mode": "historical",
+        },
+        strategy,
+        backtest,
+        allocated_capital=100.0,
+    )
+
+    assert any(record.get("status") == "forced_unwind" for record in result["telemetry"])
+    assert all(
+        record.get("inventory_notional_after_usd", 0.0) >= -1e-9
+        for record in result["telemetry"]
+        if "inventory_notional_after_usd" in record
+    )
 
 
 def test_unwind_all_requires_yes_live() -> None:


### PR DESCRIPTION
Closes #196

## Summary
- add hard live/backtest market filters for midpoint band, 24h volume, and time to resolution
- persist held-inventory cycle state and switch policy-breaching inventory to sell-only or forced unwind
- send aged or out-of-band held inventory through a marketable forced-unwind path in live execution
- align replay with live inventory constraints so the backtest cannot sell inventory it does not hold
- update config defaults, skill docs, and smoke tests for the new safety behavior

## Critical Improvements Beyond The Original Ticket
- enforce filter parity across both live selectors and replay, not just one entry path
- fix the replay/live mismatch on ask-side inventory so adverse-selection backtests stop overstating safety

## Testing
- `pytest polymarket/maker-rebate-bot/tests/test_smoke.py`
