### PR TITLE
test: guard paired basis maker sidecar imports

### DIFF
--- a/.github/workflows/enforce-seren-polymarket-publisher.yml
+++ b/.github/workflows/enforce-seren-polymarket-publisher.yml
@@ -18,6 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pytest
+
+      - name: Verify paired basis maker sidecar modules import correctly
+        run: python -m pytest tests/test_paired_basis_maker_imports.py
+
       - name: Block direct Polymarket Gamma API endpoints (must use Seren publisher)
         run: |
           set -euo pipefail

--- a/tests/test_paired_basis_maker_imports.py
+++ b/tests/test_paired_basis_maker_imports.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TARGETS = [
+    (
+        "high-throughput-paired-basis-maker",
+        REPO_ROOT / "polymarket" / "high-throughput-paired-basis-maker" / "scripts",
+    ),
+    (
+        "liquidity-paired-basis-maker",
+        REPO_ROOT / "polymarket" / "liquidity-paired-basis-maker" / "scripts",
+    ),
+]
+
+
+@pytest.mark.parametrize("skill_slug,script_dir", TARGETS, ids=[slug for slug, _ in TARGETS])
+def test_paired_basis_maker_agent_imports_with_bundled_replay_module(
+    skill_slug: str,
+    script_dir: Path,
+) -> None:
+    agent_path = script_dir / "agent.py"
+    replay_path = script_dir / "pair_stateful_replay.py"
+
+    assert replay_path.exists(), f"{skill_slug} is missing {replay_path.name}"
+
+    spec = importlib.util.spec_from_file_location(f"{skill_slug.replace('-', '_')}_agent_test", agent_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    script_dir_str = str(script_dir)
+    original_sys_path = list(sys.path)
+
+    try:
+        if script_dir_str not in sys.path:
+            sys.path.insert(0, script_dir_str)
+        sys.modules.pop("pair_stateful_replay", None)
+        sys.modules.pop("polymarket_live", None)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = original_sys_path
+        sys.modules.pop(spec.name, None)
+        sys.modules.pop("pair_stateful_replay", None)
+        sys.modules.pop("polymarket_live", None)


### PR DESCRIPTION
## Summary
- add a root-level regression test that imports the two affected paired basis maker agents from their real scripts directories
- fail fast if the bundled pair_stateful_replay.py sidecar is missing from either skill
- run that regression in the polymarket enforcement workflow so future packaging or bundling regressions are caught in CI

Closes #203
