### PR TITLE
fix: normalize SerenBucks wallet balance responses

### DIFF
--- a/polymarket/bot/scripts/seren_client.py
+++ b/polymarket/bot/scripts/seren_client.py
@@ -114,7 +114,43 @@ class SerenClient:
         url = f"{self.gateway_url}/wallet/balance"
         response = self.session.get(url, timeout=30)
         response.raise_for_status()
-        return response.json()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Unexpected wallet balance response shape")
+
+        data = payload.get('data')
+        if isinstance(data, dict):
+            payload = data
+
+        normalized = payload.copy()
+        for field in (
+            'balance_usd',
+            'funded_balance_usd',
+            'promotional_balance_usd',
+            'total_purchases_usd',
+        ):
+            parsed = self._parse_usd_amount(normalized.get(field))
+            if parsed is not None:
+                normalized[field] = parsed
+
+        return normalized
+
+    @staticmethod
+    def _parse_usd_amount(value: Any) -> Optional[float]:
+        """Parse USD amounts returned as either numbers or '$12.34' strings."""
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.strip().replace('$', '').replace(',', '')
+            if not cleaned:
+                return None
+            try:
+                return float(cleaned)
+            except ValueError:
+                return None
+        return None
 
     def _extract_text(self, response: Dict[str, Any]) -> str:
         """

--- a/polymarket/bot/scripts/test_seren_client.py
+++ b/polymarket/bot/scripts/test_seren_client.py
@@ -5,7 +5,7 @@ Unit tests for SerenClient._extract_text response shape handling.
 import pytest
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -119,3 +119,57 @@ class TestSerenClientApiKeyResolution:
         ):
             with pytest.raises(ValueError, match=r"SEREN_API_KEY.*API_KEY"):
                 SerenClient()
+
+
+class TestSerenClientWalletBalance:
+    def test_get_wallet_balance_unwraps_data_and_parses_currency_strings(self):
+        session = Mock()
+        response = Mock()
+        response.json.return_value = {
+            'data': {
+                'balance_atomic': 21028699,
+                'balance_usd': '$21.03',
+                'funded_balance_usd': '$20.33',
+                'promotional_balance_usd': '$0.70',
+            }
+        }
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+
+        with patch.dict('os.environ', {'SEREN_API_KEY': 'seren-key'}, clear=True), patch(
+            'seren_client.requests.Session',
+            return_value=session,
+        ):
+            client = SerenClient()
+
+        wallet = client.get_wallet_balance()
+
+        assert wallet['balance_atomic'] == 21028699
+        assert wallet['balance_usd'] == 21.03
+        assert wallet['funded_balance_usd'] == 20.33
+        assert wallet['promotional_balance_usd'] == 0.70
+        session.get.assert_called_once_with(
+            'https://api.serendb.com/wallet/balance',
+            timeout=30,
+        )
+
+    def test_get_wallet_balance_keeps_top_level_numeric_response(self):
+        session = Mock()
+        response = Mock()
+        response.json.return_value = {
+            'balance_atomic': 1230000,
+            'balance_usd': 1.23,
+        }
+        response.raise_for_status.return_value = None
+        session.get.return_value = response
+
+        with patch.dict('os.environ', {'SEREN_API_KEY': 'seren-key'}, clear=True), patch(
+            'seren_client.requests.Session',
+            return_value=session,
+        ):
+            client = SerenClient()
+
+        wallet = client.get_wallet_balance()
+
+        assert wallet['balance_atomic'] == 1230000
+        assert wallet['balance_usd'] == 1.23


### PR DESCRIPTION
## Summary
- normalize wallet balance responses that come back nested under `data`
- parse dollar-formatted balance strings like "$21.03" into floats before the agent reads them
- add only the wallet-balance regression tests needed for the nested-string and legacy numeric shapes

## Testing
- pytest polymarket/bot/scripts/test_seren_client.py

Closes #211
