### PR TITLE
Fix issue #210 SerenDB project routes for Polymarket bot

### DIFF
--- a/polymarket/bot/scripts/serendb_storage.py
+++ b/polymarket/bot/scripts/serendb_storage.py
@@ -809,7 +809,7 @@ class SerenDBStorage:
                     query = query.replace('?', str(param), 1)
 
         # Call Seren Gateway database API
-        url = f"{self.seren.gateway_url}/databases/projects/{self.project_id}/branches/{self.branch_id}/query"
+        url = f"{self.seren.gateway_url}/projects/{self.project_id}/branches/{self.branch_id}/query"
 
         response = self.seren.session.post(
             url,
@@ -818,39 +818,48 @@ class SerenDBStorage:
         )
 
         response.raise_for_status()
-        return response.json()
+        return self._unwrap_data(response.json())
 
     def _list_projects(self) -> List[Dict[str, Any]]:
         """List all SerenDB projects"""
-        url = f"{self.seren.gateway_url}/databases/projects"
+        url = f"{self.seren.gateway_url}/projects"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
-        return response.json().get('data', [])
+        return self._unwrap_data(response.json(), default=[])
 
     def _create_project(self, name: str) -> Dict[str, Any]:
         """Create a new SerenDB project"""
-        url = f"{self.seren.gateway_url}/databases/projects"
+        url = f"{self.seren.gateway_url}/projects"
         response = self.seren.session.post(
             url,
             json={'name': name, 'region': 'aws-us-east-2'},
             timeout=30
         )
         response.raise_for_status()
-        data = response.json()
+        data = self._unwrap_data(response.json())
         # Return full project details
-        project_id = data['data']['id']
+        project_id = data['id']
         return self._get_project(project_id)
 
     def _get_project(self, project_id: str) -> Dict[str, Any]:
         """Get project details"""
-        url = f"{self.seren.gateway_url}/databases/projects/{project_id}"
+        url = f"{self.seren.gateway_url}/projects/{project_id}"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
-        return response.json().get('data', {})
+        return self._unwrap_data(response.json(), default={})
 
     def _list_branches(self, project_id: str) -> List[Dict[str, Any]]:
         """List branches for a project"""
-        url = f"{self.seren.gateway_url}/databases/projects/{project_id}/branches"
+        url = f"{self.seren.gateway_url}/projects/{project_id}/branches"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
-        return response.json().get('data', [])
+        return self._unwrap_data(response.json(), default=[])
+
+    @staticmethod
+    def _unwrap_data(payload: Any, default: Optional[Any] = None) -> Any:
+        """Accept either wrapped {'data': ...} or direct payloads from SerenDB."""
+        if payload is None:
+            return default
+        if isinstance(payload, dict) and 'data' in payload:
+            return payload['data']
+        return payload

--- a/polymarket/bot/scripts/test_serendb_storage.py
+++ b/polymarket/bot/scripts/test_serendb_storage.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for SerenDBStorage project bootstrap routing.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from serendb_storage import SerenDBStorage
+
+
+def _response(payload):
+    response = Mock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestSerenDBStorageRoutes:
+    def test_setup_database_uses_projects_routes_for_bootstrap(self):
+        session = Mock()
+        seren = Mock()
+        seren.gateway_url = "https://api.serendb.com"
+        seren.session = session
+
+        query_urls = []
+
+        def get_side_effect(url, timeout):
+            assert timeout == 10
+            if url == "https://api.serendb.com/projects":
+                return _response([])
+            if url == "https://api.serendb.com/projects/project-123":
+                return _response({"data": {"id": "project-123", "name": "polymarket-bot"}})
+            if url == "https://api.serendb.com/projects/project-123/branches":
+                return _response([{"id": "branch-main", "name": "main"}])
+            raise AssertionError(f"Unexpected GET {url}")
+
+        def post_side_effect(url, json, timeout):
+            if url == "https://api.serendb.com/projects":
+                assert timeout == 30
+                assert json == {"name": "polymarket-bot", "region": "aws-us-east-2"}
+                return _response({"data": {"id": "project-123"}})
+            if url == "https://api.serendb.com/projects/project-123/branches/branch-main/query":
+                assert timeout == 30
+                assert "query" in json
+                query_urls.append(url)
+                return _response({"data": {"rows": [], "changes": 0}})
+            raise AssertionError(f"Unexpected POST {url}")
+
+        session.get.side_effect = get_side_effect
+        session.post.side_effect = post_side_effect
+
+        storage = SerenDBStorage(seren)
+
+        assert storage.setup_database() is True
+        assert storage.project_id == "project-123"
+        assert storage.branch_id == "branch-main"
+        assert query_urls
+
+    def test_execute_sql_uses_projects_query_endpoint_and_unwraps_data(self):
+        session = Mock()
+        seren = Mock()
+        seren.gateway_url = "https://api.serendb.com"
+        seren.session = session
+
+        session.post.return_value = _response({"data": {"rows": [{"count": 1}]}})
+
+        storage = SerenDBStorage(seren)
+        storage.project_id = "project-123"
+        storage.branch_id = "branch-main"
+
+        result = storage._execute_sql("SELECT 1 AS count")
+
+        assert result == {"rows": [{"count": 1}]}
+        session.post.assert_called_once_with(
+            "https://api.serendb.com/projects/project-123/branches/branch-main/query",
+            json={"query": "SELECT 1 AS count"},
+            timeout=30,
+        )


### PR DESCRIPTION
Closes #210

## Summary
- switch Polymarket bot SerenDB project/bootstrap calls from `/databases/projects` to `/projects`
- align SQL query execution with the same project/branch route family
- add focused regression coverage for bootstrap and query routing

## Testing
- pytest polymarket/bot/scripts/test_serendb_storage.py