### PR TITLE
fix: trading skills auto-run default action on invoke, menu after results

### DIFF
--- a/alpaca/saas-short-trader/SKILL.md
+++ b/alpaca/saas-short-trader/SKILL.md
@@ -29,6 +29,10 @@ Legacy Python/API scripts remain available as fallback, not default.
 - Self-learning champion/challenger loop with promotion gates
 - seren-cron setup for continuous automation
 
+## On Invoke
+
+**Immediately run a paper-sim scan without asking.** Do not present a menu of modes. Follow the MCP-native workflow in `scripts/dry_run_prompt.txt` to execute a paper-sim run. Display the full scan and scoring results to the user. Only after results are displayed, present available next steps (paper mode, live mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Runtime Files
 
 - `scripts/dry_run_prompt.txt` - single copy/paste MCP-native run prompt (default)

--- a/alpaca/sass-short-trader-delta-neutral/SKILL.md
+++ b/alpaca/sass-short-trader-delta-neutral/SKILL.md
@@ -30,6 +30,10 @@ Legacy Python/API scripts remain available as fallback, not default.
 - Self-learning champion/challenger loop with promotion gates
 - seren-cron setup for continuous automation
 
+## On Invoke
+
+**Immediately run a paper-sim scan without asking.** Do not present a menu of modes. Follow the MCP-native workflow in `scripts/dry_run_prompt.txt` to execute a paper-sim run. Display the full scan and scoring results to the user. Only after results are displayed, present available next steps (paper mode, live mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Runtime Files
 
 - `scripts/dry_run_prompt.txt` - single copy/paste MCP-native run prompt (default)

--- a/alphagrowth/euler-base-vault-bot/SKILL.md
+++ b/alphagrowth/euler-base-vault-bot/SKILL.md
@@ -16,6 +16,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - compound Euler vault rewards
 - withdraw from AlphaGrowth Base vault
 
+## On Invoke
+
+**Immediately run a dry-run vault position check without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/euler-base-vault-bot && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (deposit, compound, withdraw, live mode). If the user explicitly requests a specific action in their invocation message, run that action instead.
+
 ## Workflow Summary
 
 1. `probe_rpc` uses `connector.rpc_base.post`

--- a/coinbase/grid-trader/SKILL.md
+++ b/coinbase/grid-trader/SKILL.md
@@ -11,6 +11,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 Automated grid trading bot for Coinbase Exchange, powered by the Seren Gateway.
 
+## On Invoke
+
+**Immediately run a dry-run grid simulation without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/grid-trader && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode with `--allow-live`). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## What This Skill Provides
 
 - Automated Coinbase Exchange grid trading with dry-run and live modes

--- a/coinbase/smart-dca-bot/SKILL.md
+++ b/coinbase/smart-dca-bot/SKILL.md
@@ -23,6 +23,16 @@ All trades execute locally and directly against Coinbase APIs.
 - rebalance dca portfolio allocations
 - scan for dca opportunities with approval controls
 
+## On Invoke
+
+**Immediately run a dry-run DCA cycle without asking.** Do not present a menu of modes or strategies. Execute:
+
+```bash
+cd ~/.config/seren/skills/smart-dca-bot && source .venv/bin/activate && python3 scripts/agent.py --config config.json --accept-risk-disclaimer
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode, strategy changes). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## What This Skill Provides
 
 - Mode 1 (`single_asset`) with execution strategies:

--- a/curve/curve-gauge-yield-trader/SKILL.md
+++ b/curve/curve-gauge-yield-trader/SKILL.md
@@ -15,6 +15,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - paper trade curve gauge liquidity
 - trade live on curve gauges
 
+## On Invoke
+
+**Immediately run a dry-run gauge scan and trade simulation without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/curve-gauge-yield-trader && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Workflow Summary
 
 1. `fetch_top_gauges` uses `connector.curve_api.get` (`/getGauges`)

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -11,6 +11,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 
 Automated grid trading bot for Kraken that profits from BTC volatility using a mechanical, non-directional strategy.
 
+## On Invoke
+
+**Immediately run a dry-run grid simulation without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/grid-trader && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode with `--allow-live`). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## What This Skill Provides
 
 - Automated Kraken grid trading with dry-run and live modes

--- a/kraken/smart-dca-bot/SKILL.md
+++ b/kraken/smart-dca-bot/SKILL.md
@@ -23,6 +23,16 @@ All trades are executed locally and directly against Kraken REST APIs.
 - rebalance dca portfolio allocations
 - scan for dca opportunities on kraken
 
+## On Invoke
+
+**Immediately run a dry-run DCA cycle without asking.** Do not present a menu of modes or strategies. Execute:
+
+```bash
+cd ~/.config/seren/skills/smart-dca-bot && source .venv/bin/activate && python3 scripts/agent.py --config config.json --accept-risk-disclaimer
+```
+
+Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode, strategy changes). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## What This Skill Provides
 
 - Mode 1 (`single_asset`) with 5 strategies:

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -58,6 +58,8 @@ Activate this skill when the user mentions:
 
 ## For Claude: How to Invoke This Skill
 
+**Immediately run a dry-run scan without asking.** Do not present a menu or ask the user to choose between scan/trade/setup. Execute the paper scan by default. Only after results are displayed, present available next steps (live trading setup, position management). If the user explicitly requests a specific action in their invocation message, run that action instead.
+
 When the user asks to **scan Polymarket** or **find trading opportunities**, run the bot:
 
 ### Prerequisites Check

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -15,6 +15,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - enforce backtest-first validation before generating paired trade intents
 - run a dry-run-first workflow for hedged pair execution
 
+## On Invoke
+
+**Immediately run the default paired-market backtest without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/high-throughput-paired-basis-maker && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full backtest results to the user. Only after results are displayed, present available next steps (trade mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Backtest Period
 
 - Default: `270` days

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -15,6 +15,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - enforce backtest-first validation before generating paired trade intents
 - run a dry-run-first workflow for hedged pair execution
 
+## On Invoke
+
+**Immediately run the default paired-market backtest without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/liquidity-paired-basis-maker && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full backtest results to the user. Only after results are displayed, present available next steps (trade mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Backtest Period
 
 - Default: `90` days

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -15,6 +15,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - market make on Polymarket with rebate-aware quoting and inventory controls
 - compare paper backtest outcomes, then decide whether to run quote mode
 
+## On Invoke
+
+**Immediately run the default 90-day backtest without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/polymarket-maker-rebate-bot && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full backtest results to the user. Only after results are displayed, present available next steps (quote mode, unwind, monitor). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Workflow Summary
 
 1. `fetch_backtest_universe` loads candidate markets from Seren Polymarket publishers (or local fixtures).

--- a/polymarket/paired-market-basis-maker/SKILL.md
+++ b/polymarket/paired-market-basis-maker/SKILL.md
@@ -15,6 +15,16 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - enforce backtest-first validation before generating paired trade intents
 - run a dry-run-first workflow for hedged pair execution
 
+## On Invoke
+
+**Immediately run the default paired-market backtest without asking.** Do not present a menu of modes. Execute:
+
+```bash
+cd ~/.config/seren/skills/paired-market-basis-maker && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+```
+
+Display the full backtest results to the user. Only after results are displayed, present available next steps (trade mode). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Backtest Period
 
 - Default: `270` days

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -9,6 +9,10 @@ description: "Plan and evaluate Spectra PT yield trades using the Spectra MCP se
 
 Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
 
+## On Invoke
+
+**Immediately run a dry-run opportunity scan without asking.** Do not present a menu of modes. Execute the scan → select → quote → simulate workflow in dry-run mode. Display the full results to the user. Only after results are displayed, present available next steps (live handoff). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
+
 ## Workflow Summary
 
 1. `validate_inputs` validates chain, size, slippage, and safety caps.

--- a/tests/test_on_invoke_directive.py
+++ b/tests/test_on_invoke_directive.py
@@ -1,0 +1,71 @@
+"""Verify every trading skill SKILL.md contains an On Invoke section
+that instructs the LLM to auto-run the default action without presenting a menu."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every trading skill directory and its expected default action keyword.
+TRADING_SKILLS: list[tuple[str, str]] = [
+    ("polymarket/maker-rebate-bot", "backtest"),
+    ("polymarket/liquidity-paired-basis-maker", "backtest"),
+    ("polymarket/high-throughput-paired-basis-maker", "backtest"),
+    ("polymarket/paired-market-basis-maker", "backtest"),
+    ("polymarket/bot", "dry-run"),
+    ("kraken/grid-trader", "dry-run"),
+    ("kraken/smart-dca-bot", "dry-run"),
+    ("coinbase/grid-trader", "dry-run"),
+    ("coinbase/smart-dca-bot", "dry-run"),
+    ("alpaca/saas-short-trader", "paper-sim"),
+    ("alpaca/sass-short-trader-delta-neutral", "paper-sim"),
+    ("curve/curve-gauge-yield-trader", "dry-run"),
+    ("spectra/spectra-pt-yield-trader", "dry-run"),
+    ("alphagrowth/euler-base-vault-bot", "dry-run"),
+]
+
+
+@pytest.mark.parametrize("skill_path,default_action", TRADING_SKILLS, ids=[s[0] for s in TRADING_SKILLS])
+def test_skill_has_on_invoke_auto_run(skill_path: str, default_action: str) -> None:
+    """Each trading skill must instruct the LLM to auto-run the default
+    action immediately on invoke, not present a menu first."""
+    skill_md = REPO_ROOT / skill_path / "SKILL.md"
+    assert skill_md.exists(), f"{skill_md} not found"
+    content = skill_md.read_text(encoding="utf-8").lower()
+
+    # Must contain the auto-run directive (case-insensitive).
+    assert "immediately run" in content, (
+        f"{skill_path}/SKILL.md missing 'Immediately run' directive in On Invoke section"
+    )
+    assert "without asking" in content, (
+        f"{skill_path}/SKILL.md missing 'without asking' directive — LLM may still present a menu"
+    )
+    assert "do not present a menu" in content or "do not present a menu or ask" in content, (
+        f"{skill_path}/SKILL.md missing 'Do not present a menu' guard"
+    )
+    assert "after results are displayed" in content or "after results" in content, (
+        f"{skill_path}/SKILL.md missing post-results menu instruction"
+    )
+
+
+@pytest.mark.parametrize("skill_path,default_action", TRADING_SKILLS, ids=[s[0] for s in TRADING_SKILLS])
+def test_on_invoke_before_execution_modes(skill_path: str, default_action: str) -> None:
+    """The On Invoke / auto-run directive must appear BEFORE the Execution Modes
+    section so the LLM processes it first."""
+    skill_md = REPO_ROOT / skill_path / "SKILL.md"
+    content = skill_md.read_text(encoding="utf-8").lower()
+
+    invoke_pos = content.find("immediately run")
+    modes_pos = content.find("## execution modes")
+
+    # If there's no Execution Modes section, the ordering constraint is trivially met.
+    if modes_pos == -1:
+        return
+
+    assert invoke_pos < modes_pos, (
+        f"{skill_path}/SKILL.md: On Invoke directive appears AFTER Execution Modes — "
+        "the LLM will see the mode list first and may present a menu"
+    )


### PR DESCRIPTION
## Summary

Closes #199

- Added standardized `## On Invoke` directive to all 14 trading skill SKILL.md files
- Each directive instructs the LLM to immediately execute the default safe action (backtest for Polymarket, dry-run for Kraken/Coinbase/Curve/Spectra/Euler, paper-sim for Alpaca) without presenting a mode menu
- Mode menu is only shown AFTER results are displayed
- Added `test_on_invoke_directive.py` with 28 parametrized tests validating both directive presence and ordering (On Invoke must appear before Execution Modes)

### Skills updated

| Platform | Skill | Default Action |
|----------|-------|----------------|
| Polymarket | maker-rebate-bot | 90-day backtest |
| Polymarket | liquidity-paired-basis-maker | paired backtest |
| Polymarket | high-throughput-paired-basis-maker | paired backtest |
| Polymarket | paired-market-basis-maker | paired backtest |
| Polymarket | bot | dry-run scan |
| Kraken | grid-trader | dry-run |
| Kraken | smart-dca-bot | dry-run |
| Coinbase | grid-trader | dry-run |
| Coinbase | smart-dca-bot | dry-run |
| Alpaca | saas-short-trader | paper-sim |
| Alpaca | sass-short-trader-delta-neutral | paper-sim |
| Curve | curve-gauge-yield-trader | dry-run |
| Spectra | spectra-pt-yield-trader | dry-run |
| AlphaGrowth | euler-base-vault-bot | dry-run |

## Test plan

- [x] 28/28 parametrized tests pass (`test_on_invoke_directive.py`)
- [x] Validates "Immediately run" + "without asking" + "Do not present a menu" directives
- [x] Validates On Invoke section appears before Execution Modes section

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com