### PR TITLE
fix(polymarket): add safety guards for annualized return, resolution date, exit liquidity (#220)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -81,6 +81,11 @@ class TradingAgent:
         self.max_positions = int(self.config['max_positions'])
         self.stop_loss_bankroll = float(self.config.get('stop_loss_bankroll', 0.0))
 
+        # Safety guards (configurable, with backward-compatible defaults)
+        self.min_annualized_return = float(self.config.get('min_annualized_return', 0.25))
+        self.max_resolution_days = int(self.config.get('max_resolution_days', 180))
+        self.min_exit_bid_depth_ratio = float(self.config.get('min_exit_bid_depth_ratio', 0.5))
+
         # Scan pipeline limits (configurable, with backward-compatible defaults)
         self.scan_limit = int(self.config.get('scan_limit', 100))
         self.candidate_limit = int(self.config.get('candidate_limit', 20))
@@ -178,7 +183,30 @@ class TradingAgent:
             return liq_score + vol_score * 2
 
         ranked = sorted(markets, key=score, reverse=True)
-        pre_selected = ranked[:limit]
+
+        # Filter out markets resolving too far in the future
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        time_filtered = []
+        for m in ranked:
+            end_date_str = m.get('end_date', '')
+            if end_date_str:
+                try:
+                    end_dt = datetime.fromisoformat(end_date_str.replace('Z', '+00:00'))
+                    days_to_resolution = (end_dt - now).days
+                    m['days_to_resolution'] = max(days_to_resolution, 0)
+                    if days_to_resolution > self.max_resolution_days:
+                        continue  # skip far-out markets
+                except (ValueError, TypeError):
+                    m['days_to_resolution'] = 0
+            else:
+                m['days_to_resolution'] = 0
+            time_filtered.append(m)
+
+        if len(ranked) - len(time_filtered) > 0:
+            print(f"  Filtered {len(ranked) - len(time_filtered)} markets resolving >{self.max_resolution_days} days out")
+
+        pre_selected = time_filtered[:limit]
 
         # Enrich with live CLOB midpoint prices
         enriched = []
@@ -274,6 +302,26 @@ class TradingAgent:
         # Check if edge exceeds threshold
         if edge < self.mispricing_threshold:
             print(f"    ✗ Edge {edge * 100:.1f}% below threshold {self.mispricing_threshold * 100:.1f}%")
+            return None
+
+        # Annualized return gate: edge must justify the lockup period
+        days_to_resolution = market.get('days_to_resolution', 0)
+        years_to_resolution = max(days_to_resolution / 365.0, 1.0 / 365.0)
+        annualized_return = kelly.calculate_annualized_return(edge, years_to_resolution)
+        if annualized_return < self.min_annualized_return:
+            print(f"    ✗ Annualized return {annualized_return * 100:.1f}% below {self.min_annualized_return * 100:.0f}% hurdle ({days_to_resolution}d to resolution)")
+            return None
+
+        # Exit liquidity check: ensure we can sell what we buy
+        try:
+            token_to_check = market.get('no_token_id') or market.get('token_id')
+            if token_to_check:
+                bid_price = self.polymarket.get_price(token_to_check, 'SELL')
+                if bid_price <= 0:
+                    print(f"    ✗ No exit liquidity: zero bids on order book")
+                    return None
+        except Exception:
+            print(f"    ✗ Could not verify exit liquidity")
             return None
 
         # Reject low confidence estimates

--- a/polymarket/bot/scripts/kelly.py
+++ b/polymarket/bot/scripts/kelly.py
@@ -139,6 +139,22 @@ def calculate_expected_value(
     return round(ev, 2)
 
 
+def calculate_annualized_return(edge: float, years_to_resolution: float) -> float:
+    """
+    Calculate annualized return from edge and time to resolution.
+
+    Args:
+        edge: Absolute edge (e.g. 0.13 for 13%)
+        years_to_resolution: Time until market resolves in years
+
+    Returns:
+        Annualized return (e.g. 0.52 for 52%/year)
+    """
+    if years_to_resolution <= 0:
+        return float('inf')
+    return edge / years_to_resolution
+
+
 # Example usage and tests
 if __name__ == '__main__':
     # Test case 1: Underpriced market (BUY)

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -1,0 +1,145 @@
+"""
+Tests for #220 — annualized return gate, resolution date filter, exit liquidity guard.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import kelly
+
+
+class TestAnnualizedReturn:
+    def test_short_horizon_high_return(self):
+        # 10% edge over 30 days = ~122% annualized
+        result = kelly.calculate_annualized_return(0.10, 30 / 365)
+        assert result > 1.0
+
+    def test_long_horizon_low_return(self):
+        # 0.1% edge over 2 years = 0.05% annualized — should fail any hurdle
+        result = kelly.calculate_annualized_return(0.001, 2.0)
+        assert result < 0.01
+
+    def test_zero_years_returns_inf(self):
+        result = kelly.calculate_annualized_return(0.10, 0.0)
+        assert result == float('inf')
+
+    def test_hurdle_boundary(self):
+        # Exactly 25% annualized: 0.25 edge over 1 year
+        result = kelly.calculate_annualized_return(0.25, 1.0)
+        assert abs(result - 0.25) < 1e-9
+
+
+class TestResolutionDateFilter:
+    """Test that rank_candidates filters markets resolving too far out."""
+
+    def _make_agent_with_config(self, max_resolution_days=180):
+        """Create a minimal agent-like object for testing rank_candidates."""
+        from unittest.mock import MagicMock
+        from datetime import datetime, timezone, timedelta
+
+        agent = MagicMock()
+        agent.max_resolution_days = max_resolution_days
+        agent.polymarket = MagicMock()
+        agent.polymarket.get_midpoint = MagicMock(return_value=0.5)
+
+        # Import the actual rank_candidates and bind it
+        from agent import TradingAgent
+        import types
+        agent.rank_candidates = types.MethodType(TradingAgent.rank_candidates, agent)
+        return agent
+
+    def test_filters_2028_markets(self):
+        agent = self._make_agent_with_config(max_resolution_days=180)
+        markets = [
+            {'question': 'Near market', 'end_date': '2026-06-01T00:00:00Z',
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1'},
+            {'question': '2028 market', 'end_date': '2028-11-01T00:00:00Z',
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok2'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Near market' in questions
+        assert '2028 market' not in questions
+
+    def test_keeps_near_term_markets(self):
+        agent = self._make_agent_with_config(max_resolution_days=365)
+        markets = [
+            {'question': 'Soon', 'end_date': '2026-05-01T00:00:00Z',
+             'liquidity': 500, 'volume': 1000, 'token_id': 'tok1'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 1
+
+
+class TestEvaluateOpportunityGuards:
+    """Test that evaluate_opportunity rejects bad trades."""
+
+    def _make_agent(self):
+        from unittest.mock import MagicMock
+        agent = MagicMock()
+        agent.mispricing_threshold = 0.08
+        agent.min_annualized_return = 0.25
+        agent.max_positions = 10
+        agent.stop_loss_bankroll = 0.0
+        agent.bankroll = 100.0
+        agent.max_kelly_fraction = 0.06
+        agent.positions = MagicMock()
+        agent.positions.has_position.return_value = False
+        agent.positions.get_all_positions.return_value = []
+        agent.positions.get_current_bankroll.return_value = 100.0
+        agent.positions.get_available_capital.return_value = 100.0
+        agent.polymarket = MagicMock()
+        agent.polymarket.get_price.return_value = 0.95  # has exit liquidity
+
+        from agent import TradingAgent
+        import types
+        agent.evaluate_opportunity = types.MethodType(
+            TradingAgent.evaluate_opportunity, agent
+        )
+        return agent
+
+    def test_rejects_low_annualized_return(self):
+        agent = self._make_agent()
+        # 99% edge but 3 years out = 33% annualized, passes
+        # 0.1% edge but 2 years out = 0.05% annualized, fails
+        market = {
+            'market_id': 'mkt1', 'price': 0.001, 'question': 'Long shot',
+            'token_id': 'tok1', 'no_token_id': 'tok2',
+            'days_to_resolution': 730,  # 2 years
+        }
+        result = agent.evaluate_opportunity(
+            market, 'research', fair_value=0.002, confidence='high'
+        )
+        # Edge is 0.001, annualized = 0.001/2 = 0.0005 = 0.05% — below 25%
+        assert result is None
+
+    def test_accepts_good_annualized_return(self):
+        agent = self._make_agent()
+        market = {
+            'market_id': 'mkt2', 'price': 0.50, 'question': 'Good trade',
+            'token_id': 'tok1', 'no_token_id': 'tok2',
+            'days_to_resolution': 30,  # 1 month out
+        }
+        result = agent.evaluate_opportunity(
+            market, 'research', fair_value=0.65, confidence='high'
+        )
+        # Edge=0.15, years=30/365=0.082, annualized=1.83 = 183% — well above hurdle
+        assert result is not None
+        assert result['edge'] == pytest.approx(0.15, abs=0.01)
+
+    def test_rejects_zero_exit_liquidity(self):
+        agent = self._make_agent()
+        agent.polymarket.get_price.return_value = 0.0  # no bids
+        market = {
+            'market_id': 'mkt3', 'price': 0.40, 'question': 'No liquidity',
+            'token_id': 'tok1', 'no_token_id': 'tok2',
+            'days_to_resolution': 30,
+        }
+        result = agent.evaluate_opportunity(
+            market, 'research', fair_value=0.60, confidence='high'
+        )
+        assert result is None


### PR DESCRIPTION
## Summary
- **Annualized return gate**: rejects trades where edge / years_to_resolution < 25% hurdle
- **Resolution date filter**: drops markets resolving >180 days out from candidate ranking
- **Exit liquidity guard**: checks bid-side order book before entering positions

## Context
Bot deployed $111.18 into 17 illiquid 2028 NO token positions earning $0.11 over 2 years. Emergency unwind recovered $0.10. Root cause: no time-adjusted return check, no resolution filter, no exit liquidity validation.

## Test plan
- [x] 4 tests for calculate_annualized_return() in kelly.py
- [x] 2 tests for resolution date filtering in rank_candidates()
- [x] 3 tests for annualized return + exit liquidity in evaluate_opportunity()
- [x] All 14 tests pass (9 new + 5 existing)

Closes #220

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com