### PR TITLE
Fix missing Path import in polymarket bot agent

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Dict, List, Optional
 from datetime import datetime
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- add the missing `from pathlib import Path` import in `polymarket/bot/scripts/agent.py`
- restore startup for `polymarket-bot` when `_bootstrap_config_path` resolves the config file
- rely on the existing execution-safety startup test as the regression check

Closes #208