### PR TITLE
fix(ci): harden trading-skill-safety base ref diffing

### DIFF
--- a/.github/workflows/trading-skill-safety.yml
+++ b/.github/workflows/trading-skill-safety.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Fetch pull request base branch
         if: github.event_name == 'pull_request'
-        run: git fetch origin "${{ github.base_ref }}" --depth=1
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" --depth=1
 
       - name: Validate changed trading skills
         if: github.event_name == 'pull_request'

--- a/scripts/validate_trading_skill_safety.py
+++ b/scripts/validate_trading_skill_safety.py
@@ -295,6 +295,17 @@ def run_git(*args: str) -> str:
     return completed.stdout
 
 
+def git_ref_exists(ref: str) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode == 0
+
+
 def discover_skill_dirs() -> list[Path]:
     return sorted(path.parent for path in ROOT.glob("*/*/SKILL.md"))
 
@@ -310,7 +321,17 @@ def skill_dir_from_path(path_str: str) -> Path | None:
 
 
 def changed_skill_dirs(base_ref: str) -> dict[Path, list[Path]]:
-    stdout = run_git("diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base_ref}...HEAD")
+    diff_args = ("diff", "--name-only", "--diff-filter=ACMRTUXB")
+    try:
+        stdout = run_git(*diff_args, f"{base_ref}...HEAD")
+    except subprocess.CalledProcessError as exc:
+        if not git_ref_exists(base_ref):
+            stderr = (exc.stderr or exc.stdout or "").strip()
+            detail = f": {stderr}" if stderr else "."
+            raise RuntimeError(
+                f"Unable to diff against base ref `{base_ref}`. Ensure the ref is fetched in CI{detail}"
+            ) from exc
+        stdout = run_git(*diff_args, f"{base_ref}..HEAD")
     changed: dict[Path, list[Path]] = {}
     for raw in stdout.splitlines():
         skill_dir = skill_dir_from_path(raw)
@@ -786,7 +807,11 @@ def main() -> int:
         skill_dirs = discover_skill_dirs()
         changed_map = {skill_dir: [] for skill_dir in skill_dirs}
     elif args.base_ref:
-        changed_map = changed_skill_dirs(args.base_ref)
+        try:
+            changed_map = changed_skill_dirs(args.base_ref)
+        except RuntimeError as exc:
+            print(f"Git error: {exc}", file=sys.stderr)
+            return 2
         skill_dirs = sorted(changed_map)
     else:
         print("Choose `--all`, `--base-ref`, or one or more `--skill` values.", file=sys.stderr)

--- a/tests/test_validate_trading_skill_safety.py
+++ b/tests/test_validate_trading_skill_safety.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -191,3 +192,67 @@ def test_marketable_sell_plan_uses_min_tick_and_full_bid_sweep():
     assert result.is_trading is True
     assert result.violations == []
     assert "runtime_scheduler_safety" in result.waived_rules or not context.has_scheduler
+
+
+def test_changed_skill_dirs_falls_back_to_two_dot_diff(tmp_path, monkeypatch) -> None:
+    skill_dir = tmp_path / "coinbase" / "grid-trader"
+    _write(
+        skill_dir / "SKILL.md",
+        """---
+name: grid-trader
+description: Trade BTC automatically with a grid bot.
+---
+""",
+    )
+
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run_git(*args: str) -> str:
+        calls.append(args)
+        if args[-1] == "origin/main...HEAD":
+            raise subprocess.CalledProcessError(
+                128,
+                ["git", *args],
+                stderr="fatal: no merge base",
+            )
+        if args[-1] == "origin/main..HEAD":
+            return "coinbase/grid-trader/scripts/agent.py\nREADME.md\n"
+        raise AssertionError(f"Unexpected git invocation: {args}")
+
+    monkeypatch.setattr(MODULE, "ROOT", tmp_path)
+    monkeypatch.setattr(MODULE, "run_git", fake_run_git)
+    monkeypatch.setattr(MODULE, "git_ref_exists", lambda ref: ref == "origin/main")
+
+    changed = MODULE.changed_skill_dirs("origin/main")
+
+    assert changed == {
+        skill_dir: [Path("coinbase/grid-trader/scripts/agent.py")],
+    }
+    assert calls == [
+        ("diff", "--name-only", "--diff-filter=ACMRTUXB", "origin/main...HEAD"),
+        ("diff", "--name-only", "--diff-filter=ACMRTUXB", "origin/main..HEAD"),
+    ]
+
+
+def test_changed_skill_dirs_reports_missing_base_ref(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(MODULE, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        MODULE,
+        "run_git",
+        lambda *args: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(
+                128,
+                ["git", *args],
+                stderr="fatal: ambiguous argument 'origin/main...HEAD'",
+            )
+        ),
+    )
+    monkeypatch.setattr(MODULE, "git_ref_exists", lambda ref: False)
+
+    try:
+        MODULE.changed_skill_dirs("origin/main")
+    except RuntimeError as exc:
+        assert "origin/main" in str(exc)
+        assert "Ensure the ref is fetched in CI" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError for a missing base ref")


### PR DESCRIPTION
## Summary
- fetch the PR base branch into the expected `origin/<base>` remote-tracking ref before validation
- fall back from three-dot to two-dot diffing when the base ref exists but merge-base resolution fails
- add validator regression tests for both fallback and missing-base-ref error reporting

## Verification
- `python3 -m pytest tests/test_validate_trading_skill_safety.py`
- `python3 scripts/validate_trading_skill_safety.py --base-ref origin/main`