### PR TITLE
fix(polymarket): SELL orders buy NO tokens at live CLOB ask price (#218)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -158,35 +158,42 @@ class TradingAgent:
         """
         Cheap heuristic ranking to select the best candidates for LLM analysis.
 
-        No API calls. Ranks by a composite score of:
-        - Liquidity (higher = better)
-        - Price proximity to 50% (closer to 50% = more uncertain = more edge potential)
-        - Volume (if available)
+        Ranks by liquidity + volume (Gamma API prices are stale 0.50 seeds).
+        After ranking, enriches top candidates with live CLOB midpoint prices.
 
         Args:
             markets: Full list of fetched markets
             limit: Number of candidates to keep
 
         Returns:
-            Top N markets by heuristic score
+            Top N markets by heuristic score, enriched with live prices
         """
+        import math
+
         def score(m: Dict) -> float:
             liquidity = float(m.get('liquidity', 0))
-            price = float(m.get('price', 0.5))
             volume = float(m.get('volume', 0))
-            # Proximity to 50% — max uncertainty, most edge potential
-            uncertainty = 1.0 - abs(price - 0.5) * 2
-            # Normalise liquidity contribution (log scale to avoid domination)
-            import math
             liq_score = math.log1p(liquidity)
             vol_score = math.log1p(volume)
-            return liq_score + vol_score + uncertainty * 2
+            return liq_score + vol_score * 2
 
         ranked = sorted(markets, key=score, reverse=True)
-        selected = ranked[:limit]
-        dropped = len(markets) - len(selected)
-        print(f"  Ranked {len(markets)} markets → kept top {len(selected)} candidates (dropped {dropped})")
-        return selected
+        pre_selected = ranked[:limit]
+
+        # Enrich with live CLOB midpoint prices
+        enriched = []
+        for m in pre_selected:
+            try:
+                live_mid = self.polymarket.get_midpoint(m['token_id'])
+                if live_mid and 0.01 < live_mid < 0.99:
+                    m['price'] = live_mid
+            except Exception:
+                pass
+            enriched.append(m)
+
+        dropped = len(markets) - len(enriched)
+        print(f"  Ranked {len(markets)} markets → kept top {len(enriched)} candidates (dropped {dropped})")
+        return enriched
 
     def research_opportunity(self, market_question: str) -> str:
         """
@@ -362,14 +369,29 @@ class TradingAgent:
             return True
 
         # Execute actual trade
-        try:
-            print(f"    📊 Placing {side} order...")
+        # On Polymarket CLOB, "SELL" means betting against the outcome.
+        # This is done by BUYing the NO token at the live ask price.
+        if side == 'SELL' and market.get('no_token_id'):
+            exec_token_id = market['no_token_id']
+            exec_side = 'BUY'
+            try:
+                no_ask_price = self.polymarket.get_price(exec_token_id, 'BUY')
+                exec_price = no_ask_price if no_ask_price and no_ask_price > 0 else 1.0 - price
+            except Exception:
+                exec_price = 1.0 - price
+            print(f"    📊 Placing BUY NO order @ {exec_price:.4f} (betting against YES @ {price*100:.1f}%)...")
+        else:
+            exec_token_id = market['token_id']
+            exec_side = side
+            exec_price = price
+            print(f"    📊 Placing {side} order @ {exec_price:.4f}...")
 
+        try:
             order = self.polymarket.place_order(
-                token_id=market['token_id'],
-                side=side,
+                token_id=exec_token_id,
+                side=exec_side,
                 size=size,
-                price=price
+                price=exec_price
             )
 
             print(f"    ✓ Order placed: {order.get('orderID', 'unknown')}")
@@ -378,7 +400,7 @@ class TradingAgent:
             self.positions.add_position(
                 market=market['question'],
                 market_id=market['market_id'],
-                token_id=market['token_id'],
+                token_id=exec_token_id,
                 side=side,
                 entry_price=price,
                 size=size

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -96,7 +96,8 @@ class PolymarketClient:
             if not token_ids:
                 continue
 
-            token_id = token_ids[0]
+            yes_token_id = token_ids[0]
+            no_token_id = token_ids[1] if len(token_ids) > 1 else None
 
             outcome_prices = market_data.get('outcomePrices', ['0.5'])
             try:
@@ -114,7 +115,8 @@ class PolymarketClient:
             markets.append({
                 'market_id': market_id,
                 'question': question,
-                'token_id': token_id,
+                'token_id': yes_token_id,
+                'no_token_id': no_token_id,
                 'price': price,
                 'volume': volume,
                 'liquidity': liquidity,
@@ -188,27 +190,32 @@ class PolymarketClient:
         except Exception:
             return 0.0
 
-    def get_price(self, token_id: str, side: str) -> float:
-        """Get current price for a token from the CLOB orderbook."""
+    def _get_book_levels(self, token_id: str):
+        """Get best bid/ask from CLOB, falling back to raw data if parsed lists are empty."""
         from polymarket_live import fetch_book
-
-        book = fetch_book(token_id)
-        if side.upper() == 'BUY':
-            asks = book.get('asks', [])
-            return float(asks[0]['price']) if asks else 0.0
-        else:
-            bids = book.get('bids', [])
-            return float(bids[0]['price']) if bids else 0.0
-
-    def get_midpoint(self, token_id: str) -> float:
-        """Get midpoint price (average of best bid and ask)."""
-        from polymarket_live import fetch_book
-
         book = fetch_book(token_id)
         bids = book.get('bids', [])
         asks = book.get('asks', [])
+        if not bids or not asks:
+            raw = book.get('raw', {})
+            if isinstance(raw, dict):
+                bids = bids or raw.get('bids', [])
+                asks = asks or raw.get('asks', [])
         best_bid = float(bids[0]['price']) if bids else 0.0
         best_ask = float(asks[0]['price']) if asks else 0.0
+        return best_bid, best_ask
+
+    def get_price(self, token_id: str, side: str) -> float:
+        """Get current price for a token from the CLOB orderbook."""
+        best_bid, best_ask = self._get_book_levels(token_id)
+        if side.upper() == 'BUY':
+            return best_ask
+        else:
+            return best_bid
+
+    def get_midpoint(self, token_id: str) -> float:
+        """Get midpoint price (average of best bid and ask)."""
+        best_bid, best_ask = self._get_book_levels(token_id)
         if best_bid and best_ask:
             return (best_bid + best_ask) / 2.0
         return best_bid or best_ask

--- a/polymarket/bot/scripts/test_buy_no_token.py
+++ b/polymarket/bot/scripts/test_buy_no_token.py
@@ -1,0 +1,124 @@
+"""
+Tests for BUY NO token execution path and book-level fallback.
+Covers: #218 — SELL orders must BUY NO tokens at live ask price.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from polymarket_client import PolymarketClient
+
+
+def _mock_seren():
+    client = MagicMock()
+    client.call_publisher = MagicMock()
+    return client
+
+
+class TestGetMarketsExposesNoTokenId:
+    def test_no_token_id_present_when_two_clob_tokens(self):
+        seren = _mock_seren()
+        seren.call_publisher.return_value = {
+            "body": [
+                {
+                    "conditionId": "0xabc",
+                    "question": "Will X happen?",
+                    "clobTokenIds": '["YES_TOKEN", "NO_TOKEN"]',
+                    "outcomePrices": '["0.6", "0.4"]',
+                    "volume": "5000",
+                    "liquidity": "10000",
+                    "endDateIso": "2026-12-31",
+                    "active": True,
+                }
+            ]
+        }
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+        markets = client.get_markets(limit=10)
+        assert len(markets) == 1
+        assert markets[0]["token_id"] == "YES_TOKEN"
+        assert markets[0]["no_token_id"] == "NO_TOKEN"
+
+    def test_no_token_id_none_when_single_clob_token(self):
+        seren = _mock_seren()
+        seren.call_publisher.return_value = {
+            "body": [
+                {
+                    "conditionId": "0xabc",
+                    "question": "Will X happen?",
+                    "clobTokenIds": '["YES_TOKEN"]',
+                    "outcomePrices": '["0.5"]',
+                    "volume": "5000",
+                    "liquidity": "10000",
+                    "endDateIso": "2026-12-31",
+                    "active": True,
+                }
+            ]
+        }
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+        markets = client.get_markets(limit=10)
+        assert markets[0]["no_token_id"] is None
+
+
+class TestBookLevelFallback:
+    def test_get_book_levels_uses_raw_when_parsed_empty(self, monkeypatch):
+        seren = _mock_seren()
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+
+        monkeypatch.setattr(
+            "polymarket_live.fetch_book",
+            lambda token_id: {
+                "bids": [],
+                "asks": [],
+                "raw": {
+                    "bids": [{"price": "0.001", "size": "100"}],
+                    "asks": [{"price": "0.999", "size": "100"}],
+                },
+            },
+        )
+
+        best_bid, best_ask = client._get_book_levels("TOKEN-1")
+        assert best_bid == 0.001
+        assert best_ask == 0.999
+
+    def test_get_midpoint_from_raw_book(self, monkeypatch):
+        seren = _mock_seren()
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+
+        monkeypatch.setattr(
+            "polymarket_live.fetch_book",
+            lambda token_id: {
+                "bids": [],
+                "asks": [],
+                "raw": {
+                    "bids": [{"price": "0.30", "size": "100"}],
+                    "asks": [{"price": "0.70", "size": "100"}],
+                },
+            },
+        )
+
+        mid = client.get_midpoint("TOKEN-1")
+        assert mid == pytest.approx(0.50, abs=0.001)
+
+    def test_get_price_buy_returns_ask(self, monkeypatch):
+        seren = _mock_seren()
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+
+        monkeypatch.setattr(
+            "polymarket_live.fetch_book",
+            lambda token_id: {
+                "bids": [],
+                "asks": [],
+                "raw": {
+                    "bids": [{"price": "0.40", "size": "100"}],
+                    "asks": [{"price": "0.60", "size": "100"}],
+                },
+            },
+        )
+
+        assert client.get_price("TOKEN-1", "BUY") == 0.60
+        assert client.get_price("TOKEN-1", "SELL") == 0.40


### PR DESCRIPTION
## Summary
- Convert SELL opportunities to BUY NO token orders using `clobTokenIds[1]`
- Fetch live NO token ask price from CLOB instead of naive `1 - YES_price`
- Fall back to raw book data when parsed bid/ask lists are empty
- Rank candidates by liquidity+volume (Gamma API prices are stale 0.50 seeds)
- Expose `no_token_id` in market data from `get_markets()`

## Test plan
- [x] `test_buy_no_token.py` — 5 tests covering NO token exposure, book fallback, price extraction
- [x] Existing `test_polymarket_client_auth.py` — all 5 pass
- [x] Live-tested: 16 positions filled at $0.999 on Polymarket CLOB

Closes #218

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com