### PR TITLE
fix: normalize wallet balance parsing across remaining polymarket runtimes

### DIFF
--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -1206,9 +1206,19 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("data") or data.get("serenbucks") or {}
-            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
-            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+            if not isinstance(data, dict):
+                return 0.0
+            sb = data.get("data")
+            if not isinstance(sb, dict):
+                sb = data.get("serenbucks")
+            if not isinstance(sb, dict):
+                sb = data
+            for field in ("funded_balance_usd", "balance_usd"):
+                raw = sb.get(field)
+                parsed = _safe_float(str(raw).replace("$", "").replace(",", ""), -1.0)
+                if parsed >= 0.0:
+                    return parsed
+            return 0.0
     except Exception as exc:
         print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0

--- a/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
@@ -226,6 +226,24 @@ def test_backtest_optimizer_selects_targeted_pair_subset_and_tuned_config(monkey
     assert [target["market_id"] for target in output["optimization_summary"]["target_pairs"]] == ["M0", "M1"]
 
 
+def test_check_serenbucks_balance_uses_nested_funded_balance(monkeypatch) -> None:
+    module = _load_agent_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"data": {"funded_balance_usd": "$20.33"}}).encode("utf-8")
+
+    monkeypatch.setattr(module, "urlopen", lambda request, timeout=10: _Response())
+
+    assert module._check_serenbucks_balance("test-key") == 20.33
+
+
 def test_main_applies_backtest_config_updates_before_trade(monkeypatch, tmp_path: Path) -> None:
     module = _load_agent_module()
     config_path = tmp_path / "config.json"

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -1267,9 +1267,19 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("data") or data.get("serenbucks") or {}
-            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
-            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+            if not isinstance(data, dict):
+                return 0.0
+            sb = data.get("data")
+            if not isinstance(sb, dict):
+                sb = data.get("serenbucks")
+            if not isinstance(sb, dict):
+                sb = data
+            for field in ("funded_balance_usd", "balance_usd"):
+                raw = sb.get(field)
+                parsed = _safe_float(str(raw).replace("$", "").replace(",", ""), -1.0)
+                if parsed >= 0.0:
+                    return parsed
+            return 0.0
     except Exception as exc:
         print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0

--- a/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
+++ b/polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
@@ -161,3 +161,21 @@ def test_trade_mode_fetches_live_pairs_when_config_markets_is_empty(monkeypatch)
     assert result["pair_trades"][0]["market_id"] == "LIVE-LIQ-1A"
     assert result["pair_trades"][0]["pair_market_id"] == "LIVE-LIQ-1B"
     assert any("/publishers/polymarket-data/markets?" in url for url in fetched_urls)
+
+
+def test_check_serenbucks_balance_uses_nested_funded_balance(monkeypatch) -> None:
+    module = _load_agent_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"data": {"funded_balance_usd": "$20.33"}}).encode("utf-8")
+
+    monkeypatch.setattr(module, "urlopen", lambda request, timeout=10: _Response())
+
+    assert module._check_serenbucks_balance("test-key") == 20.33

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -917,9 +917,19 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("data") or data.get("serenbucks") or {}
-            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
-            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+            if not isinstance(data, dict):
+                return 0.0
+            sb = data.get("data")
+            if not isinstance(sb, dict):
+                sb = data.get("serenbucks")
+            if not isinstance(sb, dict):
+                sb = data
+            for field in ("funded_balance_usd", "balance_usd"):
+                raw = sb.get(field)
+                parsed = _safe_float(str(raw).replace("$", "").replace(",", ""), -1.0)
+                if parsed >= 0.0:
+                    return parsed
+            return 0.0
     except Exception as exc:
         print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0

--- a/polymarket/maker-rebate-bot/tests/test_smoke.py
+++ b/polymarket/maker-rebate-bot/tests/test_smoke.py
@@ -221,6 +221,24 @@ def test_quote_mode_fetches_live_markets_when_config_markets_is_empty(monkeypatc
     assert any("/publishers/polymarket-data/markets?" in url for url in fetched_urls)
 
 
+def test_check_serenbucks_balance_uses_nested_funded_balance(monkeypatch) -> None:
+    agent = _load_agent_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"data": {"funded_balance_usd": "$20.33"}}).encode("utf-8")
+
+    monkeypatch.setattr(agent, "urlopen", lambda request, timeout=10: _Response())
+
+    assert agent._check_serenbucks_balance("test-key") == 20.33
+
+
 def test_live_guard_fixture_blocks_execution() -> None:
     payload = _read_fixture("live_guard.json")
     assert payload["status"] == "error"

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -1206,9 +1206,19 @@ def _check_serenbucks_balance(api_key: str) -> float:
         )
         with urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
-            sb = data.get("data") or data.get("serenbucks") or {}
-            raw = sb.get("balance_usd") or sb.get("funded_balance_usd") or "0"
-            return _safe_float(str(raw).replace("$", "").replace(",", ""), 0.0)
+            if not isinstance(data, dict):
+                return 0.0
+            sb = data.get("data")
+            if not isinstance(sb, dict):
+                sb = data.get("serenbucks")
+            if not isinstance(sb, dict):
+                sb = data
+            for field in ("funded_balance_usd", "balance_usd"):
+                raw = sb.get(field)
+                parsed = _safe_float(str(raw).replace("$", "").replace(",", ""), -1.0)
+                if parsed >= 0.0:
+                    return parsed
+            return 0.0
     except Exception as exc:
         print(f"WARNING: could not fetch SerenBucks balance: {exc}", file=sys.stderr)
         return 0.0

--- a/polymarket/paired-market-basis-maker/tests/test_smoke.py
+++ b/polymarket/paired-market-basis-maker/tests/test_smoke.py
@@ -163,6 +163,24 @@ def test_trade_mode_fetches_live_pairs_when_config_markets_is_empty(monkeypatch)
     assert any("/publishers/polymarket-data/markets?" in url for url in fetched_urls)
 
 
+def test_check_serenbucks_balance_uses_nested_funded_balance(monkeypatch) -> None:
+    module = _load_agent_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"data": {"funded_balance_usd": "$20.33"}}).encode("utf-8")
+
+    monkeypatch.setattr(module, "urlopen", lambda request, timeout=10: _Response())
+
+    assert module._check_serenbucks_balance("test-key") == 20.33
+
+
 def test_live_trade_mode_uses_live_pair_loader_and_executor(monkeypatch) -> None:
     module = _load_agent_module()
     load_calls: list[dict[str, object]] = []


### PR DESCRIPTION
Summary:
- normalize _check_serenbucks_balance across remaining Polymarket runtimes
- accept top-level wallet payloads, nested data, or nested serenbucks
- prefer funded_balance_usd before balance_usd and parse currency-formatted strings

Testing:
- pytest polymarket/paired-market-basis-maker/tests/test_smoke.py
- pytest polymarket/high-throughput-paired-basis-maker/tests/test_smoke.py
- pytest polymarket/liquidity-paired-basis-maker/tests/test_smoke.py
- pytest polymarket/maker-rebate-bot/tests/test_smoke.py -k check_serenbucks_balance_uses_nested_funded_balance

Notes:
- the full polymarket/maker-rebate-bot/tests/test_smoke.py suite still has one unrelated pre-existing failure asserting backtest_summary.source == config while the current runtime reports an optimized source string