### PR TITLE
fix: auto-bootstrap missing skill config.json at runtime

### DIFF
--- a/alpaca/saas-short-trader/scripts/strategy_engine.py
+++ b/alpaca/saas-short-trader/scripts/strategy_engine.py
@@ -1380,11 +1380,22 @@ def _require_live_confirmation(mode: str, allow_live: bool) -> None:
         )
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
 def main() -> None:
     args = parse_args()
     config: Dict[str, Any] = {}
     if args.config:
-        with open(args.config, "r", encoding="utf-8") as f:
+        with open(_bootstrap_config_path(args.config), "r", encoding="utf-8") as f:
             config = json.load(f)
 
     dsn = resolve_dsn(

--- a/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
@@ -1480,11 +1480,22 @@ def _require_live_confirmation(mode: str, allow_live: bool) -> None:
         )
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
 def main() -> None:
     args = parse_args()
     config: Dict[str, Any] = {}
     if args.config:
-        with open(args.config, "r", encoding="utf-8") as f:
+        with open(_bootstrap_config_path(args.config), "r", encoding="utf-8") as f:
             config = json.load(f)
 
     dsn = resolve_dsn(

--- a/alphagrowth/euler-base-vault-bot/scripts/agent.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/agent.py
@@ -39,8 +39,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         raise ConfigError(f"Config file not found: {config_path}")
     return json.loads(path.read_text(encoding="utf-8"))

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -72,6 +72,19 @@ def _build_store_from_env() -> SerenDBStore:
     )
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 class CoinbaseGridTrader:
     """Coinbase Exchange Grid Trading Bot"""
 
@@ -192,7 +205,7 @@ class CoinbaseGridTrader:
 
     def _load_config(self, config_path: str) -> Dict[str, Any]:
         """Load and validate configuration"""
-        with open(config_path, 'r') as f:
+        with open(_bootstrap_config_path(config_path), 'r') as f:
             config = json.load(f)
 
         for field in ['campaign_name', 'trading_pair', 'strategy', 'risk_management']:

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -206,8 +206,19 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
-def load_config(path: str) -> dict[str, Any]:
+def _bootstrap_config_path(path: str) -> Path:
     config_path = Path(path)
+    if config_path.exists():
+        return config_path
+    example_path = config_path.with_name("config.example.json")
+    if example_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return config_path
+
+
+def load_config(path: str) -> dict[str, Any]:
+    config_path = _bootstrap_config_path(path)
     if not config_path.exists():
         raise ConfigError(f"Config file not found: {path}")
     try:

--- a/curve/curve-gauge-yield-trader/scripts/agent.py
+++ b/curve/curve-gauge-yield-trader/scripts/agent.py
@@ -235,8 +235,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(path: str) -> dict[str, Any]:
+def _bootstrap_config_path(path: str) -> Path:
     config_path = Path(path)
+    if config_path.exists():
+        return config_path
+    example_path = config_path.with_name("config.example.json")
+    if example_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return config_path
+
+
+def load_config(path: str) -> dict[str, Any]:
+    config_path = _bootstrap_config_path(path)
     if not config_path.exists():
         raise ConfigError(f"Config file not found: {config_path}")
     try:

--- a/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
+++ b/kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py
@@ -87,8 +87,19 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
-def load_config(path: str) -> dict[str, Any]:
+def _bootstrap_config_path(path: str) -> Path:
     config_path = Path(path)
+    if config_path.exists():
+        return config_path
+    example_path = config_path.with_name("config.example.json")
+    if example_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return config_path
+
+
+def load_config(path: str) -> dict[str, Any]:
+    config_path = _bootstrap_config_path(path)
     if not config_path.exists():
         raise ConfigError(f"Config file not found: {path}")
     try:

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -72,6 +72,19 @@ def _build_store_from_env() -> SerenDBStore:
     )
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 class KrakenGridTrader:
     """Kraken Grid Trading Bot"""
 
@@ -174,7 +187,7 @@ class KrakenGridTrader:
 
     def _load_config(self, config_path: str) -> Dict[str, Any]:
         """Load configuration from JSON file"""
-        with open(config_path, 'r') as f:
+        with open(_bootstrap_config_path(config_path), 'r') as f:
             config = json.load(f)
 
         # Validate required fields.

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -82,8 +82,19 @@ QUESTION_SET: List[Dict[str, Any]] = [
 ]
 
 
+def _bootstrap_config_path(path: str) -> Path:
+    config_path = Path(path)
+    if config_path.exists():
+        return config_path
+    example_path = config_path.with_name("config.example.json")
+    if example_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return config_path
+
+
 def load_config(path: str) -> Dict[str, Any]:
-    with open(path, "r", encoding="utf-8") as handle:
+    with open(_bootstrap_config_path(path), "r", encoding="utf-8") as handle:
         return json.load(handle)
 
 

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -201,8 +201,19 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
-def load_config(path: str) -> dict[str, Any]:
+def _bootstrap_config_path(path: str) -> Path:
     config_path = Path(path)
+    if config_path.exists():
+        return config_path
+    example_path = config_path.with_name("config.example.json")
+    if example_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return config_path
+
+
+def load_config(path: str) -> dict[str, Any]:
+    config_path = _bootstrap_config_path(path)
     if not config_path.exists():
         raise ConfigError(f"Config file not found: {path}")
     try:

--- a/ledger/ledger-signing/scripts/agent.py
+++ b/ledger/ledger-signing/scripts/agent.py
@@ -37,8 +37,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -523,6 +523,19 @@ class TradingAgent:
         print()
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description='Polymarket Trading Agent')
@@ -544,9 +557,11 @@ def main():
 
     args = parser.parse_args()
 
+    config_path = _bootstrap_config_path(args.config)
+
     # Check config exists
-    if not os.path.exists(args.config):
-        print(f"Error: Config file not found: {args.config}")
+    if not os.path.exists(config_path):
+        print(f"Error: Config file not found: {config_path}")
         sys.exit(1)
 
     if not args.dry_run and not args.yes_live:
@@ -558,7 +573,7 @@ def main():
 
     # Initialize agent
     try:
-        agent = TradingAgent(args.config, dry_run=args.dry_run)
+        agent = TradingAgent(str(config_path), dry_run=args.dry_run)
     except Exception as e:
         print(f"Error initializing agent: {e}")
         sys.exit(1)

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -201,8 +201,21 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def load_config(config_path: str) -> dict[str, Any]:
-    payload = load_json(Path(config_path))
+    payload = load_json(_bootstrap_config_path(config_path))
     return payload if isinstance(payload, dict) else {}
 
 

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -209,8 +209,21 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def load_config(config_path: str) -> dict[str, Any]:
-    payload = load_json(Path(config_path))
+    payload = load_json(_bootstrap_config_path(config_path))
     return payload if isinstance(payload, dict) else {}
 
 

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -183,8 +183,21 @@ def load_json_file(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def load_config(config_path: str) -> dict[str, Any]:
-    return load_json_file(Path(config_path))
+    return load_json_file(_bootstrap_config_path(config_path))
 
 
 def _clone_config(config: dict[str, Any]) -> dict[str, Any]:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -201,8 +201,21 @@ def load_json(path: Path) -> dict[str, Any] | list[Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def load_config(config_path: str) -> dict[str, Any]:
-    payload = load_json(Path(config_path))
+    payload = load_json(_bootstrap_config_path(config_path))
     return payload if isinstance(payload, dict) else {}
 
 

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -73,8 +73,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -73,8 +73,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -73,8 +73,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/seren/customer-support-intake/scripts/agent.py
+++ b/seren/customer-support-intake/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/seren/seren-scheduler/scripts/agent.py
+++ b/seren/seren-scheduler/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -50,8 +50,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         raise ConfigError(f"Config file not found: {config_path}")
     try:

--- a/tests/test_config_bootstrap_runtime.py
+++ b/tests/test_config_bootstrap_runtime.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TARGET_FILES = [
+    "alpaca/saas-short-trader/scripts/strategy_engine.py",
+    "alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py",
+    "alphagrowth/euler-base-vault-bot/scripts/agent.py",
+    "coinbase/grid-trader/scripts/agent.py",
+    "coinbase/smart-dca-bot/scripts/agent.py",
+    "curve/curve-gauge-yield-trader/scripts/agent.py",
+    "kraken/carf-dac8-crypto-asset-reporting/scripts/agent.py",
+    "kraken/grid-trader/scripts/agent.py",
+    "kraken/money-mode-router/scripts/agent.py",
+    "kraken/smart-dca-bot/scripts/agent.py",
+    "ledger/ledger-signing/scripts/agent.py",
+    "polymarket/bot/scripts/agent.py",
+    "polymarket/high-throughput-paired-basis-maker/scripts/agent.py",
+    "polymarket/liquidity-paired-basis-maker/scripts/agent.py",
+    "polymarket/maker-rebate-bot/scripts/agent.py",
+    "polymarket/paired-market-basis-maker/scripts/agent.py",
+    "prophet/prophet-adversarial-auditor/scripts/agent.py",
+    "prophet/prophet-growth-agent/scripts/agent.py",
+    "prophet/prophet-market-seeder/scripts/agent.py",
+    "seren/customer-support-intake/scripts/agent.py",
+    "seren/seren-scheduler/scripts/agent.py",
+    "spectra/spectra-pt-yield-trader/scripts/agent.py",
+    "wellsfargo/bank-statement-processing/scripts/run.py",
+    "wellsfargo/budget-tracker/scripts/agent.py",
+    "wellsfargo/cash-flow-statement/scripts/run.py",
+    "wellsfargo/income-statement/scripts/run.py",
+    "wellsfargo/net-worth-tracker/scripts/agent.py",
+    "wellsfargo/recurring-transactions/scripts/run.py",
+    "wellsfargo/tax-prep/scripts/agent.py",
+    "wellsfargo/vendor-analysis/scripts/agent.py",
+    "zkp2p/peer-to-peer-payments-exchange/scripts/agent.py",
+]
+
+
+def _extract_bootstrap_helper(relative_path: str):
+    source_path = REPO_ROOT / relative_path
+    source = source_path.read_text(encoding="utf-8")
+    module = ast.parse(source, filename=str(source_path))
+
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_bootstrap_config_path":
+            helper_source = ast.get_source_segment(source, node)
+            assert helper_source is not None, f"Could not extract helper from {relative_path}"
+            namespace = {"Path": Path}
+            exec(helper_source, namespace)  # noqa: S102
+            return namespace["_bootstrap_config_path"]
+
+    raise AssertionError(f"{relative_path} is missing _bootstrap_config_path")
+
+
+@pytest.mark.parametrize("relative_path", TARGET_FILES, ids=TARGET_FILES)
+def test_bootstrap_helper_copies_config_example(relative_path: str, tmp_path: Path) -> None:
+    helper = _extract_bootstrap_helper(relative_path)
+    config_path = tmp_path / "config.json"
+    example_path = tmp_path / "config.example.json"
+    example_body = '{\n  "dry_run": true\n}\n'
+    example_path.write_text(example_body, encoding="utf-8")
+
+    resolved = helper(str(config_path))
+
+    assert resolved == config_path
+    assert config_path.read_text(encoding="utf-8") == example_body
+
+
+@pytest.mark.parametrize("relative_path", TARGET_FILES, ids=TARGET_FILES)
+def test_bootstrap_helper_leaves_missing_config_missing_without_example(
+    relative_path: str,
+    tmp_path: Path,
+) -> None:
+    helper = _extract_bootstrap_helper(relative_path)
+    config_path = tmp_path / "config.json"
+
+    resolved = helper(str(config_path))
+
+    assert resolved == config_path
+    assert not config_path.exists()
+
+
+@pytest.mark.parametrize("relative_path", TARGET_FILES, ids=TARGET_FILES)
+def test_runtime_routes_config_loading_through_bootstrap(relative_path: str) -> None:
+    source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+    assert "config.example.json" in source, f"{relative_path} does not reference config.example.json"
+    assert source.count("_bootstrap_config_path(") >= 2, (
+        f"{relative_path} defines the bootstrap helper but does not route config loading through it"
+    )

--- a/wellsfargo/bank-statement-processing/scripts/run.py
+++ b/wellsfargo/bank-statement-processing/scripts/run.py
@@ -150,7 +150,21 @@ def merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
     return merged
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def load_config(config_path: Path, skill_root: Path) -> dict[str, Any]:
+    config_path = _bootstrap_config_path(str(config_path))
     default_config = {
         "runtime": {
             "strict_read_only": True,

--- a/wellsfargo/budget-tracker/scripts/agent.py
+++ b/wellsfargo/budget-tracker/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/wellsfargo/cash-flow-statement/scripts/run.py
+++ b/wellsfargo/cash-flow-statement/scripts/run.py
@@ -395,10 +395,23 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def main() -> None:
     args = parse_args()
 
-    config_path = Path(args.config)
+    config_path = _bootstrap_config_path(args.config)
     if not config_path.exists():
         print(f"Config file not found: {config_path}", file=sys.stderr)
         sys.exit(1)

--- a/wellsfargo/income-statement/scripts/run.py
+++ b/wellsfargo/income-statement/scripts/run.py
@@ -393,11 +393,24 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def main() -> None:
     args = parse_args()
 
     # Load config
-    config_path = Path(args.config)
+    config_path = _bootstrap_config_path(args.config)
     if not config_path.exists():
         print(f"Config file not found: {config_path}", file=sys.stderr)
         sys.exit(1)

--- a/wellsfargo/net-worth-tracker/scripts/agent.py
+++ b/wellsfargo/net-worth-tracker/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/wellsfargo/recurring-transactions/scripts/run.py
+++ b/wellsfargo/recurring-transactions/scripts/run.py
@@ -372,10 +372,23 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return path
+
+
 def main() -> None:
     args = parse_args()
 
-    config_path = Path(args.config)
+    config_path = _bootstrap_config_path(args.config)
     if not config_path.exists():
         print(f"Config file not found: {config_path}", file=sys.stderr)
         sys.exit(1)

--- a/wellsfargo/tax-prep/scripts/agent.py
+++ b/wellsfargo/tax-prep/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/wellsfargo/vendor-analysis/scripts/agent.py
+++ b/wellsfargo/vendor-analysis/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))

--- a/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
+++ b/zkp2p/peer-to-peer-payments-exchange/scripts/agent.py
@@ -25,8 +25,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- auto-bootstrap missing `config.json` from sibling `config.example.json` in Taariq-authored runtime entrypoints
- preserve existing failure behavior when neither file exists
- add one focused runtime bootstrap test file that validates helper behavior and wiring across the patched files

Closes #201
