### PR TITLE
fix(polymarket): expand optimizer from 4 to 14 candidates (#202)

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -1076,6 +1076,107 @@ def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) ->
             },
             "backtest": {},
         },
+        # --- 10 new candidates below ---
+        {
+            "name": "defensive-wide-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.3, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.2, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "narrow-top2-concentration",
+            "subset_size": max(2, min(2, total_markets)),
+            "strategy": {
+                "pairs_max": max(2, min(2, total_markets)),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.4, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.3, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "aggressive-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.2, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "passive-conservative",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.15, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.3, 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.8, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "optimistic-costs",
+            "subset_size": base_pairs,
+            "strategy": {
+                "expected_unwind_cost_bps": round(max(0.5, p.expected_unwind_cost_bps * 0.7), 4),
+                "adverse_selection_bps": round(max(0.3, p.adverse_selection_bps * 0.7), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "tight-exit-fast-convergence",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.25, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-diversified",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.75, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 0.7, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "mid-edge-relaxed",
+            "subset_size": base_pairs,
+            "strategy": {
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.5), 4),
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "high-notional-concentrated",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.5, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.5, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.4, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-moderate",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.9), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.08, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.05, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
     ]
 
 

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -1137,6 +1137,107 @@ def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) ->
             },
             "backtest": {},
         },
+        # --- 10 new candidates below ---
+        {
+            "name": "defensive-wide-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.3, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.2, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "narrow-top2-concentration",
+            "subset_size": max(2, min(2, total_markets)),
+            "strategy": {
+                "pairs_max": max(2, min(2, total_markets)),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.4, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.3, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "aggressive-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.2, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "passive-conservative",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.15, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.3, 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.8, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "optimistic-costs",
+            "subset_size": base_pairs,
+            "strategy": {
+                "expected_unwind_cost_bps": round(max(0.5, p.expected_unwind_cost_bps * 0.7), 4),
+                "adverse_selection_bps": round(max(0.3, p.adverse_selection_bps * 0.7), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "tight-exit-fast-convergence",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.25, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-diversified",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.75, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 0.7, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "mid-edge-relaxed",
+            "subset_size": base_pairs,
+            "strategy": {
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.5), 4),
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "high-notional-concentrated",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.5, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.5, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.4, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-moderate",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.9), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.08, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.05, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
     ]
 
 

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -2020,6 +2020,107 @@ def _maker_optimization_candidates(config: dict[str, Any], total_markets: int) -
             },
             "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.05, 0.0, 1.0), 4)},
         },
+        # --- 10 new candidates below ---
+        {
+            "name": "defensive-wide-spread",
+            "subset_size": base_markets,
+            "strategy": {
+                "min_spread_bps": round(p.min_spread_bps * 1.3, 4),
+                "max_spread_bps": round(p.max_spread_bps * 1.2, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate - 0.1, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "narrow-top3-concentration",
+            "subset_size": max(1, min(3, total_markets)),
+            "strategy": {
+                "markets_max": max(1, min(3, total_markets)),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.4, 4),
+                "max_notional_per_market_usd": round(p.max_notional_per_market_usd * 1.3, 4),
+                "max_position_notional_usd": round(p.max_position_notional_usd * 1.3, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.1, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "mid-aggressive-edge",
+            "subset_size": base_markets,
+            "strategy": {
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.6), 4),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 1.2, 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.05, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "passive-low-participation",
+            "subset_size": base_markets,
+            "strategy": {
+                "min_spread_bps": round(p.min_spread_bps * 1.15, 4),
+                "base_order_notional_usd": round(p.base_order_notional_usd * 0.85, 4),
+            },
+            "backtest": {"participation_rate": round(max(0.1, bt.participation_rate - 0.2), 4)},
+        },
+        {
+            "name": "optimistic-rebate",
+            "subset_size": base_markets,
+            "strategy": {
+                "expected_unwind_cost_bps": round(max(0.5, p.expected_unwind_cost_bps * 0.7), 4),
+                "adverse_selection_bps": round(max(0.3, p.adverse_selection_bps * 0.7), 4),
+            },
+            "backtest": {
+                "join_best_queue_factor": round(min(1.0, bt.join_best_queue_factor + 0.1), 4),
+                "off_best_queue_factor": round(min(1.0, bt.off_best_queue_factor + 0.1), 4),
+            },
+        },
+        {
+            "name": "optimistic-fill-quality",
+            "subset_size": base_markets,
+            "strategy": {
+                "min_spread_bps": round(max(5.0, p.min_spread_bps * 0.8), 4),
+            },
+            "backtest": {
+                "spread_decay_bps": round(max(10.0, bt.spread_decay_bps * 0.75), 4),
+                "participation_rate": round(clamp(bt.participation_rate + 0.1, 0.0, 1.0), 4),
+            },
+        },
+        {
+            "name": "broad-diversified",
+            "subset_size": broad_markets,
+            "strategy": {
+                "markets_max": broad_markets,
+                "base_order_notional_usd": round(p.base_order_notional_usd * 0.8, 4),
+                "max_notional_per_market_usd": round(p.max_notional_per_market_usd * 0.75, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.25, 4),
+            },
+            "backtest": {"participation_rate": round(bt.participation_rate, 4)},
+        },
+        {
+            "name": "tight-midpoint-band",
+            "subset_size": base_markets,
+            "strategy": {
+                "min_mid_price": round(min(0.40, p.min_mid_price + 0.05), 4),
+                "max_mid_price": round(max(0.60, p.max_mid_price - 0.05), 4),
+            },
+            "backtest": {"participation_rate": round(clamp(bt.participation_rate + 0.05, 0.0, 1.0), 4)},
+        },
+        {
+            "name": "high-inventory-skew",
+            "subset_size": base_markets,
+            "strategy": {
+                "inventory_skew_strength_bps": round(p.inventory_skew_strength_bps * 1.5, 4),
+                "max_inventory_hold_cycles": max(1, p.max_inventory_hold_cycles - 1),
+            },
+            "backtest": {"participation_rate": round(bt.participation_rate, 4)},
+        },
+        {
+            "name": "vol-adjusted-wide",
+            "subset_size": base_markets,
+            "strategy": {
+                "volatility_spread_multiplier": round(p.volatility_spread_multiplier * 1.5, 4),
+                "min_spread_bps": round(p.min_spread_bps * 1.1, 4),
+                "max_spread_bps": round(p.max_spread_bps * 1.3, 4),
+            },
+            "backtest": {"participation_rate": round(max(0.1, bt.participation_rate - 0.05), 4)},
+        },
     ]
 
 

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -1076,6 +1076,107 @@ def _pair_optimization_candidates(config: dict[str, Any], total_markets: int) ->
             },
             "backtest": {},
         },
+        # --- 10 new candidates below ---
+        {
+            "name": "defensive-wide-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.3, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.2, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "narrow-top2-concentration",
+            "subset_size": max(2, min(2, total_markets)),
+            "strategy": {
+                "pairs_max": max(2, min(2, total_markets)),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.4, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.3, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "aggressive-entry",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.2, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "passive-conservative",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(p.basis_entry_bps * 1.15, 4),
+                "basis_exit_bps": round(p.basis_exit_bps * 1.3, 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.8, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "optimistic-costs",
+            "subset_size": base_pairs,
+            "strategy": {
+                "expected_unwind_cost_bps": round(max(0.5, p.expected_unwind_cost_bps * 0.7), 4),
+                "adverse_selection_bps": round(max(0.3, p.adverse_selection_bps * 0.7), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "tight-exit-fast-convergence",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.6), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.25, 0.0, 1.0), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "broad-diversified",
+            "subset_size": broad_pairs,
+            "strategy": {
+                "pairs_max": broad_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 0.75, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 0.7, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.3, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "mid-edge-relaxed",
+            "subset_size": base_pairs,
+            "strategy": {
+                "min_edge_bps": round(max(0.5, p.min_edge_bps * 0.5), 4),
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.85), 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "high-notional-concentrated",
+            "subset_size": focus_pairs,
+            "strategy": {
+                "pairs_max": focus_pairs,
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.5, 4),
+                "max_notional_per_pair_usd": round(p.max_notional_per_pair_usd * 1.5, 4),
+                "max_leg_notional_usd": round(p.max_leg_notional_usd * 1.4, 4),
+            },
+            "backtest": {},
+        },
+        {
+            "name": "balanced-moderate",
+            "subset_size": base_pairs,
+            "strategy": {
+                "basis_entry_bps": round(max(10.0, p.basis_entry_bps * 0.9), 4),
+                "basis_exit_bps": round(max(0.0, p.basis_exit_bps * 0.9), 4),
+                "expected_convergence_ratio": round(clamp(p.expected_convergence_ratio + 0.08, 0.0, 1.0), 4),
+                "base_pair_notional_usd": round(p.base_pair_notional_usd * 1.05, 4),
+                "max_total_notional_usd": round(p.max_total_notional_usd * 1.1, 4),
+            },
+            "backtest": {},
+        },
     ]
 
 

--- a/tests/test_optimizer_candidates.py
+++ b/tests/test_optimizer_candidates.py
@@ -1,0 +1,75 @@
+"""Verify optimization candidate functions return >= 14 candidates
+with unique names so max_iterations=15 is fully utilized."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SKILLS: list[tuple[str, str]] = [
+    ("polymarket/maker-rebate-bot/scripts/agent.py", "_maker_optimization_candidates"),
+    ("polymarket/liquidity-paired-basis-maker/scripts/agent.py", "_pair_optimization_candidates"),
+    ("polymarket/high-throughput-paired-basis-maker/scripts/agent.py", "_pair_optimization_candidates"),
+    ("polymarket/paired-market-basis-maker/scripts/agent.py", "_pair_optimization_candidates"),
+]
+
+MIN_CANDIDATES = 14  # 1 baseline + 14 candidates = 15 max_iterations
+
+
+def _extract_candidate_list(filepath: Path, func_name: str) -> ast.List:
+    """AST-extract the return list from the optimization function."""
+    tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            for child in ast.walk(node):
+                if isinstance(child, ast.Return) and isinstance(child.value, ast.List):
+                    return child.value
+    raise AssertionError(f"{func_name} not found or has no return list in {filepath}")
+
+
+def _extract_candidate_names(filepath: Path, func_name: str) -> list[str]:
+    """Extract candidate 'name' strings from the AST."""
+    lst = _extract_candidate_list(filepath, func_name)
+    names: list[str] = []
+    for elt in lst.elts:
+        if not isinstance(elt, ast.Dict):
+            continue
+        for key, val in zip(elt.keys, elt.values):
+            if isinstance(key, ast.Constant) and key.value == "name" and isinstance(val, ast.Constant):
+                names.append(val.value)
+    return names
+
+
+@pytest.mark.parametrize("rel_path,func_name", SKILLS, ids=[s[0].split("/")[0] + "/" + s[0].split("/")[1] for s in SKILLS])
+def test_candidate_count_at_least_14(rel_path: str, func_name: str) -> None:
+    """Optimizer must have >= 14 candidates to support max_iterations=15."""
+    filepath = REPO_ROOT / rel_path
+    lst = _extract_candidate_list(filepath, func_name)
+    assert len(lst.elts) >= MIN_CANDIDATES, (
+        f"{rel_path}: {func_name}() returns {len(lst.elts)} candidates, need >= {MIN_CANDIDATES}"
+    )
+
+
+@pytest.mark.parametrize("rel_path,func_name", SKILLS, ids=[s[0].split("/")[0] + "/" + s[0].split("/")[1] for s in SKILLS])
+def test_candidate_names_unique(rel_path: str, func_name: str) -> None:
+    """All candidate names must be unique to avoid confusion in results."""
+    filepath = REPO_ROOT / rel_path
+    names = _extract_candidate_names(filepath, func_name)
+    dupes = [n for n in names if names.count(n) > 1]
+    assert not dupes, f"{rel_path}: duplicate candidate names: {set(dupes)}"
+
+
+@pytest.mark.parametrize("rel_path,func_name", SKILLS, ids=[s[0].split("/")[0] + "/" + s[0].split("/")[1] for s in SKILLS])
+def test_every_candidate_has_name_and_subset_size(rel_path: str, func_name: str) -> None:
+    """Every candidate dict must have 'name' and 'subset_size' keys."""
+    filepath = REPO_ROOT / rel_path
+    lst = _extract_candidate_list(filepath, func_name)
+    for i, elt in enumerate(lst.elts):
+        assert isinstance(elt, ast.Dict), f"Candidate {i} is not a dict"
+        keys = [k.value for k in elt.keys if isinstance(k, ast.Constant)]
+        assert "name" in keys, f"Candidate {i} missing 'name'"
+        assert "subset_size" in keys, f"Candidate {i} missing 'subset_size'"


### PR DESCRIPTION
## Summary

Closes #202

- Expanded `_maker_optimization_candidates()` in `polymarket/maker-rebate-bot` from 4 to 14 candidates
- Expanded `_pair_optimization_candidates()` in all 3 paired-basis skills from 4 to 14 candidates
- Optimizer now fully utilizes `max_iterations=15` (1 baseline + 14 candidates) instead of stopping at 5

### New candidates (maker-rebate-bot)

| # | Name | Strategy |
|---|------|----------|
| 5 | defensive-wide-spread | Wider spreads, lower participation |
| 6 | narrow-top3-concentration | Fewer markets, higher notional |
| 7 | mid-aggressive-edge | Lower edge threshold |
| 8 | passive-low-participation | Lower participation, wider spreads |
| 9 | optimistic-rebate | Better fill assumptions |
| 10 | optimistic-fill-quality | Tighter spread decay |
| 11 | broad-diversified | Widest scan, lower per-market exposure |
| 12 | tight-midpoint-band | Narrower market selection |
| 13 | high-inventory-skew | Stronger inventory management |
| 14 | vol-adjusted-wide | Higher volatility multiplier |

### New candidates (paired-basis skills x3)

| # | Name | Strategy |
|---|------|----------|
| 5 | defensive-wide-entry | Higher entry threshold |
| 6 | narrow-top2-concentration | Fewer pairs, higher notional |
| 7 | aggressive-entry | Lower entry, higher convergence |
| 8 | passive-conservative | Wider entry/exit, lower notional |
| 9 | optimistic-costs | Lower unwind/adverse costs |
| 10 | tight-exit-fast-convergence | Tight exit, high convergence |
| 11 | broad-diversified | Widest scan, lower per-pair exposure |
| 12 | mid-edge-relaxed | Lower edge threshold |
| 13 | high-notional-concentrated | Max single-pair exposure |
| 14 | balanced-moderate | Moderate tweaks across all knobs |

## Test plan

- [x] 12 new tests in `test_optimizer_candidates.py` (count >= 14, unique names, required keys)
- [x] All 43 tests pass (12 new + 28 on-invoke + 3 safety)
- [x] All 4 files pass Python AST syntax validation

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com