### PR TITLE
Fix issue #209 Polymarket RPC fallback handling

### DIFF
--- a/polymarket/bot/scripts/polymarket_live.py
+++ b/polymarket/bot/scripts/polymarket_live.py
@@ -947,36 +947,78 @@ def _eth_call_via_public_polygon_rpc(
     return safe_str(response.get("result"), "0x0")
 
 
+def _eth_get_transaction_count_via_seren_polygon(
+    wallet_address: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_getTransactionCount",
+                "params": [wallet_address, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
+def _eth_get_transaction_count_via_public_polygon_rpc(
+    wallet_address: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionCount",
+        "id": 1,
+        "params": [wallet_address, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
 def _resolve_polygon_rpc_transport(
     *,
     rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
-    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
-        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
-        if publisher:
-            try:
-                target = _probe_seren_polygon_rpc_target(
-                    publisher,
-                    timeout_seconds=timeout_seconds,
-                )
-                return {
-                    "rpc_transport": "seren-publisher",
-                    "rpc_publisher": publisher,
-                    "rpc_path": safe_str(target.get("path"), "/") or "/",
-                    "seren_balance_usd": balance,
-                }
-            except Exception as exc:
-                fallback_reason = (
-                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
-                )
-        else:
-            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+    if publisher:
+        try:
+            target = _probe_seren_polygon_rpc_target(
+                publisher,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "rpc_transport": "seren-publisher",
+                "rpc_publisher": publisher,
+                "rpc_path": safe_str(target.get("path"), "/") or "/",
+                "seren_balance_usd": balance,
+            }
+        except Exception as exc:
+            fallback_reason = (
+                f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+            )
     else:
         fallback_reason = (
-            f"Seren prepaid balance ${balance:.2f} is below the "
-            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+            "No Polygon RPC publisher was discovered in the Seren catalog. "
+            f"Seren prepaid balance was ${balance:.2f}, but read-only publisher RPC "
+            "resolution is attempted regardless of balance."
         )
 
     return {
@@ -1017,6 +1059,28 @@ def _eth_call_with_transport(
                 f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
             ) from exc
         raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
+
+
+def _eth_get_transaction_count_with_transport(
+    wallet_address: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_get_transaction_count_via_seren_polygon(
+            wallet_address,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    return _eth_get_transaction_count_via_public_polygon_rpc(
+        wallet_address,
+        rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def current_machine_label() -> str:
@@ -1856,6 +1920,30 @@ def check_neg_risk_approvals(
     except (ValueError, TypeError):
         ct_approved = False
     results["ct_approved"] = ct_approved
+
+    if (
+        results["rpc_transport"] == "public"
+        and not results["usdc_approved"]
+        and not results["ct_approved"]
+    ):
+        try:
+            wallet_nonce = _eth_get_transaction_count_with_transport(
+                wallet_address,
+                rpc_transport=rpc_transport,
+                timeout_seconds=timeout_seconds,
+            )
+            results["wallet_nonce"] = wallet_nonce
+        except Exception:
+            wallet_nonce = 0
+
+        if wallet_nonce > 0:
+            results["errors"].append(
+                "Public Polygon RPC fallback returned an all-zero approval state for a "
+                f"wallet with nonce {wallet_nonce}. This fallback can be stale or "
+                "rate-limited and is not being treated as authoritative. Re-run with "
+                "a working Seren Polygon publisher or configure a reliable Polygon RPC."
+            )
+            return results
 
     if not results["usdc_approved"]:
         results["errors"].append(

--- a/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
@@ -947,36 +947,78 @@ def _eth_call_via_public_polygon_rpc(
     return safe_str(response.get("result"), "0x0")
 
 
+def _eth_get_transaction_count_via_seren_polygon(
+    wallet_address: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_getTransactionCount",
+                "params": [wallet_address, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
+def _eth_get_transaction_count_via_public_polygon_rpc(
+    wallet_address: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionCount",
+        "id": 1,
+        "params": [wallet_address, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
 def _resolve_polygon_rpc_transport(
     *,
     rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
-    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
-        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
-        if publisher:
-            try:
-                target = _probe_seren_polygon_rpc_target(
-                    publisher,
-                    timeout_seconds=timeout_seconds,
-                )
-                return {
-                    "rpc_transport": "seren-publisher",
-                    "rpc_publisher": publisher,
-                    "rpc_path": safe_str(target.get("path"), "/") or "/",
-                    "seren_balance_usd": balance,
-                }
-            except Exception as exc:
-                fallback_reason = (
-                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
-                )
-        else:
-            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+    if publisher:
+        try:
+            target = _probe_seren_polygon_rpc_target(
+                publisher,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "rpc_transport": "seren-publisher",
+                "rpc_publisher": publisher,
+                "rpc_path": safe_str(target.get("path"), "/") or "/",
+                "seren_balance_usd": balance,
+            }
+        except Exception as exc:
+            fallback_reason = (
+                f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+            )
     else:
         fallback_reason = (
-            f"Seren prepaid balance ${balance:.2f} is below the "
-            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+            "No Polygon RPC publisher was discovered in the Seren catalog. "
+            f"Seren prepaid balance was ${balance:.2f}, but read-only publisher RPC "
+            "resolution is attempted regardless of balance."
         )
 
     return {
@@ -1017,6 +1059,28 @@ def _eth_call_with_transport(
                 f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
             ) from exc
         raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
+
+
+def _eth_get_transaction_count_with_transport(
+    wallet_address: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_get_transaction_count_via_seren_polygon(
+            wallet_address,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    return _eth_get_transaction_count_via_public_polygon_rpc(
+        wallet_address,
+        rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def current_machine_label() -> str:
@@ -1856,6 +1920,30 @@ def check_neg_risk_approvals(
     except (ValueError, TypeError):
         ct_approved = False
     results["ct_approved"] = ct_approved
+
+    if (
+        results["rpc_transport"] == "public"
+        and not results["usdc_approved"]
+        and not results["ct_approved"]
+    ):
+        try:
+            wallet_nonce = _eth_get_transaction_count_with_transport(
+                wallet_address,
+                rpc_transport=rpc_transport,
+                timeout_seconds=timeout_seconds,
+            )
+            results["wallet_nonce"] = wallet_nonce
+        except Exception:
+            wallet_nonce = 0
+
+        if wallet_nonce > 0:
+            results["errors"].append(
+                "Public Polygon RPC fallback returned an all-zero approval state for a "
+                f"wallet with nonce {wallet_nonce}. This fallback can be stale or "
+                "rate-limited and is not being treated as authoritative. Re-run with "
+                "a working Seren Polygon publisher or configure a reliable Polygon RPC."
+            )
+            return results
 
     if not results["usdc_approved"]:
         results["errors"].append(

--- a/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
@@ -947,36 +947,78 @@ def _eth_call_via_public_polygon_rpc(
     return safe_str(response.get("result"), "0x0")
 
 
+def _eth_get_transaction_count_via_seren_polygon(
+    wallet_address: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_getTransactionCount",
+                "params": [wallet_address, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
+def _eth_get_transaction_count_via_public_polygon_rpc(
+    wallet_address: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionCount",
+        "id": 1,
+        "params": [wallet_address, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
 def _resolve_polygon_rpc_transport(
     *,
     rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
-    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
-        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
-        if publisher:
-            try:
-                target = _probe_seren_polygon_rpc_target(
-                    publisher,
-                    timeout_seconds=timeout_seconds,
-                )
-                return {
-                    "rpc_transport": "seren-publisher",
-                    "rpc_publisher": publisher,
-                    "rpc_path": safe_str(target.get("path"), "/") or "/",
-                    "seren_balance_usd": balance,
-                }
-            except Exception as exc:
-                fallback_reason = (
-                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
-                )
-        else:
-            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+    if publisher:
+        try:
+            target = _probe_seren_polygon_rpc_target(
+                publisher,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "rpc_transport": "seren-publisher",
+                "rpc_publisher": publisher,
+                "rpc_path": safe_str(target.get("path"), "/") or "/",
+                "seren_balance_usd": balance,
+            }
+        except Exception as exc:
+            fallback_reason = (
+                f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+            )
     else:
         fallback_reason = (
-            f"Seren prepaid balance ${balance:.2f} is below the "
-            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+            "No Polygon RPC publisher was discovered in the Seren catalog. "
+            f"Seren prepaid balance was ${balance:.2f}, but read-only publisher RPC "
+            "resolution is attempted regardless of balance."
         )
 
     return {
@@ -1017,6 +1059,28 @@ def _eth_call_with_transport(
                 f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
             ) from exc
         raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
+
+
+def _eth_get_transaction_count_with_transport(
+    wallet_address: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_get_transaction_count_via_seren_polygon(
+            wallet_address,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    return _eth_get_transaction_count_via_public_polygon_rpc(
+        wallet_address,
+        rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def current_machine_label() -> str:
@@ -1856,6 +1920,30 @@ def check_neg_risk_approvals(
     except (ValueError, TypeError):
         ct_approved = False
     results["ct_approved"] = ct_approved
+
+    if (
+        results["rpc_transport"] == "public"
+        and not results["usdc_approved"]
+        and not results["ct_approved"]
+    ):
+        try:
+            wallet_nonce = _eth_get_transaction_count_with_transport(
+                wallet_address,
+                rpc_transport=rpc_transport,
+                timeout_seconds=timeout_seconds,
+            )
+            results["wallet_nonce"] = wallet_nonce
+        except Exception:
+            wallet_nonce = 0
+
+        if wallet_nonce > 0:
+            results["errors"].append(
+                "Public Polygon RPC fallback returned an all-zero approval state for a "
+                f"wallet with nonce {wallet_nonce}. This fallback can be stale or "
+                "rate-limited and is not being treated as authoritative. Re-run with "
+                "a working Seren Polygon publisher or configure a reliable Polygon RPC."
+            )
+            return results
 
     if not results["usdc_approved"]:
         results["errors"].append(

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -951,36 +951,78 @@ def _eth_call_via_public_polygon_rpc(
     return safe_str(response.get("result"), "0x0")
 
 
+def _eth_get_transaction_count_via_seren_polygon(
+    wallet_address: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_getTransactionCount",
+                "params": [wallet_address, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
+def _eth_get_transaction_count_via_public_polygon_rpc(
+    wallet_address: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionCount",
+        "id": 1,
+        "params": [wallet_address, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
 def _resolve_polygon_rpc_transport(
     *,
     rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
-    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
-        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
-        if publisher:
-            try:
-                target = _probe_seren_polygon_rpc_target(
-                    publisher,
-                    timeout_seconds=timeout_seconds,
-                )
-                return {
-                    "rpc_transport": "seren-publisher",
-                    "rpc_publisher": publisher,
-                    "rpc_path": safe_str(target.get("path"), "/") or "/",
-                    "seren_balance_usd": balance,
-                }
-            except Exception as exc:
-                fallback_reason = (
-                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
-                )
-        else:
-            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+    if publisher:
+        try:
+            target = _probe_seren_polygon_rpc_target(
+                publisher,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "rpc_transport": "seren-publisher",
+                "rpc_publisher": publisher,
+                "rpc_path": safe_str(target.get("path"), "/") or "/",
+                "seren_balance_usd": balance,
+            }
+        except Exception as exc:
+            fallback_reason = (
+                f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+            )
     else:
         fallback_reason = (
-            f"Seren prepaid balance ${balance:.2f} is below the "
-            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+            "No Polygon RPC publisher was discovered in the Seren catalog. "
+            f"Seren prepaid balance was ${balance:.2f}, but read-only publisher RPC "
+            "resolution is attempted regardless of balance."
         )
 
     return {
@@ -1021,6 +1063,28 @@ def _eth_call_with_transport(
                 f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
             ) from exc
         raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
+
+
+def _eth_get_transaction_count_with_transport(
+    wallet_address: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_get_transaction_count_via_seren_polygon(
+            wallet_address,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    return _eth_get_transaction_count_via_public_polygon_rpc(
+        wallet_address,
+        rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def current_machine_label() -> str:
@@ -1869,6 +1933,30 @@ def check_neg_risk_approvals(
     except (ValueError, TypeError):
         ct_approved = False
     results["ct_approved"] = ct_approved
+
+    if (
+        results["rpc_transport"] == "public"
+        and not results["usdc_approved"]
+        and not results["ct_approved"]
+    ):
+        try:
+            wallet_nonce = _eth_get_transaction_count_with_transport(
+                wallet_address,
+                rpc_transport=rpc_transport,
+                timeout_seconds=timeout_seconds,
+            )
+            results["wallet_nonce"] = wallet_nonce
+        except Exception:
+            wallet_nonce = 0
+
+        if wallet_nonce > 0:
+            results["errors"].append(
+                "Public Polygon RPC fallback returned an all-zero approval state for a "
+                f"wallet with nonce {wallet_nonce}. This fallback can be stale or "
+                "rate-limited and is not being treated as authoritative. Re-run with "
+                "a working Seren Polygon publisher or configure a reliable Polygon RPC."
+            )
+            return results
 
     if not results["usdc_approved"]:
         results["errors"].append(

--- a/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/paired-market-basis-maker/scripts/polymarket_live.py
@@ -947,36 +947,78 @@ def _eth_call_via_public_polygon_rpc(
     return safe_str(response.get("result"), "0x0")
 
 
+def _eth_get_transaction_count_via_seren_polygon(
+    wallet_address: str,
+    *,
+    publisher: str,
+    path: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    response = _extract_rpc_result(
+        call_publisher_json(
+            publisher=publisher,
+            method="POST",
+            path=path,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_getTransactionCount",
+                "params": [wallet_address, "latest"],
+            },
+            timeout_seconds=timeout_seconds,
+        ),
+        source=f"{publisher}{path or '(root)'}",
+    )
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
+def _eth_get_transaction_count_via_public_polygon_rpc(
+    wallet_address: str,
+    *,
+    rpc_url: str = POLYGON_PUBLIC_RPC_URL,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionCount",
+        "id": 1,
+        "params": [wallet_address, "latest"],
+    }).encode()
+    req = Request(rpc_url, data=payload, headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout_seconds) as resp:
+        body = json.loads(resp.read())
+    response = _extract_rpc_result(body, source=rpc_url)
+    return _parse_rpc_int(response.get("result"), field="transaction_count")
+
+
 def _resolve_polygon_rpc_transport(
     *,
     rpc_url: str = POLYGON_PUBLIC_RPC_URL,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     balance = get_seren_prepaid_balance(timeout_seconds=timeout_seconds)
-    if balance >= SEREN_MIN_PUBLISHER_BALANCE_USD:
-        publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
-        if publisher:
-            try:
-                target = _probe_seren_polygon_rpc_target(
-                    publisher,
-                    timeout_seconds=timeout_seconds,
-                )
-                return {
-                    "rpc_transport": "seren-publisher",
-                    "rpc_publisher": publisher,
-                    "rpc_path": safe_str(target.get("path"), "/") or "/",
-                    "seren_balance_usd": balance,
-                }
-            except Exception as exc:
-                fallback_reason = (
-                    f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
-                )
-        else:
-            fallback_reason = "No Polygon RPC publisher was discovered in the Seren catalog."
+    publisher = discover_seren_polygon_publisher(timeout_seconds=timeout_seconds)
+    if publisher:
+        try:
+            target = _probe_seren_polygon_rpc_target(
+                publisher,
+                timeout_seconds=timeout_seconds,
+            )
+            return {
+                "rpc_transport": "seren-publisher",
+                "rpc_publisher": publisher,
+                "rpc_path": safe_str(target.get("path"), "/") or "/",
+                "seren_balance_usd": balance,
+            }
+        except Exception as exc:
+            fallback_reason = (
+                f"Seren Polygon publisher '{publisher}' probe failed: {exc}"
+            )
     else:
         fallback_reason = (
-            f"Seren prepaid balance ${balance:.2f} is below the "
-            f"${SEREN_MIN_PUBLISHER_BALANCE_USD:.2f} minimum."
+            "No Polygon RPC publisher was discovered in the Seren catalog. "
+            f"Seren prepaid balance was ${balance:.2f}, but read-only publisher RPC "
+            "resolution is attempted regardless of balance."
         )
 
     return {
@@ -1017,6 +1059,28 @@ def _eth_call_with_transport(
                 f"Polygon RPC read failed via public fallback. {fallback_reason} | public-rpc: {exc}"
             ) from exc
         raise RuntimeError(f"Polygon RPC read failed via public fallback: {exc}") from exc
+
+
+def _eth_get_transaction_count_with_transport(
+    wallet_address: str,
+    *,
+    rpc_transport: dict[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    mode = safe_str(rpc_transport.get("rpc_transport"), "public")
+    if mode == "seren-publisher":
+        return _eth_get_transaction_count_via_seren_polygon(
+            wallet_address,
+            publisher=safe_str(rpc_transport.get("rpc_publisher"), ""),
+            path=safe_str(rpc_transport.get("rpc_path"), ""),
+            timeout_seconds=timeout_seconds,
+        )
+
+    return _eth_get_transaction_count_via_public_polygon_rpc(
+        wallet_address,
+        rpc_url=safe_str(rpc_transport.get("rpc_url"), POLYGON_PUBLIC_RPC_URL),
+        timeout_seconds=timeout_seconds,
+    )
 
 
 def current_machine_label() -> str:
@@ -1856,6 +1920,30 @@ def check_neg_risk_approvals(
     except (ValueError, TypeError):
         ct_approved = False
     results["ct_approved"] = ct_approved
+
+    if (
+        results["rpc_transport"] == "public"
+        and not results["usdc_approved"]
+        and not results["ct_approved"]
+    ):
+        try:
+            wallet_nonce = _eth_get_transaction_count_with_transport(
+                wallet_address,
+                rpc_transport=rpc_transport,
+                timeout_seconds=timeout_seconds,
+            )
+            results["wallet_nonce"] = wallet_nonce
+        except Exception:
+            wallet_nonce = 0
+
+        if wallet_nonce > 0:
+            results["errors"].append(
+                "Public Polygon RPC fallback returned an all-zero approval state for a "
+                f"wallet with nonce {wallet_nonce}. This fallback can be stale or "
+                "rate-limited and is not being treated as authoritative. Re-run with "
+                "a working Seren Polygon publisher or configure a reliable Polygon RPC."
+            )
+            return results
 
     if not results["usdc_approved"]:
         results["errors"].append(

--- a/polymarket/tests/test_execution_safety.py
+++ b/polymarket/tests/test_execution_safety.py
@@ -194,18 +194,70 @@ def test_neg_risk_approval_check_prefers_seren_polygon_publisher_when_funded(
 
 
 @pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
-def test_neg_risk_approval_check_falls_back_to_public_polygon_rpc_without_seren_funding(
+def test_neg_risk_approval_check_uses_seren_polygon_publisher_even_without_seren_funding(
     skill_slug: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_module(
-        f"{skill_slug.replace('-', '_')}_public_polygon_test",
+        f"{skill_slug.replace('-', '_')}_seren_polygon_zero_balance_test",
+        LIVE_MODULE_PATHS[skill_slug],
+        clear_modules=("polymarket_live",),
+    )
+    publisher_calls: list[tuple[str, str, str, str]] = []
+
+    monkeypatch.setattr(module, "get_seren_prepaid_balance", lambda **kwargs: 0.0)
+    monkeypatch.setattr(
+        module,
+        "discover_seren_polygon_publisher",
+        lambda **kwargs: "seren-polygon",
+    )
+
+    def fake_call_publisher_json(
+        publisher: str,
+        method: str,
+        path: str,
+        headers=None,
+        body=None,
+        timeout_seconds: float = 30.0,
+    ):
+        rpc_method = body["method"]
+        publisher_calls.append((publisher, method, path, rpc_method))
+        if rpc_method == "eth_chainId":
+            return {"jsonrpc": "2.0", "id": 1, "result": "0x89"}
+        if body["params"][0]["to"] == module.POLYGON_USDC_E:
+            return {"jsonrpc": "2.0", "id": 1, "result": hex(2 * (10 ** module.USDC_DECIMALS))}
+        return {"jsonrpc": "2.0", "id": 1, "result": "0x1"}
+
+    monkeypatch.setattr(module, "call_publisher_json", fake_call_publisher_json)
+    monkeypatch.setattr(
+        module,
+        "urlopen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("public fallback should not be used")),
+    )
+
+    result = module.check_neg_risk_approvals("0x" + ("2" * 40))
+
+    assert result["checks_passed"] is True
+    assert result["rpc_transport"] == "seren-publisher"
+    assert result["rpc_publisher"] == "seren-polygon"
+    assert all(call[0] == "seren-polygon" for call in publisher_calls)
+    assert [call[3] for call in publisher_calls] == ["eth_chainId", "eth_call", "eth_call"]
+
+
+@pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))
+def test_neg_risk_approval_check_flags_public_rpc_zero_state_as_non_authoritative(
+    skill_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(
+        f"{skill_slug.replace('-', '_')}_public_polygon_warning_test",
         LIVE_MODULE_PATHS[skill_slug],
         clear_modules=("polymarket_live",),
     )
     public_rpc_methods: list[str] = []
 
     monkeypatch.setattr(module, "get_seren_prepaid_balance", lambda **kwargs: 0.0)
+    monkeypatch.setattr(module, "discover_seren_polygon_publisher", lambda **kwargs: "")
     monkeypatch.setattr(
         module,
         "call_publisher_json",
@@ -215,18 +267,20 @@ def test_neg_risk_approval_check_falls_back_to_public_polygon_rpc_without_seren_
     def fake_urlopen(request, timeout: float = 10.0):
         payload = json.loads(request.data.decode("utf-8"))
         public_rpc_methods.append(payload["method"])
-        if payload["params"][0]["to"] == module.POLYGON_USDC_E:
-            return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": hex(2 * (10 ** module.USDC_DECIMALS))})
-        return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": "0x1"})
+        if payload["method"] == "eth_getTransactionCount":
+            return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": "0x3"})
+        return _JsonResponse({"jsonrpc": "2.0", "id": 1, "result": "0x0"})
 
     monkeypatch.setattr(module, "urlopen", fake_urlopen)
 
     result = module.check_neg_risk_approvals("0x" + ("2" * 40))
 
-    assert result["checks_passed"] is True
+    assert result["checks_passed"] is False
     assert result["rpc_transport"] == "public"
-    assert result["rpc_url"] == module.POLYGON_PUBLIC_RPC_URL
-    assert public_rpc_methods == ["eth_call", "eth_call"]
+    assert result["wallet_nonce"] == 3
+    assert any("not being treated as authoritative" in error for error in result["errors"])
+    assert public_rpc_methods == ["eth_call", "eth_call", "eth_getTransactionCount"]
+    assert not any("not approved" in error.lower() for error in result["errors"])
 
 
 @pytest.mark.parametrize("skill_slug", sorted(LIVE_MODULE_PATHS))


### PR DESCRIPTION
Closes #209

## Summary
- remove the prepaid-balance gate from Polygon publisher RPC discovery across all Polymarket skills
- keep public Polygon RPC as fallback only when publisher discovery or probe actually fails
- flag all-zero public fallback approval reads as non-authoritative when the wallet has prior onchain activity
- update shared execution-safety coverage for the new resolver behavior

## Testing
- pytest polymarket/tests/test_execution_safety.py -k "seren_polygon or public_rpc_zero_state or polygon_rpc_failure"

## Note
- `pytest polymarket/tests/test_execution_safety.py` still hits one unrelated pre-existing failure in `polymarket/bot/scripts/agent.py` (`Path` import) outside this change.