### PR TITLE
feat: emit post-cycle trade reports for trading skills

### DIFF
--- a/alpaca/saas-short-trader/scripts/serendb_storage.py
+++ b/alpaca/saas-short-trader/scripts/serendb_storage.py
@@ -14,6 +14,8 @@ from uuid import uuid4
 import psycopg
 from psycopg.rows import dict_row
 
+from trade_reporting import ShortTradeReportEmitter
+
 
 SKILL_SLUG = "alpaca-saas-short-trader"
 STRATEGY_NAME = "saas-short-trader"
@@ -22,6 +24,10 @@ STRATEGY_NAME = "saas-short-trader"
 class SerenDBStorage:
     def __init__(self, dsn: str):
         self.dsn = dsn
+        self.reporter = ShortTradeReportEmitter(
+            skill_slug=SKILL_SLUG,
+            strategy_name=STRATEGY_NAME,
+        )
 
     def connect(self) -> psycopg.Connection:
         return psycopg.connect(self.dsn, row_factory=dict_row)
@@ -86,6 +92,12 @@ class SerenDBStorage:
         metadata: Dict[str, Any],
     ) -> str:
         run_id = str(uuid4())
+        self.reporter.start_run(
+            run_id,
+            mode=mode,
+            dry_run=mode != "live",
+            metadata=metadata,
+        )
         with self.connect() as conn:
             with conn.cursor() as cur:
                 cur.execute(
@@ -153,6 +165,8 @@ class SerenDBStorage:
                     ),
                 )
             conn.commit()
+        if status in {"completed", "failed", "blocked", "stopped"}:
+            self.reporter.finish_run(run_id, status=status, metadata_patch=metadata_patch)
 
     def insert_candidate_scores(self, run_id: str, rows: List[Dict[str, Any]]) -> None:
         with self.connect() as conn:
@@ -214,6 +228,7 @@ class SerenDBStorage:
             conn.commit()
 
     def insert_order_events(self, run_id: str, mode: str, events: List[Dict[str, Any]]) -> None:
+        self.reporter.record_order_events(run_id, events)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for e in events:
@@ -290,6 +305,7 @@ class SerenDBStorage:
             conn.commit()
 
     def upsert_position_marks(self, as_of_date: date, mode: str, rows: List[Dict[str, Any]], source_run_id: str) -> None:
+        self.reporter.record_position_marks(source_run_id, rows)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for r in rows:
@@ -417,6 +433,15 @@ class SerenDBStorage:
         max_drawdown: float,
         source_run_id: str,
     ) -> None:
+        self.reporter.record_pnl(
+            source_run_id,
+            realized_pnl=realized_pnl,
+            unrealized_pnl=unrealized_pnl,
+            gross_exposure=gross_exposure,
+            net_exposure=net_exposure,
+            hit_rate=hit_rate,
+            max_drawdown=max_drawdown,
+        )
         net_pnl = realized_pnl + unrealized_pnl
         period_start, period_end = self._period_bounds(as_of_date)
         with self.connect() as conn:

--- a/alpaca/saas-short-trader/scripts/trade_reporting.py
+++ b/alpaca/saas-short-trader/scripts/trade_reporting.py
@@ -1,0 +1,322 @@
+"""Post-cycle trade reporting helpers for SaaS short trader skills."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+class ShortTradeReportEmitter:
+    """Accumulates a single run and emits a structured post-cycle report."""
+
+    def __init__(self, *, skill_slug: str, strategy_name: str, logs_dir: str = "logs") -> None:
+        self.skill_slug = skill_slug
+        self.strategy_name = strategy_name
+        self.logs_dir = Path(logs_dir)
+        self.log_path = self.logs_dir / "trade_reports.jsonl"
+        self._runs: dict[str, dict[str, Any]] = {}
+
+    def start_run(self, run_id: str, *, mode: str, dry_run: bool, metadata: dict[str, Any] | None = None) -> None:
+        self._runs[run_id] = {
+            "run_id": run_id,
+            "mode": mode,
+            "dry_run": dry_run,
+            "started_at": _now_iso(),
+            "metadata": dict(metadata or {}),
+            "order_events": [],
+            "marks": {},
+            "pnl": None,
+        }
+
+    def record_order_events(self, run_id: str, events: list[dict[str, Any]]) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        run["order_events"].extend(json.loads(json.dumps(events, default=str)))
+
+    def record_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            ticker = _first_text(row.get("ticker"), row.get("symbol"), row.get("position_key"))
+            if not ticker:
+                continue
+            run["marks"][ticker] = json.loads(json.dumps(row, default=str))
+
+    def record_pnl(
+        self,
+        run_id: str,
+        *,
+        realized_pnl: float,
+        unrealized_pnl: float,
+        gross_exposure: float,
+        net_exposure: float,
+        hit_rate: float,
+        max_drawdown: float,
+    ) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        net_pnl = float(realized_pnl) + float(unrealized_pnl)
+        run["pnl"] = {
+            "realized_pnl_usd": float(realized_pnl),
+            "unrealized_pnl_usd": float(unrealized_pnl),
+            "gross_pnl_usd": net_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_end_usd": net_pnl,
+            "gross_exposure": float(gross_exposure),
+            "net_exposure": float(net_exposure),
+            "hit_rate": float(hit_rate),
+            "max_drawdown": float(max_drawdown),
+        }
+
+    def finish_run(self, run_id: str, *, status: str, metadata_patch: dict[str, Any]) -> None:
+        run = self._runs.pop(run_id, None)
+        if run is None:
+            return
+        report = self._build_report(run, status=status, metadata_patch=metadata_patch)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+        if os.getenv("PYTHONUNBUFFERED") == "1":
+            self._print_report(report)
+
+    def _build_report(self, run: dict[str, Any], *, status: str, metadata_patch: dict[str, Any]) -> dict[str, Any]:
+        marks = run.get("marks", {})
+        pnl = run.get("pnl") or {}
+        previous_equity, peak_equity = self._history_stats(mode=str(run.get("mode") or ""))
+        equity_end = _float_or_none(pnl.get("equity_end_usd"))
+        drawdown_usd = _float_or_none(pnl.get("max_drawdown"))
+        drawdown_pct = None
+        if drawdown_usd is not None and peak_equity not in (None, 0.0):
+            drawdown_pct = drawdown_usd / peak_equity * 100.0
+        trades: list[dict[str, Any]] = []
+        fill_count = 0
+        for event in run.get("order_events", []):
+            if not isinstance(event, dict):
+                continue
+            details = event.get("details") if isinstance(event.get("details"), dict) else {}
+            ticker = _first_text(event.get("ticker"), event.get("symbol"), event.get("instrument_id"))
+            mark = marks.get(ticker or "")
+            filled_qty = _float_or_none(event.get("filled_qty"))
+            filled_price = _float_or_none(event.get("filled_avg_price"))
+            if filled_qty is not None and filled_price is not None:
+                fill_count += 1
+            trades.append(
+                {
+                    "order_id": event.get("order_ref"),
+                    "market": ticker,
+                    "market_id": ticker,
+                    "symbol": ticker,
+                    "side": event.get("side"),
+                    "quantity": _float_or_none(event.get("qty")),
+                    "entry_price": _float_or_none(details.get("entry_price")) or _float_or_none(event.get("limit_price")),
+                    "exit_price": filled_price if _first_text(details.get("close_reason")) else None,
+                    "current_price": _float_or_none(mark.get("mark_price")) if isinstance(mark, dict) else None,
+                    "fill_price": filled_price,
+                    "realized_pnl_usd": _float_or_none(details.get("realized_pnl")),
+                    "unrealized_pnl_usd": _float_or_none(mark.get("unrealized_pnl")) if isinstance(mark, dict) else None,
+                    "fee_usd": None,
+                    "fill_time": event.get("event_time"),
+                    "status": event.get("status"),
+                    "metadata": details,
+                }
+            )
+
+        open_positions = []
+        for ticker, mark in marks.items():
+            qty = _float_or_none(mark.get("qty"))
+            if qty is None or abs(qty) <= 1e-12:
+                continue
+            open_positions.append(
+                {
+                    "market": ticker,
+                    "market_id": ticker,
+                    "symbol": ticker,
+                    "side": "SELL" if qty < 0 else "BUY",
+                    "quantity": qty,
+                    "entry_price": _float_or_none(mark.get("avg_entry_price")),
+                    "current_price": _float_or_none(mark.get("mark_price")),
+                    "market_value_usd": _float_or_none(mark.get("market_value")),
+                    "realized_pnl_usd": _float_or_none(mark.get("realized_pnl")),
+                    "unrealized_pnl_usd": _float_or_none(mark.get("unrealized_pnl")),
+                    "metadata": {
+                        "gross_exposure": _float_or_none(mark.get("gross_exposure")),
+                        "net_exposure": _float_or_none(mark.get("net_exposure")),
+                    },
+                }
+            )
+
+        halt_reason = _first_text(
+            metadata_patch.get("error"),
+            metadata_patch.get("blocked_reason"),
+            metadata_patch.get("reason"),
+            metadata_patch.get("status"),
+        )
+        cycle_summary = {
+            "realized_pnl_usd": _float_or_none(pnl.get("realized_pnl_usd")),
+            "unrealized_pnl_usd": _float_or_none(pnl.get("unrealized_pnl_usd")),
+            "fees_usd": None,
+            "gross_pnl_usd": _float_or_none(pnl.get("gross_pnl_usd")),
+            "net_pnl_usd": _float_or_none(pnl.get("net_pnl_usd")),
+            "equity_start_usd": previous_equity,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": None
+            if previous_equity is None or equity_end is None
+            else equity_end - previous_equity,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(run.get("order_events", [])),
+            "fill_count": fill_count,
+            "halt_reason": halt_reason if status in {"failed", "blocked", "stopped"} else None,
+            "breach_positions": [],
+        }
+        return {
+            "generated_at": _now_iso(),
+            "run_id": run.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": "alpaca",
+            "strategy_name": self.strategy_name,
+            "mode": run.get("mode"),
+            "status": status,
+            "dry_run": bool(run.get("dry_run", True)),
+            "started_at": run.get("started_at"),
+            "completed_at": _now_iso(),
+            "summary": metadata_patch,
+            "metadata": {
+                **dict(run.get("metadata") or {}),
+                "max_drawdown": _float_or_none(pnl.get("max_drawdown")),
+                "gross_exposure": _float_or_none(pnl.get("gross_exposure")),
+                "net_exposure": _float_or_none(pnl.get("net_exposure")),
+                "hit_rate": _float_or_none(pnl.get("hit_rate")),
+            },
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        if not self.log_path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with self.log_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "net="
+            f"{_format_money(_float_or_none(cycle_summary.get('net_pnl_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Status"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        str(row.get("status") or "-"),
+                    ]
+                    for row in report.get("trades", [])
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in report.get("open_positions", [])
+                ],
+            )
+        )

--- a/alpaca/saas-short-trader/tests/test_alpaca_trade_reports.py
+++ b/alpaca/saas-short-trader/tests/test_alpaca_trade_reports.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+
+def _load_module(script_dir: Path, module_name: str):
+    sys.path[:] = [str(script_dir), *[path for path in sys.path if path != str(script_dir)]]
+    for cached_name in ("trade_reporting", "serendb_storage"):
+        sys.modules.pop(cached_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, script_dir / f"{module_name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params=None):
+        del query, params
+
+
+class _FakeConn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _FakeCursor()
+
+    def commit(self):
+        return None
+
+
+def test_storage_emits_trade_report_on_terminal_status(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTHONUNBUFFERED", "1")
+    psycopg_stub = types.ModuleType("psycopg")
+    psycopg_stub.connect = lambda *args, **kwargs: _FakeConn()
+    rows_stub = types.ModuleType("psycopg.rows")
+    rows_stub.dict_row = object()
+    sys.modules["psycopg"] = psycopg_stub
+    sys.modules["psycopg.rows"] = rows_stub
+
+    script_dir = Path(__file__).resolve().parents[1] / "scripts"
+    storage_module = _load_module(script_dir, "serendb_storage")
+    storage = storage_module.SerenDBStorage("postgresql://unused")
+    storage.connect = lambda: _FakeConn()
+
+    run_id = storage.insert_run(
+        mode="paper-sim",
+        universe=["SNOW"],
+        max_names_scored=30,
+        max_names_orders=8,
+        min_conviction=65.0,
+        status="running",
+        metadata={"run_type": "scan"},
+    )
+    storage.insert_order_events(
+        run_id,
+        "paper-sim",
+        [
+            {
+                "order_ref": "SNOW-open",
+                "ticker": "SNOW",
+                "side": "SELL",
+                "order_type": "limit",
+                "status": "planned",
+                "qty": 10.0,
+                "filled_qty": 10.0,
+                "filled_avg_price": 120.0,
+                "limit_price": 120.0,
+                "details": {"entry_price": 120.0, "planned_notional_usd": 1200.0},
+            }
+        ],
+    )
+    storage.upsert_position_marks(
+        date(2026, 3, 20),
+        "paper-sim",
+        [
+            {
+                "ticker": "SNOW",
+                "qty": 10.0,
+                "avg_entry_price": 120.0,
+                "mark_price": 110.0,
+                "market_value": 1100.0,
+                "realized_pnl": 0.0,
+                "unrealized_pnl": 100.0,
+                "gross_exposure": 1200.0,
+                "net_exposure": -1200.0,
+            }
+        ],
+        source_run_id=run_id,
+    )
+    storage.upsert_pnl_daily(
+        as_of_date=date(2026, 3, 20),
+        mode="paper-sim",
+        realized_pnl=0.0,
+        unrealized_pnl=100.0,
+        gross_exposure=1200.0,
+        net_exposure=-1200.0,
+        hit_rate=1.0,
+        max_drawdown=25.0,
+        source_run_id=run_id,
+    )
+    storage.update_run_status(run_id, "completed", {"selected_count": 1})
+
+    report_path = tmp_path / "logs" / "trade_reports.jsonl"
+    report = json.loads(report_path.read_text(encoding="utf-8").strip())
+    assert report["skill_slug"] == "alpaca-saas-short-trader"
+    assert report["status"] == "completed"
+    assert report["cycle_summary"]["fill_count"] == 1
+    assert report["open_positions"][0]["symbol"] == "SNOW"
+    assert report["trades"][0]["order_id"] == "SNOW-open"
+
+    stdout = capsys.readouterr().out
+    assert "[trade-report] alpaca-saas-short-trader" in stdout

--- a/alpaca/sass-short-trader-delta-neutral/scripts/serendb_storage.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/serendb_storage.py
@@ -14,6 +14,8 @@ from uuid import uuid4
 import psycopg
 from psycopg.rows import dict_row
 
+from trade_reporting import ShortTradeReportEmitter
+
 
 SKILL_SLUG = "alpaca-sass-short-trader-delta-neutral"
 STRATEGY_NAME = "sass-short-trader-delta-neutral"
@@ -22,6 +24,10 @@ STRATEGY_NAME = "sass-short-trader-delta-neutral"
 class SerenDBStorage:
     def __init__(self, dsn: str):
         self.dsn = dsn
+        self.reporter = ShortTradeReportEmitter(
+            skill_slug=SKILL_SLUG,
+            strategy_name=STRATEGY_NAME,
+        )
 
     def connect(self) -> psycopg.Connection:
         return psycopg.connect(self.dsn, row_factory=dict_row)
@@ -86,6 +92,12 @@ class SerenDBStorage:
         metadata: Dict[str, Any],
     ) -> str:
         run_id = str(uuid4())
+        self.reporter.start_run(
+            run_id,
+            mode=mode,
+            dry_run=mode != "live",
+            metadata=metadata,
+        )
         with self.connect() as conn:
             with conn.cursor() as cur:
                 cur.execute(
@@ -153,6 +165,8 @@ class SerenDBStorage:
                     ),
                 )
             conn.commit()
+        if status in {"completed", "failed", "blocked", "stopped"}:
+            self.reporter.finish_run(run_id, status=status, metadata_patch=metadata_patch)
 
     def insert_candidate_scores(self, run_id: str, rows: List[Dict[str, Any]]) -> None:
         with self.connect() as conn:
@@ -214,6 +228,7 @@ class SerenDBStorage:
             conn.commit()
 
     def insert_order_events(self, run_id: str, mode: str, events: List[Dict[str, Any]]) -> None:
+        self.reporter.record_order_events(run_id, events)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for e in events:
@@ -290,6 +305,7 @@ class SerenDBStorage:
             conn.commit()
 
     def upsert_position_marks(self, as_of_date: date, mode: str, rows: List[Dict[str, Any]], source_run_id: str) -> None:
+        self.reporter.record_position_marks(source_run_id, rows)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for r in rows:
@@ -417,6 +433,15 @@ class SerenDBStorage:
         max_drawdown: float,
         source_run_id: str,
     ) -> None:
+        self.reporter.record_pnl(
+            source_run_id,
+            realized_pnl=realized_pnl,
+            unrealized_pnl=unrealized_pnl,
+            gross_exposure=gross_exposure,
+            net_exposure=net_exposure,
+            hit_rate=hit_rate,
+            max_drawdown=max_drawdown,
+        )
         net_pnl = realized_pnl + unrealized_pnl
         period_start, period_end = self._period_bounds(as_of_date)
         with self.connect() as conn:

--- a/alpaca/sass-short-trader-delta-neutral/scripts/trade_reporting.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/trade_reporting.py
@@ -1,0 +1,322 @@
+"""Post-cycle trade reporting helpers for SaaS short trader skills."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+class ShortTradeReportEmitter:
+    """Accumulates a single run and emits a structured post-cycle report."""
+
+    def __init__(self, *, skill_slug: str, strategy_name: str, logs_dir: str = "logs") -> None:
+        self.skill_slug = skill_slug
+        self.strategy_name = strategy_name
+        self.logs_dir = Path(logs_dir)
+        self.log_path = self.logs_dir / "trade_reports.jsonl"
+        self._runs: dict[str, dict[str, Any]] = {}
+
+    def start_run(self, run_id: str, *, mode: str, dry_run: bool, metadata: dict[str, Any] | None = None) -> None:
+        self._runs[run_id] = {
+            "run_id": run_id,
+            "mode": mode,
+            "dry_run": dry_run,
+            "started_at": _now_iso(),
+            "metadata": dict(metadata or {}),
+            "order_events": [],
+            "marks": {},
+            "pnl": None,
+        }
+
+    def record_order_events(self, run_id: str, events: list[dict[str, Any]]) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        run["order_events"].extend(json.loads(json.dumps(events, default=str)))
+
+    def record_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            ticker = _first_text(row.get("ticker"), row.get("symbol"), row.get("position_key"))
+            if not ticker:
+                continue
+            run["marks"][ticker] = json.loads(json.dumps(row, default=str))
+
+    def record_pnl(
+        self,
+        run_id: str,
+        *,
+        realized_pnl: float,
+        unrealized_pnl: float,
+        gross_exposure: float,
+        net_exposure: float,
+        hit_rate: float,
+        max_drawdown: float,
+    ) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        net_pnl = float(realized_pnl) + float(unrealized_pnl)
+        run["pnl"] = {
+            "realized_pnl_usd": float(realized_pnl),
+            "unrealized_pnl_usd": float(unrealized_pnl),
+            "gross_pnl_usd": net_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_end_usd": net_pnl,
+            "gross_exposure": float(gross_exposure),
+            "net_exposure": float(net_exposure),
+            "hit_rate": float(hit_rate),
+            "max_drawdown": float(max_drawdown),
+        }
+
+    def finish_run(self, run_id: str, *, status: str, metadata_patch: dict[str, Any]) -> None:
+        run = self._runs.pop(run_id, None)
+        if run is None:
+            return
+        report = self._build_report(run, status=status, metadata_patch=metadata_patch)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+        if os.getenv("PYTHONUNBUFFERED") == "1":
+            self._print_report(report)
+
+    def _build_report(self, run: dict[str, Any], *, status: str, metadata_patch: dict[str, Any]) -> dict[str, Any]:
+        marks = run.get("marks", {})
+        pnl = run.get("pnl") or {}
+        previous_equity, peak_equity = self._history_stats(mode=str(run.get("mode") or ""))
+        equity_end = _float_or_none(pnl.get("equity_end_usd"))
+        drawdown_usd = _float_or_none(pnl.get("max_drawdown"))
+        drawdown_pct = None
+        if drawdown_usd is not None and peak_equity not in (None, 0.0):
+            drawdown_pct = drawdown_usd / peak_equity * 100.0
+        trades: list[dict[str, Any]] = []
+        fill_count = 0
+        for event in run.get("order_events", []):
+            if not isinstance(event, dict):
+                continue
+            details = event.get("details") if isinstance(event.get("details"), dict) else {}
+            ticker = _first_text(event.get("ticker"), event.get("symbol"), event.get("instrument_id"))
+            mark = marks.get(ticker or "")
+            filled_qty = _float_or_none(event.get("filled_qty"))
+            filled_price = _float_or_none(event.get("filled_avg_price"))
+            if filled_qty is not None and filled_price is not None:
+                fill_count += 1
+            trades.append(
+                {
+                    "order_id": event.get("order_ref"),
+                    "market": ticker,
+                    "market_id": ticker,
+                    "symbol": ticker,
+                    "side": event.get("side"),
+                    "quantity": _float_or_none(event.get("qty")),
+                    "entry_price": _float_or_none(details.get("entry_price")) or _float_or_none(event.get("limit_price")),
+                    "exit_price": filled_price if _first_text(details.get("close_reason")) else None,
+                    "current_price": _float_or_none(mark.get("mark_price")) if isinstance(mark, dict) else None,
+                    "fill_price": filled_price,
+                    "realized_pnl_usd": _float_or_none(details.get("realized_pnl")),
+                    "unrealized_pnl_usd": _float_or_none(mark.get("unrealized_pnl")) if isinstance(mark, dict) else None,
+                    "fee_usd": None,
+                    "fill_time": event.get("event_time"),
+                    "status": event.get("status"),
+                    "metadata": details,
+                }
+            )
+
+        open_positions = []
+        for ticker, mark in marks.items():
+            qty = _float_or_none(mark.get("qty"))
+            if qty is None or abs(qty) <= 1e-12:
+                continue
+            open_positions.append(
+                {
+                    "market": ticker,
+                    "market_id": ticker,
+                    "symbol": ticker,
+                    "side": "SELL" if qty < 0 else "BUY",
+                    "quantity": qty,
+                    "entry_price": _float_or_none(mark.get("avg_entry_price")),
+                    "current_price": _float_or_none(mark.get("mark_price")),
+                    "market_value_usd": _float_or_none(mark.get("market_value")),
+                    "realized_pnl_usd": _float_or_none(mark.get("realized_pnl")),
+                    "unrealized_pnl_usd": _float_or_none(mark.get("unrealized_pnl")),
+                    "metadata": {
+                        "gross_exposure": _float_or_none(mark.get("gross_exposure")),
+                        "net_exposure": _float_or_none(mark.get("net_exposure")),
+                    },
+                }
+            )
+
+        halt_reason = _first_text(
+            metadata_patch.get("error"),
+            metadata_patch.get("blocked_reason"),
+            metadata_patch.get("reason"),
+            metadata_patch.get("status"),
+        )
+        cycle_summary = {
+            "realized_pnl_usd": _float_or_none(pnl.get("realized_pnl_usd")),
+            "unrealized_pnl_usd": _float_or_none(pnl.get("unrealized_pnl_usd")),
+            "fees_usd": None,
+            "gross_pnl_usd": _float_or_none(pnl.get("gross_pnl_usd")),
+            "net_pnl_usd": _float_or_none(pnl.get("net_pnl_usd")),
+            "equity_start_usd": previous_equity,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": None
+            if previous_equity is None or equity_end is None
+            else equity_end - previous_equity,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(run.get("order_events", [])),
+            "fill_count": fill_count,
+            "halt_reason": halt_reason if status in {"failed", "blocked", "stopped"} else None,
+            "breach_positions": [],
+        }
+        return {
+            "generated_at": _now_iso(),
+            "run_id": run.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": "alpaca",
+            "strategy_name": self.strategy_name,
+            "mode": run.get("mode"),
+            "status": status,
+            "dry_run": bool(run.get("dry_run", True)),
+            "started_at": run.get("started_at"),
+            "completed_at": _now_iso(),
+            "summary": metadata_patch,
+            "metadata": {
+                **dict(run.get("metadata") or {}),
+                "max_drawdown": _float_or_none(pnl.get("max_drawdown")),
+                "gross_exposure": _float_or_none(pnl.get("gross_exposure")),
+                "net_exposure": _float_or_none(pnl.get("net_exposure")),
+                "hit_rate": _float_or_none(pnl.get("hit_rate")),
+            },
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        if not self.log_path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with self.log_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "net="
+            f"{_format_money(_float_or_none(cycle_summary.get('net_pnl_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Status"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        str(row.get("status") or "-"),
+                    ]
+                    for row in report.get("trades", [])
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in report.get("open_positions", [])
+                ],
+            )
+        )

--- a/alphagrowth/euler-base-vault-bot/scripts/agent.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/agent.py
@@ -189,8 +189,6 @@ def _persist_normalized_result(config: dict, result: dict, *, run_type: str) -> 
         venue="euler",
         strategy_name="euler-base-vault-bot",
     )
-    if not store.enabled:
-        return
     inputs = config.get("inputs", {}) if isinstance(config.get("inputs"), dict) else {}
     action = str(inputs.get("action", "status"))
     order_events = [

--- a/alphagrowth/euler-base-vault-bot/scripts/normalized_trade_store.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/coinbase/grid-trader/scripts/serendb_store.py
+++ b/coinbase/grid-trader/scripts/serendb_store.py
@@ -10,6 +10,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from trade_reporting import CycleTradeReportEmitter
+
 
 class SerenMCPError(RuntimeError):
     """Raised when a local seren-mcp tool call fails."""
@@ -199,6 +201,22 @@ class SerenDBStore:
         self._target: Optional[DBTarget] = None
         self._mcp = _SerenMCPClient(api_key=api_key, mcp_command=mcp_command)
         self._mcp.start()
+        self._reporter = CycleTradeReportEmitter(
+            skill_slug="coinbase-grid-trader",
+            venue="coinbase",
+            strategy_name="grid-trader",
+        )
+
+    def _ensure_reporter(self) -> CycleTradeReportEmitter:
+        reporter = getattr(self, "_reporter", None)
+        if reporter is None:
+            reporter = CycleTradeReportEmitter(
+                skill_slug="coinbase-grid-trader",
+                venue="coinbase",
+                strategy_name="grid-trader",
+            )
+            self._reporter = reporter
+        return reporter
 
     def close(self) -> None:
         self._mcp.close()
@@ -385,6 +403,13 @@ class SerenDBStore:
         self._execute_sql(ddl)
 
     def create_session(self, session_id: str, campaign_name: str, trading_pair: str, dry_run: bool) -> None:
+        self._ensure_reporter().start_session(
+            session_id,
+            mode="paper" if dry_run else "live",
+            dry_run=dry_run,
+            instrument_id=trading_pair,
+            metadata={"campaign_name": campaign_name},
+        )
         query = f"""
         INSERT INTO coinbase_grid_sessions (session_id, campaign_name, trading_pair, dry_run)
         VALUES (
@@ -428,6 +453,15 @@ class SerenDBStore:
         status: str,
         payload: Optional[Dict[str, Any]] = None,
     ) -> None:
+        self._ensure_reporter().record_order(
+            session_id,
+            order_id=order_id,
+            side=side,
+            price=price,
+            quantity=size,
+            status=status,
+            metadata=payload or {},
+        )
         query = f"""
         INSERT INTO coinbase_grid_orders (session_id, order_id, side, price, size, status, payload)
         VALUES (
@@ -472,6 +506,15 @@ class SerenDBStore:
         cost: float,
         payload: Optional[Dict[str, Any]] = None,
     ) -> None:
+        self._ensure_reporter().record_fill(
+            session_id,
+            order_id=order_id,
+            side=side,
+            price=price,
+            quantity=size,
+            fee_usd=fee,
+            metadata=payload or {},
+        )
         query = f"""
         INSERT INTO coinbase_grid_fills (session_id, order_id, side, price, size, fee, cost, payload)
         VALUES (
@@ -514,6 +557,15 @@ class SerenDBStore:
         unrealized_pnl: float,
         open_orders: int,
     ) -> None:
+        self._ensure_reporter().record_position(
+            session_id,
+            instrument_id=trading_pair,
+            base_balance=base_balance,
+            quote_balance=quote_balance,
+            total_value_usd=total_value_usd,
+            unrealized_pnl_usd=unrealized_pnl,
+            open_orders=open_orders,
+        )
         query = f"""
         INSERT INTO coinbase_grid_positions (
             session_id,
@@ -588,6 +640,8 @@ class SerenDBStore:
         self._execute_sql(query)
 
     def save_event(self, session_id: str, event_type: str, payload: Dict[str, Any]) -> None:
+        terminal_status = self._normalized_terminal_status(event_type)
+        self._ensure_reporter().record_event(session_id, event_type=event_type, payload=payload, status=terminal_status)
         query = f"""
         INSERT INTO coinbase_grid_events (session_id, event_type, payload)
         VALUES (
@@ -608,7 +662,6 @@ class SerenDBStore:
             {self._sql_json(payload)}
         );
         """
-        terminal_status = self._normalized_terminal_status(event_type)
         if terminal_status:
             query += f"""
             UPDATE trading.strategy_runs

--- a/coinbase/grid-trader/scripts/trade_reporting.py
+++ b/coinbase/grid-trader/scripts/trade_reporting.py
@@ -1,0 +1,369 @@
+"""Shared cycle trade reporting for grid-trader runtimes."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+class CycleTradeReportEmitter:
+    """Collect per-cycle grid events and emit structured reports."""
+
+    def __init__(self, *, skill_slug: str, venue: str, strategy_name: str, logs_dir: str = "logs") -> None:
+        self.skill_slug = skill_slug
+        self.venue = venue
+        self.strategy_name = strategy_name
+        self.logs_dir = Path(logs_dir)
+        self.log_path = self.logs_dir / "trade_reports.jsonl"
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    def start_session(
+        self,
+        session_id: str,
+        *,
+        mode: str,
+        dry_run: bool,
+        instrument_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._sessions[session_id] = {
+            "session_id": session_id,
+            "mode": mode,
+            "dry_run": dry_run,
+            "instrument_id": instrument_id,
+            "metadata": dict(metadata or {}),
+            "started_at": _now_iso(),
+            "cycle_index": 0,
+            "last_equity_end_usd": None,
+            "peak_equity_end_usd": None,
+            "current_position": None,
+            "cycle_order_events": [],
+            "cycle_fills": [],
+            "last_halt_reason": None,
+            "breach_positions": [],
+        }
+
+    def record_order(
+        self,
+        session_id: str,
+        *,
+        order_id: str,
+        side: str,
+        price: float,
+        quantity: float,
+        status: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["cycle_order_events"].append(
+            {
+                "order_id": order_id,
+                "side": side,
+                "price": float(price),
+                "quantity": float(quantity),
+                "status": status,
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    def record_fill(
+        self,
+        session_id: str,
+        *,
+        order_id: str,
+        side: str,
+        price: float,
+        quantity: float,
+        fee_usd: float,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["cycle_fills"].append(
+            {
+                "order_id": order_id,
+                "side": side,
+                "fill_price": float(price),
+                "quantity": float(quantity),
+                "fee_usd": float(fee_usd),
+                "fill_time": _now_iso(),
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    def record_position(
+        self,
+        session_id: str,
+        *,
+        instrument_id: str,
+        base_balance: float,
+        quote_balance: float,
+        total_value_usd: float,
+        unrealized_pnl_usd: float,
+        open_orders: int,
+        status: str = "running",
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        current_price = None
+        if abs(float(base_balance)) > 1e-12:
+            current_price = max((float(total_value_usd) - float(quote_balance)) / float(base_balance), 0.0)
+        session["current_position"] = {
+            "market": instrument_id,
+            "market_id": instrument_id,
+            "symbol": instrument_id,
+            "side": "LONG" if float(base_balance) > 0 else "FLAT",
+            "quantity": float(base_balance),
+            "current_price": current_price,
+            "quote_balance": float(quote_balance),
+            "market_value_usd": float(total_value_usd),
+            "unrealized_pnl_usd": float(unrealized_pnl_usd),
+            "open_orders": int(open_orders),
+        }
+        self._emit_report(session_id, status=status)
+
+    def record_event(self, session_id: str, *, event_type: str, payload: dict[str, Any], status: str | None) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["last_halt_reason"] = _first_text(
+            payload.get("error_message"),
+            payload.get("blocked_reason"),
+            payload.get("reason"),
+            event_type,
+        )
+        instrument = _first_text(payload.get("pair"), payload.get("product_id"))
+        if instrument:
+            breach = instrument
+            if breach not in session["breach_positions"]:
+                session["breach_positions"].append(breach)
+        if status:
+            self._emit_report(session_id, status=status, terminal_event=event_type, event_payload=payload)
+
+    def _emit_report(
+        self,
+        session_id: str,
+        *,
+        status: str,
+        terminal_event: str | None = None,
+        event_payload: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        position = session.get("current_position") or {}
+        equity_end = _float_or_none(position.get("market_value_usd"))
+        previous_equity = _float_or_none(session.get("last_equity_end_usd"))
+        peak_equity = _float_or_none(session.get("peak_equity_end_usd"))
+        if equity_end is not None:
+            peak_equity = equity_end if peak_equity is None else max(peak_equity, equity_end)
+        fees_usd = sum(_float_or_none(fill.get("fee_usd")) or 0.0 for fill in session["cycle_fills"])
+        cycle_summary = {
+            "realized_pnl_usd": None,
+            "unrealized_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+            "net_pnl_usd": None
+            if position.get("unrealized_pnl_usd") is None
+            else float(position["unrealized_pnl_usd"]) - fees_usd,
+            "equity_start_usd": previous_equity,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": None
+            if equity_end is None or previous_equity is None
+            else equity_end - previous_equity,
+            "drawdown_usd": None
+            if peak_equity is None or equity_end is None
+            else max(peak_equity - equity_end, 0.0),
+            "drawdown_pct": None
+            if peak_equity in (None, 0.0) or equity_end is None
+            else max(peak_equity - equity_end, 0.0) / peak_equity * 100.0,
+            "order_event_count": len(session["cycle_order_events"]),
+            "fill_count": len(session["cycle_fills"]),
+            "halt_reason": session.get("last_halt_reason"),
+            "breach_positions": list(session.get("breach_positions") or []),
+        }
+        trades = [
+            {
+                "order_id": fill.get("order_id"),
+                "market": position.get("market") or session.get("instrument_id"),
+                "market_id": position.get("market_id") or session.get("instrument_id"),
+                "symbol": position.get("symbol") or session.get("instrument_id"),
+                "side": fill.get("side"),
+                "quantity": fill.get("quantity"),
+                "entry_price": fill.get("fill_price"),
+                "exit_price": None,
+                "current_price": position.get("current_price"),
+                "fill_price": fill.get("fill_price"),
+                "realized_pnl_usd": None,
+                "unrealized_pnl_usd": position.get("unrealized_pnl_usd"),
+                "fee_usd": fill.get("fee_usd"),
+                "fill_time": fill.get("fill_time"),
+                "metadata": fill.get("metadata") or {},
+            }
+            for fill in session["cycle_fills"]
+        ]
+        open_positions = []
+        quantity = _float_or_none(position.get("quantity"))
+        if quantity is None or abs(quantity) > 1e-12:
+            open_positions.append(
+                {
+                    "market": position.get("market") or session.get("instrument_id"),
+                    "market_id": position.get("market_id") or session.get("instrument_id"),
+                    "symbol": position.get("symbol") or session.get("instrument_id"),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": None,
+                    "current_price": _float_or_none(position.get("current_price")),
+                    "market_value_usd": _float_or_none(position.get("market_value_usd")),
+                    "unrealized_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+                    "metadata": {
+                        "quote_balance": _float_or_none(position.get("quote_balance")),
+                        "open_orders": position.get("open_orders"),
+                    },
+                }
+            )
+
+        report = {
+            "generated_at": _now_iso(),
+            "run_id": session_id,
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": session.get("mode"),
+            "status": status,
+            "dry_run": bool(session.get("dry_run", True)),
+            "started_at": session.get("started_at"),
+            "completed_at": _now_iso() if terminal_event else None,
+            "summary": {
+                "cycle_index": session.get("cycle_index", 0) + 1,
+                "terminal_event": terminal_event,
+            },
+            "metadata": {
+                **dict(session.get("metadata") or {}),
+                "instrument_id": session.get("instrument_id"),
+                "event_payload": dict(event_payload or {}),
+            },
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+        if os.getenv("PYTHONUNBUFFERED") == "1":
+            self._print_report(report)
+
+        session["cycle_index"] = int(session.get("cycle_index", 0)) + 1
+        session["last_equity_end_usd"] = equity_end
+        session["peak_equity_end_usd"] = peak_equity
+        session["cycle_order_events"] = []
+        session["cycle_fills"] = []
+        if not terminal_event:
+            session["breach_positions"] = []
+            session["last_halt_reason"] = None
+        if terminal_event:
+            self._sessions.pop(session_id, None)
+
+    def _print_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in report.get("trades", [])
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in report.get("open_positions", [])
+                ],
+            )
+        )

--- a/coinbase/smart-dca-bot/scripts/normalized_trade_store.py
+++ b/coinbase/smart-dca-bot/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/coinbase/smart-dca-bot/scripts/serendb_store.py
+++ b/coinbase/smart-dca-bot/scripts/serendb_store.py
@@ -128,6 +128,14 @@ class SerenDBStore:
         return True
 
     def create_session(self, session_id: str, mode: str, config: dict[str, Any]) -> None:
+        self.normalized.start_run(
+            run_id=session_id,
+            mode=mode,
+            dry_run=bool(config.get("dry_run", True)),
+            config=config,
+            status="running",
+            metadata={"session_kind": "dca"},
+        )
         if not self.enabled:
             return
         self.connect()
@@ -142,14 +150,6 @@ class SerenDBStore:
                 (session_id, mode, json.dumps(config)),
             )
         self.conn.commit()
-        self.normalized.start_run(
-            run_id=session_id,
-            mode=mode,
-            dry_run=bool(config.get("dry_run", True)),
-            config=config,
-            status="running",
-            metadata={"session_kind": "dca"},
-        )
 
     def close_session(
         self,
@@ -159,22 +159,21 @@ class SerenDBStore:
         total_invested_usd: float,
         total_savings_bps: int,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE dca_sessions
-                SET ended_at = NOW(), status = %s,
-                    total_invested_usd = %s,
-                    total_savings_bps = %s
-                WHERE session_id = %s
-                """,
-                (status, total_invested_usd, total_savings_bps, session_id),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE dca_sessions
+                    SET ended_at = NOW(), status = %s,
+                        total_invested_usd = %s,
+                        total_savings_bps = %s
+                    WHERE session_id = %s
+                    """,
+                    (status, total_invested_usd, total_savings_bps, session_id),
+                )
+            self.conn.commit()
         self.normalized.finish_run(
             run_id=session_id,
             status=status,
@@ -186,38 +185,37 @@ class SerenDBStore:
         )
 
     def persist_execution(self, row: dict[str, Any]) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO dca_executions (
-                    execution_id, mode, asset, target_amount_usd,
-                    executed_amount_usd, executed_price, vwap_at_execution,
-                    savings_vs_naive_bps, strategy, window_start, window_end,
-                    executed_at, status, coinbase_order_id, metadata
-                ) VALUES (
-                    %(execution_id)s, %(mode)s, %(asset)s, %(target_amount_usd)s,
-                    %(executed_amount_usd)s, %(executed_price)s, %(vwap_at_execution)s,
-                    %(savings_vs_naive_bps)s, %(strategy)s, %(window_start)s, %(window_end)s,
-                    %(executed_at)s, %(status)s, %(coinbase_order_id)s, %(metadata)s
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO dca_executions (
+                        execution_id, mode, asset, target_amount_usd,
+                        executed_amount_usd, executed_price, vwap_at_execution,
+                        savings_vs_naive_bps, strategy, window_start, window_end,
+                        executed_at, status, coinbase_order_id, metadata
+                    ) VALUES (
+                        %(execution_id)s, %(mode)s, %(asset)s, %(target_amount_usd)s,
+                        %(executed_amount_usd)s, %(executed_price)s, %(vwap_at_execution)s,
+                        %(savings_vs_naive_bps)s, %(strategy)s, %(window_start)s, %(window_end)s,
+                        %(executed_at)s, %(status)s, %(coinbase_order_id)s, %(metadata)s
+                    )
+                    ON CONFLICT (execution_id) DO UPDATE SET
+                        status = EXCLUDED.status,
+                        executed_amount_usd = EXCLUDED.executed_amount_usd,
+                        executed_price = EXCLUDED.executed_price,
+                        executed_at = EXCLUDED.executed_at,
+                        coinbase_order_id = EXCLUDED.coinbase_order_id,
+                        metadata = EXCLUDED.metadata
+                    """,
+                    {
+                        **row,
+                        "metadata": json.dumps(row.get("metadata", {})),
+                    },
                 )
-                ON CONFLICT (execution_id) DO UPDATE SET
-                    status = EXCLUDED.status,
-                    executed_amount_usd = EXCLUDED.executed_amount_usd,
-                    executed_price = EXCLUDED.executed_price,
-                    executed_at = EXCLUDED.executed_at,
-                    coinbase_order_id = EXCLUDED.coinbase_order_id,
-                    metadata = EXCLUDED.metadata
-                """,
-                {
-                    **row,
-                    "metadata": json.dumps(row.get("metadata", {})),
-                },
-            )
-        self.conn.commit()
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             quantity = None
@@ -257,27 +255,26 @@ class SerenDBStore:
                 )
 
     def persist_portfolio_snapshot(self, row: dict[str, Any]) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO portfolio_snapshots (
-                    snapshot_id, total_value_usd, allocations, target_allocations, drift_max_pct
-                ) VALUES (%s, %s, %s, %s, %s)
-                ON CONFLICT (snapshot_id) DO NOTHING
-                """,
-                (
-                    row["snapshot_id"],
-                    row["total_value_usd"],
-                    json.dumps(row["allocations"]),
-                    json.dumps(row["target_allocations"]),
-                    row["drift_max_pct"],
-                ),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO portfolio_snapshots (
+                        snapshot_id, total_value_usd, allocations, target_allocations, drift_max_pct
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (snapshot_id) DO NOTHING
+                    """,
+                    (
+                        row["snapshot_id"],
+                        row["total_value_usd"],
+                        json.dumps(row["allocations"]),
+                        json.dumps(row["target_allocations"]),
+                        row["drift_max_pct"],
+                    ),
+                )
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             positions, marks = self._allocation_rows(row)
@@ -285,32 +282,31 @@ class SerenDBStore:
             self.normalized.insert_position_marks(session_id, marks)
 
     def persist_scanner_signal(self, row: dict[str, Any], user_action: str | None = None) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO scanner_signals (
-                    signal_id, signal_type, asset, confidence_pct,
-                    trigger_data, suggestion, reallocation_pct, user_action
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (signal_id) DO UPDATE SET
-                    user_action = EXCLUDED.user_action
-                """,
-                (
-                    row["signal_id"],
-                    row["signal_type"],
-                    row["asset"],
-                    row["confidence_pct"],
-                    json.dumps(row["trigger_data"]),
-                    row["suggestion"],
-                    row["reallocation_pct"],
-                    user_action,
-                ),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO scanner_signals (
+                        signal_id, signal_type, asset, confidence_pct,
+                        trigger_data, suggestion, reallocation_pct, user_action
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (signal_id) DO UPDATE SET
+                        user_action = EXCLUDED.user_action
+                    """,
+                    (
+                        row["signal_id"],
+                        row["signal_type"],
+                        row["asset"],
+                        row["confidence_pct"],
+                        json.dumps(row["trigger_data"]),
+                        row["suggestion"],
+                        row["reallocation_pct"],
+                        user_action,
+                    ),
+                )
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             self.normalized.insert_order_events(

--- a/curve/curve-gauge-yield-trader/scripts/agent.py
+++ b/curve/curve-gauge-yield-trader/scripts/agent.py
@@ -1751,8 +1751,6 @@ def _persist_normalized_result(config: dict[str, Any], result: dict[str, Any], *
         venue="curve",
         strategy_name="curve-gauge-yield-trader",
     )
-    if not store.enabled:
-        return
     order_events = [
         {
             "order_id": run_type,

--- a/curve/curve-gauge-yield-trader/scripts/normalized_trade_store.py
+++ b/curve/curve-gauge-yield-trader/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/kraken/grid-trader/scripts/serendb_store.py
+++ b/kraken/grid-trader/scripts/serendb_store.py
@@ -10,6 +10,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from trade_reporting import CycleTradeReportEmitter
+
 
 class SerenMCPError(RuntimeError):
     """Raised when a local seren-mcp tool call fails."""
@@ -199,6 +201,22 @@ class SerenDBStore:
         self._target: Optional[DBTarget] = None
         self._mcp = _SerenMCPClient(api_key=api_key, mcp_command=mcp_command)
         self._mcp.start()
+        self._reporter = CycleTradeReportEmitter(
+            skill_slug="kraken-grid-trader",
+            venue="kraken",
+            strategy_name="grid-trader",
+        )
+
+    def _ensure_reporter(self) -> CycleTradeReportEmitter:
+        reporter = getattr(self, "_reporter", None)
+        if reporter is None:
+            reporter = CycleTradeReportEmitter(
+                skill_slug="kraken-grid-trader",
+                venue="kraken",
+                strategy_name="grid-trader",
+            )
+            self._reporter = reporter
+        return reporter
 
     def close(self) -> None:
         self._mcp.close()
@@ -385,6 +403,13 @@ class SerenDBStore:
         self._execute_sql(ddl)
 
     def create_session(self, session_id: str, campaign_name: str, trading_pair: str, dry_run: bool) -> None:
+        self._ensure_reporter().start_session(
+            session_id,
+            mode="paper" if dry_run else "live",
+            dry_run=dry_run,
+            instrument_id=trading_pair,
+            metadata={"campaign_name": campaign_name},
+        )
         query = f"""
         INSERT INTO kraken_grid_sessions (session_id, campaign_name, trading_pair, dry_run)
         VALUES (
@@ -428,6 +453,15 @@ class SerenDBStore:
         status: str,
         payload: Optional[Dict[str, Any]] = None,
     ) -> None:
+        self._ensure_reporter().record_order(
+            session_id,
+            order_id=order_id,
+            side=side,
+            price=price,
+            quantity=volume,
+            status=status,
+            metadata=payload or {},
+        )
         query = f"""
         INSERT INTO kraken_grid_orders (session_id, order_id, side, price, volume, status, payload)
         VALUES (
@@ -472,6 +506,15 @@ class SerenDBStore:
         cost: float,
         payload: Optional[Dict[str, Any]] = None,
     ) -> None:
+        self._ensure_reporter().record_fill(
+            session_id,
+            order_id=order_id,
+            side=side,
+            price=price,
+            quantity=volume,
+            fee_usd=fee,
+            metadata=payload or {},
+        )
         query = f"""
         INSERT INTO kraken_grid_fills (session_id, order_id, side, price, volume, fee, cost, payload)
         VALUES (
@@ -514,6 +557,15 @@ class SerenDBStore:
         unrealized_pnl: float,
         open_orders: int,
     ) -> None:
+        self._ensure_reporter().record_position(
+            session_id,
+            instrument_id=trading_pair,
+            base_balance=base_balance,
+            quote_balance=quote_balance,
+            total_value_usd=total_value_usd,
+            unrealized_pnl_usd=unrealized_pnl,
+            open_orders=open_orders,
+        )
         query = f"""
         INSERT INTO kraken_grid_positions (
             session_id,
@@ -588,6 +640,8 @@ class SerenDBStore:
         self._execute_sql(query)
 
     def save_event(self, session_id: str, event_type: str, payload: Dict[str, Any]) -> None:
+        terminal_status = self._normalized_terminal_status(event_type)
+        self._ensure_reporter().record_event(session_id, event_type=event_type, payload=payload, status=terminal_status)
         query = f"""
         INSERT INTO kraken_grid_events (session_id, event_type, payload)
         VALUES (
@@ -608,7 +662,6 @@ class SerenDBStore:
             {self._sql_json(payload)}
         );
         """
-        terminal_status = self._normalized_terminal_status(event_type)
         if terminal_status:
             query += f"""
             UPDATE trading.strategy_runs

--- a/kraken/grid-trader/scripts/trade_reporting.py
+++ b/kraken/grid-trader/scripts/trade_reporting.py
@@ -1,0 +1,369 @@
+"""Shared cycle trade reporting for grid-trader runtimes."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+class CycleTradeReportEmitter:
+    """Collect per-cycle grid events and emit structured reports."""
+
+    def __init__(self, *, skill_slug: str, venue: str, strategy_name: str, logs_dir: str = "logs") -> None:
+        self.skill_slug = skill_slug
+        self.venue = venue
+        self.strategy_name = strategy_name
+        self.logs_dir = Path(logs_dir)
+        self.log_path = self.logs_dir / "trade_reports.jsonl"
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    def start_session(
+        self,
+        session_id: str,
+        *,
+        mode: str,
+        dry_run: bool,
+        instrument_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._sessions[session_id] = {
+            "session_id": session_id,
+            "mode": mode,
+            "dry_run": dry_run,
+            "instrument_id": instrument_id,
+            "metadata": dict(metadata or {}),
+            "started_at": _now_iso(),
+            "cycle_index": 0,
+            "last_equity_end_usd": None,
+            "peak_equity_end_usd": None,
+            "current_position": None,
+            "cycle_order_events": [],
+            "cycle_fills": [],
+            "last_halt_reason": None,
+            "breach_positions": [],
+        }
+
+    def record_order(
+        self,
+        session_id: str,
+        *,
+        order_id: str,
+        side: str,
+        price: float,
+        quantity: float,
+        status: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["cycle_order_events"].append(
+            {
+                "order_id": order_id,
+                "side": side,
+                "price": float(price),
+                "quantity": float(quantity),
+                "status": status,
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    def record_fill(
+        self,
+        session_id: str,
+        *,
+        order_id: str,
+        side: str,
+        price: float,
+        quantity: float,
+        fee_usd: float,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["cycle_fills"].append(
+            {
+                "order_id": order_id,
+                "side": side,
+                "fill_price": float(price),
+                "quantity": float(quantity),
+                "fee_usd": float(fee_usd),
+                "fill_time": _now_iso(),
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    def record_position(
+        self,
+        session_id: str,
+        *,
+        instrument_id: str,
+        base_balance: float,
+        quote_balance: float,
+        total_value_usd: float,
+        unrealized_pnl_usd: float,
+        open_orders: int,
+        status: str = "running",
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        current_price = None
+        if abs(float(base_balance)) > 1e-12:
+            current_price = max((float(total_value_usd) - float(quote_balance)) / float(base_balance), 0.0)
+        session["current_position"] = {
+            "market": instrument_id,
+            "market_id": instrument_id,
+            "symbol": instrument_id,
+            "side": "LONG" if float(base_balance) > 0 else "FLAT",
+            "quantity": float(base_balance),
+            "current_price": current_price,
+            "quote_balance": float(quote_balance),
+            "market_value_usd": float(total_value_usd),
+            "unrealized_pnl_usd": float(unrealized_pnl_usd),
+            "open_orders": int(open_orders),
+        }
+        self._emit_report(session_id, status=status)
+
+    def record_event(self, session_id: str, *, event_type: str, payload: dict[str, Any], status: str | None) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        session["last_halt_reason"] = _first_text(
+            payload.get("error_message"),
+            payload.get("blocked_reason"),
+            payload.get("reason"),
+            event_type,
+        )
+        instrument = _first_text(payload.get("pair"), payload.get("product_id"))
+        if instrument:
+            breach = instrument
+            if breach not in session["breach_positions"]:
+                session["breach_positions"].append(breach)
+        if status:
+            self._emit_report(session_id, status=status, terminal_event=event_type, event_payload=payload)
+
+    def _emit_report(
+        self,
+        session_id: str,
+        *,
+        status: str,
+        terminal_event: str | None = None,
+        event_payload: dict[str, Any] | None = None,
+    ) -> None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        position = session.get("current_position") or {}
+        equity_end = _float_or_none(position.get("market_value_usd"))
+        previous_equity = _float_or_none(session.get("last_equity_end_usd"))
+        peak_equity = _float_or_none(session.get("peak_equity_end_usd"))
+        if equity_end is not None:
+            peak_equity = equity_end if peak_equity is None else max(peak_equity, equity_end)
+        fees_usd = sum(_float_or_none(fill.get("fee_usd")) or 0.0 for fill in session["cycle_fills"])
+        cycle_summary = {
+            "realized_pnl_usd": None,
+            "unrealized_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+            "net_pnl_usd": None
+            if position.get("unrealized_pnl_usd") is None
+            else float(position["unrealized_pnl_usd"]) - fees_usd,
+            "equity_start_usd": previous_equity,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": None
+            if equity_end is None or previous_equity is None
+            else equity_end - previous_equity,
+            "drawdown_usd": None
+            if peak_equity is None or equity_end is None
+            else max(peak_equity - equity_end, 0.0),
+            "drawdown_pct": None
+            if peak_equity in (None, 0.0) or equity_end is None
+            else max(peak_equity - equity_end, 0.0) / peak_equity * 100.0,
+            "order_event_count": len(session["cycle_order_events"]),
+            "fill_count": len(session["cycle_fills"]),
+            "halt_reason": session.get("last_halt_reason"),
+            "breach_positions": list(session.get("breach_positions") or []),
+        }
+        trades = [
+            {
+                "order_id": fill.get("order_id"),
+                "market": position.get("market") or session.get("instrument_id"),
+                "market_id": position.get("market_id") or session.get("instrument_id"),
+                "symbol": position.get("symbol") or session.get("instrument_id"),
+                "side": fill.get("side"),
+                "quantity": fill.get("quantity"),
+                "entry_price": fill.get("fill_price"),
+                "exit_price": None,
+                "current_price": position.get("current_price"),
+                "fill_price": fill.get("fill_price"),
+                "realized_pnl_usd": None,
+                "unrealized_pnl_usd": position.get("unrealized_pnl_usd"),
+                "fee_usd": fill.get("fee_usd"),
+                "fill_time": fill.get("fill_time"),
+                "metadata": fill.get("metadata") or {},
+            }
+            for fill in session["cycle_fills"]
+        ]
+        open_positions = []
+        quantity = _float_or_none(position.get("quantity"))
+        if quantity is None or abs(quantity) > 1e-12:
+            open_positions.append(
+                {
+                    "market": position.get("market") or session.get("instrument_id"),
+                    "market_id": position.get("market_id") or session.get("instrument_id"),
+                    "symbol": position.get("symbol") or session.get("instrument_id"),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": None,
+                    "current_price": _float_or_none(position.get("current_price")),
+                    "market_value_usd": _float_or_none(position.get("market_value_usd")),
+                    "unrealized_pnl_usd": _float_or_none(position.get("unrealized_pnl_usd")),
+                    "metadata": {
+                        "quote_balance": _float_or_none(position.get("quote_balance")),
+                        "open_orders": position.get("open_orders"),
+                    },
+                }
+            )
+
+        report = {
+            "generated_at": _now_iso(),
+            "run_id": session_id,
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": session.get("mode"),
+            "status": status,
+            "dry_run": bool(session.get("dry_run", True)),
+            "started_at": session.get("started_at"),
+            "completed_at": _now_iso() if terminal_event else None,
+            "summary": {
+                "cycle_index": session.get("cycle_index", 0) + 1,
+                "terminal_event": terminal_event,
+            },
+            "metadata": {
+                **dict(session.get("metadata") or {}),
+                "instrument_id": session.get("instrument_id"),
+                "event_payload": dict(event_payload or {}),
+            },
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+        if os.getenv("PYTHONUNBUFFERED") == "1":
+            self._print_report(report)
+
+        session["cycle_index"] = int(session.get("cycle_index", 0)) + 1
+        session["last_equity_end_usd"] = equity_end
+        session["peak_equity_end_usd"] = peak_equity
+        session["cycle_order_events"] = []
+        session["cycle_fills"] = []
+        if not terminal_event:
+            session["breach_positions"] = []
+            session["last_halt_reason"] = None
+        if terminal_event:
+            self._sessions.pop(session_id, None)
+
+    def _print_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in report.get("trades", [])
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in report.get("open_positions", [])
+                ],
+            )
+        )

--- a/kraken/grid-trader/tests/test_grid_trade_reports.py
+++ b/kraken/grid-trader/tests/test_grid_trade_reports.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_local_module(module_name: str):
+    script_dir = Path(__file__).resolve().parents[1] / "scripts"
+    script_dir_str = str(script_dir)
+    sys.path[:] = [script_dir_str, *[path for path in sys.path if path != script_dir_str]]
+    for cached_name in ("serendb_store", "trade_reporting"):
+        sys.modules.pop(cached_name, None)
+    spec = importlib.util.spec_from_file_location(f"test_grid_{module_name}", script_dir / f"{module_name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_store(tmp_path):
+    store_module = _load_local_module("serendb_store")
+    reporting_module = _load_local_module("trade_reporting")
+    store = object.__new__(store_module.SerenDBStore)
+    store._execute_sql = lambda query: None
+    store._sql_text = store_module.SerenDBStore._sql_text
+    store._sql_bool = store_module.SerenDBStore._sql_bool
+    store._sql_json = store_module.SerenDBStore._sql_json
+    store._normalized_terminal_status = store_module.SerenDBStore._normalized_terminal_status
+    store._reporter = reporting_module.CycleTradeReportEmitter(
+        skill_slug="kraken-grid-trader",
+        venue="kraken",
+        strategy_name="grid-trader",
+        logs_dir=str(tmp_path / "logs"),
+    )
+    return store_module, store
+
+
+def test_grid_store_emits_cycle_and_terminal_reports(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("PYTHONUNBUFFERED", "1")
+    store_module, store = _make_store(tmp_path)
+
+    store_module.SerenDBStore.create_session(
+        store,
+        "00000000-0000-0000-0000-000000000001",
+        "grid-cycle",
+        "XBTUSD",
+        False,
+    )
+    store_module.SerenDBStore.save_order(
+        store,
+        "00000000-0000-0000-0000-000000000001",
+        "ord-1",
+        "buy",
+        50000.0,
+        0.01,
+        "placed",
+        {"pair": "XBTUSD", "order_type": "limit"},
+    )
+    store_module.SerenDBStore.save_fill(
+        store,
+        "00000000-0000-0000-0000-000000000001",
+        "ord-1",
+        "buy",
+        50000.0,
+        0.01,
+        0.8,
+        500.0,
+        {"pair": "XBTUSD"},
+    )
+    store_module.SerenDBStore.save_position(
+        store,
+        "00000000-0000-0000-0000-000000000001",
+        "XBTUSD",
+        0.01,
+        1000.0,
+        1500.0,
+        25.0,
+        3,
+    )
+    store_module.SerenDBStore.save_event(
+        store,
+        "00000000-0000-0000-0000-000000000001",
+        "stop_loss_triggered",
+        {"pair": "XBTUSD", "error_message": "stop loss triggered"},
+    )
+
+    report_path = tmp_path / "logs" / "trade_reports.jsonl"
+    lines = [json.loads(line) for line in report_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[0]["cycle_summary"]["fill_count"] == 1
+    assert lines[0]["status"] == "running"
+    assert lines[1]["status"] == "stopped"
+    assert lines[1]["cycle_summary"]["halt_reason"] == "stop loss triggered"
+
+    stdout = capsys.readouterr().out
+    assert "[trade-report] kraken-grid-trader" in stdout

--- a/kraken/smart-dca-bot/scripts/normalized_trade_store.py
+++ b/kraken/smart-dca-bot/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/kraken/smart-dca-bot/scripts/serendb_store.py
+++ b/kraken/smart-dca-bot/scripts/serendb_store.py
@@ -128,6 +128,14 @@ class SerenDBStore:
         return True
 
     def create_session(self, session_id: str, mode: str, config: dict[str, Any]) -> None:
+        self.normalized.start_run(
+            run_id=session_id,
+            mode=mode,
+            dry_run=bool(config.get("dry_run", True)),
+            config=config,
+            status="running",
+            metadata={"session_kind": "dca"},
+        )
         if not self.enabled:
             return
         self.connect()
@@ -142,14 +150,6 @@ class SerenDBStore:
                 (session_id, mode, json.dumps(config)),
             )
         self.conn.commit()
-        self.normalized.start_run(
-            run_id=session_id,
-            mode=mode,
-            dry_run=bool(config.get("dry_run", True)),
-            config=config,
-            status="running",
-            metadata={"session_kind": "dca"},
-        )
 
     def close_session(
         self,
@@ -159,22 +159,21 @@ class SerenDBStore:
         total_invested_usd: float,
         total_savings_bps: int,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE dca_sessions
-                SET ended_at = NOW(), status = %s,
-                    total_invested_usd = %s,
-                    total_savings_bps = %s
-                WHERE session_id = %s
-                """,
-                (status, total_invested_usd, total_savings_bps, session_id),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE dca_sessions
+                    SET ended_at = NOW(), status = %s,
+                        total_invested_usd = %s,
+                        total_savings_bps = %s
+                    WHERE session_id = %s
+                    """,
+                    (status, total_invested_usd, total_savings_bps, session_id),
+                )
+            self.conn.commit()
         self.normalized.finish_run(
             run_id=session_id,
             status=status,
@@ -186,38 +185,37 @@ class SerenDBStore:
         )
 
     def persist_execution(self, row: dict[str, Any]) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO dca_executions (
-                    execution_id, mode, asset, target_amount_usd,
-                    executed_amount_usd, executed_price, vwap_at_execution,
-                    savings_vs_naive_bps, strategy, window_start, window_end,
-                    executed_at, status, kraken_order_id, metadata
-                ) VALUES (
-                    %(execution_id)s, %(mode)s, %(asset)s, %(target_amount_usd)s,
-                    %(executed_amount_usd)s, %(executed_price)s, %(vwap_at_execution)s,
-                    %(savings_vs_naive_bps)s, %(strategy)s, %(window_start)s, %(window_end)s,
-                    %(executed_at)s, %(status)s, %(kraken_order_id)s, %(metadata)s
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO dca_executions (
+                        execution_id, mode, asset, target_amount_usd,
+                        executed_amount_usd, executed_price, vwap_at_execution,
+                        savings_vs_naive_bps, strategy, window_start, window_end,
+                        executed_at, status, kraken_order_id, metadata
+                    ) VALUES (
+                        %(execution_id)s, %(mode)s, %(asset)s, %(target_amount_usd)s,
+                        %(executed_amount_usd)s, %(executed_price)s, %(vwap_at_execution)s,
+                        %(savings_vs_naive_bps)s, %(strategy)s, %(window_start)s, %(window_end)s,
+                        %(executed_at)s, %(status)s, %(kraken_order_id)s, %(metadata)s
+                    )
+                    ON CONFLICT (execution_id) DO UPDATE SET
+                        status = EXCLUDED.status,
+                        executed_amount_usd = EXCLUDED.executed_amount_usd,
+                        executed_price = EXCLUDED.executed_price,
+                        executed_at = EXCLUDED.executed_at,
+                        kraken_order_id = EXCLUDED.kraken_order_id,
+                        metadata = EXCLUDED.metadata
+                    """,
+                    {
+                        **row,
+                        "metadata": json.dumps(row.get("metadata", {})),
+                    },
                 )
-                ON CONFLICT (execution_id) DO UPDATE SET
-                    status = EXCLUDED.status,
-                    executed_amount_usd = EXCLUDED.executed_amount_usd,
-                    executed_price = EXCLUDED.executed_price,
-                    executed_at = EXCLUDED.executed_at,
-                    kraken_order_id = EXCLUDED.kraken_order_id,
-                    metadata = EXCLUDED.metadata
-                """,
-                {
-                    **row,
-                    "metadata": json.dumps(row.get("metadata", {})),
-                },
-            )
-        self.conn.commit()
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             quantity = None
@@ -257,27 +255,26 @@ class SerenDBStore:
                 )
 
     def persist_portfolio_snapshot(self, row: dict[str, Any]) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO portfolio_snapshots (
-                    snapshot_id, total_value_usd, allocations, target_allocations, drift_max_pct
-                ) VALUES (%s, %s, %s, %s, %s)
-                ON CONFLICT (snapshot_id) DO NOTHING
-                """,
-                (
-                    row["snapshot_id"],
-                    row["total_value_usd"],
-                    json.dumps(row["allocations"]),
-                    json.dumps(row["target_allocations"]),
-                    row["drift_max_pct"],
-                ),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO portfolio_snapshots (
+                        snapshot_id, total_value_usd, allocations, target_allocations, drift_max_pct
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (snapshot_id) DO NOTHING
+                    """,
+                    (
+                        row["snapshot_id"],
+                        row["total_value_usd"],
+                        json.dumps(row["allocations"]),
+                        json.dumps(row["target_allocations"]),
+                        row["drift_max_pct"],
+                    ),
+                )
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             positions, marks = self._allocation_rows(row)
@@ -285,32 +282,31 @@ class SerenDBStore:
             self.normalized.insert_position_marks(session_id, marks)
 
     def persist_scanner_signal(self, row: dict[str, Any], user_action: str | None = None) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO scanner_signals (
-                    signal_id, signal_type, asset, confidence_pct,
-                    trigger_data, suggestion, reallocation_pct, user_action
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (signal_id) DO UPDATE SET
-                    user_action = EXCLUDED.user_action
-                """,
-                (
-                    row["signal_id"],
-                    row["signal_type"],
-                    row["asset"],
-                    row["confidence_pct"],
-                    json.dumps(row["trigger_data"]),
-                    row["suggestion"],
-                    row["reallocation_pct"],
-                    user_action,
-                ),
-            )
-        self.conn.commit()
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO scanner_signals (
+                        signal_id, signal_type, asset, confidence_pct,
+                        trigger_data, suggestion, reallocation_pct, user_action
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (signal_id) DO UPDATE SET
+                        user_action = EXCLUDED.user_action
+                    """,
+                    (
+                        row["signal_id"],
+                        row["signal_type"],
+                        row["asset"],
+                        row["confidence_pct"],
+                        json.dumps(row["trigger_data"]),
+                        row["suggestion"],
+                        row["reallocation_pct"],
+                        user_action,
+                    ),
+                )
+            self.conn.commit()
         session_id = self._normalized_session_id(row)
         if session_id:
             self.normalized.insert_order_events(

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -2285,8 +2285,6 @@ def _persist_normalized_result(config: dict[str, Any], result: dict[str, Any], *
         venue="polymarket",
         strategy_name="high-throughput-paired-basis-maker",
     )
-    if not store.enabled:
-        return
     try:
         mode = run_type
         dry_run = run_type != "live"

--- a/polymarket/high-throughput-paired-basis-maker/scripts/normalized_trade_store.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -2346,8 +2346,6 @@ def _persist_normalized_result(config: dict[str, Any], result: dict[str, Any], *
         venue="polymarket",
         strategy_name="liquidity-paired-basis-maker",
     )
-    if not store.enabled:
-        return
     try:
         mode = run_type
         dry_run = run_type != "live"

--- a/polymarket/liquidity-paired-basis-maker/scripts/normalized_trade_store.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -2964,8 +2964,6 @@ def _persist_normalized_result(config: dict[str, Any], result: dict[str, Any], *
         venue="polymarket",
         strategy_name="maker-rebate-bot",
     )
-    if not store.enabled:
-        return
     try:
         summary: dict[str, Any]
         order_events: list[dict[str, Any]] = []

--- a/polymarket/maker-rebate-bot/scripts/normalized_trade_store.py
+++ b/polymarket/maker-rebate-bot/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/polymarket/paired-market-basis-maker/scripts/agent.py
+++ b/polymarket/paired-market-basis-maker/scripts/agent.py
@@ -2285,8 +2285,6 @@ def _persist_normalized_result(config: dict[str, Any], result: dict[str, Any], *
         venue="polymarket",
         strategy_name="paired-market-basis-maker",
     )
-    if not store.enabled:
-        return
     try:
         mode = run_type
         dry_run = run_type != "live"

--- a/polymarket/paired-market-basis-maker/scripts/normalized_trade_store.py
+++ b/polymarket/paired-market-basis-maker/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -487,8 +487,6 @@ def _persist_normalized_result(config: dict, result: dict, *, run_type: str) -> 
         venue="spectra",
         strategy_name="spectra-pt-yield-trader",
     )
-    if not store.enabled:
-        return
     order_events = []
     for step in result.get("mcp_plan", []):
         if not isinstance(step, dict):

--- a/spectra/spectra-pt-yield-trader/scripts/normalized_trade_store.py
+++ b/spectra/spectra-pt-yield-trader/scripts/normalized_trade_store.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -166,6 +168,133 @@ def _position_key(row: dict[str, Any], fallback: str) -> str:
     return fallback
 
 
+def _clone_jsonable(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))
+
+
+def _trade_reports_path() -> Path:
+    configured = (os.getenv("TRADE_REPORTS_PATH") or "").strip()
+    if configured:
+        return Path(configured)
+    return Path("logs") / "trade_reports.jsonl"
+
+
+def _latest_row(rows: list[dict[str, Any]], *, time_key: str) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda row: str(row.get(time_key) or ""))
+
+
+def _metadata_dict(row: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {}
+    metadata = row.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _first_numeric(*values: Any) -> float | None:
+    for value in values:
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _format_money(value: float | None) -> str:
+    return "-" if value is None else f"${value:,.2f}"
+
+
+def _format_qty(value: float | None) -> str:
+    return "-" if value is None else f"{value:,.4f}"
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "  (none)"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    header_line = "  " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  " + "-+-".join("-" * width for width in widths)
+    body = [
+        "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+        for row in rows
+    ]
+    return "\n".join([header_line, divider, *body])
+
+
+def _extract_halt_reason(
+    *,
+    status: str,
+    summary: dict[str, Any],
+    metadata: dict[str, Any],
+    error_code: str | None,
+    error_message: str | None,
+) -> str | None:
+    for candidate in (
+        error_message,
+        error_code,
+        summary.get("halt_reason"),
+        summary.get("blocked_reason"),
+        summary.get("reason"),
+        metadata.get("halt_reason"),
+        metadata.get("blocked_reason"),
+        metadata.get("reason"),
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    if status in {"failed", "blocked", "stopped"}:
+        return status
+    return None
+
+
+def _extract_breach_positions(summary: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+    results: list[str] = []
+    for payload in (summary, metadata):
+        for key in (
+            "breach_positions",
+            "positions_triggered_breach",
+            "positions_breaching",
+            "breached_positions",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    text = _first_non_empty(
+                        item.get("symbol") if isinstance(item, dict) else None,
+                        item.get("ticker") if isinstance(item, dict) else None,
+                        item.get("position_key") if isinstance(item, dict) else None,
+                        item,
+                    )
+                    if text and text not in results:
+                        results.append(text)
+        live_risk = payload.get("live_risk")
+        if isinstance(live_risk, dict):
+            for key in ("breach_positions", "positions_breaching", "breached_positions", "blocked_positions"):
+                value = live_risk.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        text = _first_non_empty(
+                            item.get("symbol") if isinstance(item, dict) else None,
+                            item.get("ticker") if isinstance(item, dict) else None,
+                            item,
+                        )
+                        if text and text not in results:
+                            results.append(text)
+    return results
+
+
 class NormalizedTradingStore:
     """Best-effort normalized trading persistence for Postgres-backed SerenDB skills."""
 
@@ -175,6 +304,7 @@ class NormalizedTradingStore:
         self.venue = venue
         self.strategy_name = strategy_name
         self.conn = None
+        self._run_buffers: dict[str, dict[str, Any]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -215,12 +345,37 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> str | None:
+        resolved_run_id = run_id or str(uuid4())
+        buffer = self._run_buffers.setdefault(
+            resolved_run_id,
+            {
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+            },
+        )
+        buffer.update(
+            {
+                "run_id": resolved_run_id,
+                "mode": mode,
+                "dry_run": bool(dry_run),
+                "status": status,
+                "started_at": started_at or _now_iso(),
+                "config": _clone_jsonable(config or {}),
+                "summary": _clone_jsonable(summary or {}),
+                "metadata": _clone_jsonable(metadata or {}),
+                "error_code": error_code,
+                "error_message": error_message,
+                "completed_at": buffer.get("completed_at"),
+            }
+        )
         if not self.enabled:
-            return None
+            return resolved_run_id
         self.ensure_schema()
         self.connect()
         assert self.conn is not None
-        resolved_run_id = run_id or str(uuid4())
         with self.conn.cursor() as cur:
             cur.execute(
                 """
@@ -275,35 +430,63 @@ class NormalizedTradingStore:
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> None:
-        if not self.enabled:
-            return
-        self.connect()
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE trading.strategy_runs
-                SET status = %s,
-                    completed_at = %s,
-                    summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
-                    metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
-                    error_code = COALESCE(%s, error_code),
-                    error_message = COALESCE(%s, error_message)
-                WHERE run_id = %s
-                """,
-                (
-                    status,
-                    completed_at or _now_iso(),
-                    _json(summary),
-                    _json(metadata),
-                    error_code,
-                    error_message,
-                    run_id,
-                ),
-            )
-        self.conn.commit()
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {
+                "run_id": run_id,
+                "order_events": [],
+                "fills": [],
+                "positions": {},
+                "position_marks": [],
+                "pnl_periods": [],
+                "summary": {},
+                "metadata": {},
+            },
+        )
+        merged_summary = dict(buffer.get("summary") or {})
+        merged_summary.update(_clone_jsonable(summary or {}))
+        merged_metadata = dict(buffer.get("metadata") or {})
+        merged_metadata.update(_clone_jsonable(metadata or {}))
+        buffer.update(
+            {
+                "status": status,
+                "completed_at": completed_at or _now_iso(),
+                "summary": merged_summary,
+                "metadata": merged_metadata,
+                "error_code": error_code or buffer.get("error_code"),
+                "error_message": error_message or buffer.get("error_message"),
+            }
+        )
+        if self.enabled:
+            self.connect()
+            assert self.conn is not None
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE trading.strategy_runs
+                    SET status = %s,
+                        completed_at = %s,
+                        summary = COALESCE(summary, '{}'::jsonb) || %s::jsonb,
+                        metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb,
+                        error_code = COALESCE(%s, error_code),
+                        error_message = COALESCE(%s, error_message)
+                    WHERE run_id = %s
+                    """,
+                    (
+                        status,
+                        completed_at or _now_iso(),
+                        _json(summary),
+                        _json(metadata),
+                        error_code,
+                        error_message,
+                        run_id,
+                    ),
+                )
+            self.conn.commit()
+        self._emit_trade_report(run_id)
 
     def insert_order_events(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -313,6 +496,23 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            event_time = row.get("event_time") or _now_iso()
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "order_type": row.get("order_type"),
+                    "event_type": row.get("event_type") or row.get("status") or "order_event",
+                    "status": row.get("status"),
+                    "price": price,
+                    "quantity": quantity,
+                    "notional_usd": notional,
+                    "event_time": event_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -326,10 +526,15 @@ class NormalizedTradingStore:
                     price,
                     quantity,
                     notional,
-                    row.get("event_time") or _now_iso(),
+                    event_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("order_events", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.order_events (
@@ -344,6 +549,7 @@ class NormalizedTradingStore:
         )
 
     def insert_fills(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_rows: list[dict[str, Any]] = []
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
@@ -357,6 +563,27 @@ class NormalizedTradingStore:
             notional = _float_or_none(row.get("notional_usd"))
             if notional is None and price is not None and quantity is not None:
                 notional = price * quantity
+            fill_time = row.get("fill_time") or row.get("event_time") or _now_iso()
+            fee = _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee"))
+            realized_pnl = _float_or_none(
+                row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+            )
+            buffered_rows.append(
+                {
+                    "order_id": row.get("order_id"),
+                    "venue_fill_id": row.get("venue_fill_id"),
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "fill_price": price,
+                    "fill_quantity": quantity,
+                    "fee_usd": fee,
+                    "notional_usd": notional,
+                    "realized_pnl_usd": realized_pnl,
+                    "fill_time": fill_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
@@ -367,13 +594,18 @@ class NormalizedTradingStore:
                     row.get("side"),
                     price,
                     quantity,
-                    _float_or_none(row.get("fee_usd") if "fee_usd" in row else row.get("fee")),
+                    fee,
                     notional,
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("fill_time") or row.get("event_time") or _now_iso(),
+                    realized_pnl,
+                    fill_time,
                     _json(row.get("metadata")),
                 )
             )
+        buffer = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        )
+        buffer.setdefault("fills", []).extend(buffered_rows)
         self._executemany(
             """
             INSERT INTO trading.fills (
@@ -388,6 +620,10 @@ class NormalizedTradingStore:
         )
 
     def upsert_positions(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_positions = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("positions", {})
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -397,10 +633,34 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-{index}")
+            buffered_positions[position_key] = {
+                "position_key": position_key,
+                "instrument_id": row.get("instrument_id"),
+                "symbol": row.get("symbol"),
+                "side": row.get("side"),
+                "quantity": quantity,
+                "entry_price": _float_or_none(row.get("entry_price")),
+                "cost_basis_usd": _float_or_none(
+                    row.get("cost_basis_usd") if "cost_basis_usd" in row else row.get("cost_basis")
+                ),
+                "market_price": price,
+                "market_value_usd": market_value,
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "status": row.get("status"),
+                "opened_at": row.get("opened_at"),
+                "closed_at": row.get("closed_at"),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -448,6 +708,10 @@ class NormalizedTradingStore:
         )
 
     def insert_position_marks(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_marks = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("position_marks", [])
         prepared = []
         for index, row in enumerate(rows):
             if not isinstance(row, dict):
@@ -457,10 +721,31 @@ class NormalizedTradingStore:
             market_value = _float_or_none(row.get("market_value_usd") if "market_value_usd" in row else row.get("market_value"))
             if market_value is None and price is not None and quantity is not None:
                 market_value = price * quantity
+            position_key = _position_key(row, f"position-mark-{index}")
+            mark_time = row.get("mark_time") or _now_iso()
+            buffered_marks.append(
+                {
+                    "position_key": position_key,
+                    "instrument_id": row.get("instrument_id"),
+                    "symbol": row.get("symbol"),
+                    "side": row.get("side"),
+                    "quantity": quantity,
+                    "mark_price": price,
+                    "market_value_usd": market_value,
+                    "unrealized_pnl_usd": _float_or_none(
+                        row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                    ),
+                    "realized_pnl_usd": _float_or_none(
+                        row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                    ),
+                    "mark_time": mark_time,
+                    "metadata": _clone_jsonable(row.get("metadata") or {}),
+                }
+            )
             prepared.append(
                 (
                     run_id,
-                    _position_key(row, f"position-mark-{index}"),
+                    position_key,
                     row.get("instrument_id"),
                     row.get("symbol"),
                     row.get("side"),
@@ -469,7 +754,7 @@ class NormalizedTradingStore:
                     market_value,
                     _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
                     _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    row.get("mark_time") or _now_iso(),
+                    mark_time,
                     _json(row.get("metadata")),
                 )
             )
@@ -487,23 +772,51 @@ class NormalizedTradingStore:
         )
 
     def insert_pnl_periods(self, run_id: str, rows: list[dict[str, Any]]) -> None:
+        buffered_periods = self._run_buffers.setdefault(
+            run_id,
+            {"order_events": [], "fills": [], "positions": {}, "position_marks": [], "pnl_periods": []},
+        ).setdefault("pnl_periods", [])
         prepared = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            period = {
+                "period_type": row.get("period_type") or "run",
+                "period_start": row.get("period_start"),
+                "period_end": row.get("period_end") or _now_iso(),
+                "realized_pnl_usd": _float_or_none(
+                    row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")
+                ),
+                "unrealized_pnl_usd": _float_or_none(
+                    row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")
+                ),
+                "fees_usd": _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
+                "gross_pnl_usd": _float_or_none(
+                    row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")
+                ),
+                "net_pnl_usd": _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
+                "equity_start_usd": _float_or_none(
+                    row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")
+                ),
+                "equity_end_usd": _float_or_none(
+                    row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")
+                ),
+                "metadata": _clone_jsonable(row.get("metadata") or {}),
+            }
+            buffered_periods.append(period)
             prepared.append(
                 (
                     run_id,
-                    row.get("period_type") or "run",
-                    row.get("period_start"),
-                    row.get("period_end") or _now_iso(),
-                    _float_or_none(row.get("realized_pnl_usd") if "realized_pnl_usd" in row else row.get("realized_pnl")),
-                    _float_or_none(row.get("unrealized_pnl_usd") if "unrealized_pnl_usd" in row else row.get("unrealized_pnl")),
-                    _float_or_none(row.get("fees_usd") if "fees_usd" in row else row.get("fees")),
-                    _float_or_none(row.get("gross_pnl_usd") if "gross_pnl_usd" in row else row.get("gross_pnl")),
-                    _float_or_none(row.get("net_pnl_usd") if "net_pnl_usd" in row else row.get("net_pnl")),
-                    _float_or_none(row.get("equity_start_usd") if "equity_start_usd" in row else row.get("equity_start")),
-                    _float_or_none(row.get("equity_end_usd") if "equity_end_usd" in row else row.get("equity_end")),
+                    period["period_type"],
+                    period["period_start"],
+                    period["period_end"],
+                    period["realized_pnl_usd"],
+                    period["unrealized_pnl_usd"],
+                    period["fees_usd"],
+                    period["gross_pnl_usd"],
+                    period["net_pnl_usd"],
+                    period["equity_start_usd"],
+                    period["equity_end_usd"],
                     _json(row.get("metadata")),
                 )
             )
@@ -571,6 +884,368 @@ class NormalizedTradingStore:
             error_message=error_message,
         )
         return resolved_run_id
+
+    def _emit_trade_report(self, run_id: str) -> None:
+        buffer = self._run_buffers.pop(run_id, None)
+        if not isinstance(buffer, dict):
+            return
+        try:
+            report = self._build_trade_report(buffer)
+            path = _trade_reports_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(report, default=str, sort_keys=True) + "\n")
+            if os.getenv("PYTHONUNBUFFERED") == "1":
+                self._print_trade_report(report)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            print(f"[trade-report] failed to emit report for {run_id}: {exc}")
+
+    def _build_trade_report(self, buffer: dict[str, Any]) -> dict[str, Any]:
+        order_events = [row for row in buffer.get("order_events", []) if isinstance(row, dict)]
+        fills = [row for row in buffer.get("fills", []) if isinstance(row, dict)]
+        positions = [
+            row
+            for row in (buffer.get("positions") or {}).values()
+            if isinstance(row, dict)
+        ]
+        position_marks = [row for row in buffer.get("position_marks", []) if isinstance(row, dict)]
+        pnl_periods = [row for row in buffer.get("pnl_periods", []) if isinstance(row, dict)]
+        summary = buffer.get("summary") if isinstance(buffer.get("summary"), dict) else {}
+        metadata = buffer.get("metadata") if isinstance(buffer.get("metadata"), dict) else {}
+
+        order_by_id = {
+            str(row.get("order_id")): row
+            for row in order_events
+            if row.get("order_id") not in (None, "")
+        }
+        position_by_key: dict[str, dict[str, Any]] = {}
+        for row in positions:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate not in (None, ""):
+                    position_by_key[str(candidate)] = row
+        latest_marks: dict[str, dict[str, Any]] = {}
+        for row in position_marks:
+            for candidate in (row.get("position_key"), row.get("instrument_id"), row.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                key = str(candidate)
+                if key not in latest_marks or str(row.get("mark_time") or "") >= str(latest_marks[key].get("mark_time") or ""):
+                    latest_marks[key] = row
+
+        trades: list[dict[str, Any]] = []
+        total_fees = 0.0
+        total_realized = 0.0
+        for fill in fills:
+            fee_usd = _first_numeric(fill.get("fee_usd"), _metadata_dict(fill).get("fee_usd")) or 0.0
+            total_fees += fee_usd
+            realized_pnl = _first_numeric(fill.get("realized_pnl_usd"), _metadata_dict(fill).get("realized_pnl"))
+            if realized_pnl is not None:
+                total_realized += realized_pnl
+            order_event = order_by_id.get(str(fill.get("order_id")))
+            metadata_row = {}
+            metadata_row.update(_metadata_dict(order_event))
+            metadata_row.update(_metadata_dict(fill))
+            instrument_id = _first_non_empty(
+                fill.get("instrument_id"),
+                order_event.get("instrument_id") if isinstance(order_event, dict) else None,
+                metadata_row.get("market_id"),
+            )
+            symbol = _first_non_empty(
+                fill.get("symbol"),
+                order_event.get("symbol") if isinstance(order_event, dict) else None,
+                metadata_row.get("ticker"),
+                instrument_id,
+            )
+            position = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                position = position_by_key.get(str(candidate))
+                if position is not None:
+                    break
+            latest_mark = None
+            for candidate in (fill.get("instrument_id"), fill.get("symbol"), instrument_id, symbol):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            fill_price = _first_numeric(fill.get("fill_price"), fill.get("price"))
+            entry_price = _first_numeric(
+                metadata_row.get("entry_price"),
+                position.get("entry_price") if isinstance(position, dict) else None,
+            )
+            is_close = _first_non_empty(metadata_row.get("close_reason"), metadata_row.get("open_order_ref")) is not None
+            if entry_price is None and not is_close:
+                entry_price = fill_price
+            current_price = _first_numeric(
+                position.get("market_price") if isinstance(position, dict) else None,
+                latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                metadata_row.get("current_price"),
+                metadata_row.get("mark_price"),
+            )
+            trades.append(
+                {
+                    "order_id": fill.get("order_id"),
+                    "market_id": instrument_id,
+                    "market": _first_non_empty(
+                        metadata_row.get("question"),
+                        metadata_row.get("market"),
+                        metadata_row.get("title"),
+                        metadata_row.get("name"),
+                        symbol,
+                    ),
+                    "symbol": symbol,
+                    "side": _first_non_empty(fill.get("side"), order_event.get("side") if isinstance(order_event, dict) else None),
+                    "quantity": _first_numeric(fill.get("fill_quantity"), fill.get("quantity")),
+                    "entry_price": entry_price,
+                    "exit_price": fill_price if is_close else None,
+                    "current_price": current_price,
+                    "fill_price": fill_price,
+                    "realized_pnl_usd": realized_pnl,
+                    "unrealized_pnl_usd": _first_numeric(
+                        position.get("unrealized_pnl_usd") if isinstance(position, dict) else None,
+                        latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "fee_usd": fee_usd,
+                    "fill_time": fill.get("fill_time"),
+                    "metadata": metadata_row,
+                }
+            )
+
+        open_positions: list[dict[str, Any]] = []
+        total_unrealized = 0.0
+        for position in positions:
+            quantity = _first_numeric(position.get("quantity"))
+            status = str(position.get("status") or "").lower()
+            if status == "closed":
+                continue
+            if quantity is not None and abs(quantity) <= 1e-12 and status not in {"open", "active"}:
+                continue
+            latest_mark = None
+            for candidate in (position.get("position_key"), position.get("instrument_id"), position.get("symbol")):
+                if candidate in (None, ""):
+                    continue
+                latest_mark = latest_marks.get(str(candidate))
+                if latest_mark is not None:
+                    break
+            unrealized = _first_numeric(
+                position.get("unrealized_pnl_usd"),
+                latest_mark.get("unrealized_pnl_usd") if isinstance(latest_mark, dict) else None,
+            )
+            if unrealized is not None:
+                total_unrealized += unrealized
+            open_positions.append(
+                {
+                    "position_key": position.get("position_key"),
+                    "market_id": _first_non_empty(position.get("instrument_id"), position.get("symbol")),
+                    "market": _first_non_empty(
+                        _metadata_dict(position).get("question"),
+                        _metadata_dict(position).get("market"),
+                        position.get("symbol"),
+                        position.get("instrument_id"),
+                    ),
+                    "symbol": _first_non_empty(position.get("symbol"), position.get("instrument_id")),
+                    "side": position.get("side"),
+                    "quantity": quantity,
+                    "entry_price": _first_numeric(position.get("entry_price")),
+                    "current_price": _first_numeric(
+                        position.get("market_price"),
+                        latest_mark.get("mark_price") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "market_value_usd": _first_numeric(
+                        position.get("market_value_usd"),
+                        latest_mark.get("market_value_usd") if isinstance(latest_mark, dict) else None,
+                    ),
+                    "realized_pnl_usd": _first_numeric(position.get("realized_pnl_usd")),
+                    "unrealized_pnl_usd": unrealized,
+                    "status": position.get("status"),
+                    "opened_at": position.get("opened_at"),
+                    "metadata": _metadata_dict(position),
+                }
+            )
+
+        latest_pnl = _latest_row(pnl_periods, time_key="period_end")
+        equity_end = _first_numeric(
+            latest_pnl.get("equity_end_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("current_equity_usd"),
+            metadata.get("current_equity_usd"),
+            (metadata.get("live_risk") or {}).get("current_equity_usd") if isinstance(metadata.get("live_risk"), dict) else None,
+        )
+        equity_start = _first_numeric(
+            latest_pnl.get("equity_start_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("starting_bankroll_usd"),
+            metadata.get("starting_bankroll_usd"),
+        )
+        realized_pnl = _first_numeric(
+            latest_pnl.get("realized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("realized_pnl_usd"),
+            metadata.get("realized_pnl_usd"),
+            total_realized,
+        )
+        unrealized_pnl = _first_numeric(
+            latest_pnl.get("unrealized_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("unrealized_pnl_usd"),
+            metadata.get("unrealized_pnl_usd"),
+            total_unrealized,
+        )
+        fees_usd = _first_numeric(
+            latest_pnl.get("fees_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("fees_usd"),
+            metadata.get("fees_usd"),
+            total_fees,
+        )
+        gross_pnl = _first_numeric(
+            latest_pnl.get("gross_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("gross_pnl_usd"),
+            metadata.get("gross_pnl_usd"),
+            (realized_pnl or 0.0) + (unrealized_pnl or 0.0),
+        )
+        net_pnl = _first_numeric(
+            latest_pnl.get("net_pnl_usd") if isinstance(latest_pnl, dict) else None,
+            summary.get("net_pnl_usd"),
+            metadata.get("net_pnl_usd"),
+            (gross_pnl or 0.0) - (fees_usd or 0.0),
+        )
+
+        previous_equity, peak_equity = self._history_stats(mode=str(buffer.get("mode") or ""))
+        equity_change = None
+        if equity_end is not None and previous_equity is not None:
+            equity_change = equity_end - previous_equity
+        peak_reference = max(value for value in (peak_equity, equity_end) if value is not None) if any(
+            value is not None for value in (peak_equity, equity_end)
+        ) else None
+        drawdown_usd = _first_numeric(
+            summary.get("max_drawdown"),
+            metadata.get("max_drawdown"),
+            latest_pnl.get("metadata", {}).get("max_drawdown") if isinstance(latest_pnl, dict) and isinstance(latest_pnl.get("metadata"), dict) else None,
+        )
+        if drawdown_usd is None and peak_reference is not None and equity_end is not None:
+            drawdown_usd = max(peak_reference - equity_end, 0.0)
+        drawdown_pct = _first_numeric(summary.get("max_drawdown_pct"), metadata.get("max_drawdown_pct"))
+        if drawdown_pct is None and drawdown_usd is not None and peak_reference not in (None, 0.0):
+            drawdown_pct = (drawdown_usd / peak_reference) * 100.0
+
+        cycle_summary = {
+            "realized_pnl_usd": realized_pnl,
+            "unrealized_pnl_usd": unrealized_pnl,
+            "fees_usd": fees_usd,
+            "gross_pnl_usd": gross_pnl,
+            "net_pnl_usd": net_pnl,
+            "equity_start_usd": equity_start,
+            "equity_end_usd": equity_end,
+            "previous_equity_end_usd": previous_equity,
+            "equity_change_vs_previous_cycle_usd": equity_change,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_pct": drawdown_pct,
+            "order_event_count": len(order_events),
+            "fill_count": len(fills),
+            "halt_reason": _extract_halt_reason(
+                status=str(buffer.get("status") or ""),
+                summary=summary,
+                metadata=metadata,
+                error_code=buffer.get("error_code"),
+                error_message=buffer.get("error_message"),
+            ),
+            "breach_positions": _extract_breach_positions(summary, metadata),
+        }
+
+        return {
+            "generated_at": _now_iso(),
+            "run_id": buffer.get("run_id"),
+            "skill_slug": self.skill_slug,
+            "venue": self.venue,
+            "strategy_name": self.strategy_name,
+            "mode": buffer.get("mode"),
+            "status": buffer.get("status"),
+            "dry_run": bool(buffer.get("dry_run", True)),
+            "started_at": buffer.get("started_at"),
+            "completed_at": buffer.get("completed_at"),
+            "summary": summary,
+            "metadata": metadata,
+            "cycle_summary": cycle_summary,
+            "trades": trades,
+            "open_positions": open_positions,
+        }
+
+    def _history_stats(self, *, mode: str) -> tuple[float | None, float | None]:
+        path = _trade_reports_path()
+        if not path.exists():
+            return None, None
+        previous_equity = None
+        peak_equity = None
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("skill_slug") != self.skill_slug or entry.get("mode") != mode:
+                    continue
+                cycle_summary = entry.get("cycle_summary")
+                if not isinstance(cycle_summary, dict):
+                    continue
+                equity = _float_or_none(cycle_summary.get("equity_end_usd"))
+                if equity is None:
+                    continue
+                previous_equity = equity
+                peak_equity = equity if peak_equity is None else max(peak_equity, equity)
+        return previous_equity, peak_equity
+
+    def _print_trade_report(self, report: dict[str, Any]) -> None:
+        cycle_summary = report.get("cycle_summary", {})
+        trades = report.get("trades", [])
+        open_positions = report.get("open_positions", [])
+        print(
+            f"[trade-report] {self.skill_slug} "
+            f"{report.get('mode')}/{report.get('status')} run={report.get('run_id')}"
+        )
+        print(
+            "  realized="
+            f"{_format_money(_float_or_none(cycle_summary.get('realized_pnl_usd')))} "
+            "unrealized="
+            f"{_format_money(_float_or_none(cycle_summary.get('unrealized_pnl_usd')))} "
+            "fees="
+            f"{_format_money(_float_or_none(cycle_summary.get('fees_usd')))} "
+            "equity="
+            f"{_format_money(_float_or_none(cycle_summary.get('equity_end_usd')))}"
+        )
+        print("  Trades:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Fill", "Current", "Realized", "Order"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("fill_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("realized_pnl_usd"))),
+                        str(row.get("order_id") or "-"),
+                    ]
+                    for row in trades
+                ],
+            )
+        )
+        print("  Open Positions:")
+        print(
+            _render_table(
+                ["Market", "Side", "Qty", "Entry", "Current", "Value", "Unrealized"],
+                [
+                    [
+                        str(row.get("market") or row.get("symbol") or "-"),
+                        str(row.get("side") or "-"),
+                        _format_qty(_float_or_none(row.get("quantity"))),
+                        _format_money(_float_or_none(row.get("entry_price"))),
+                        _format_money(_float_or_none(row.get("current_price"))),
+                        _format_money(_float_or_none(row.get("market_value_usd"))),
+                        _format_money(_float_or_none(row.get("unrealized_pnl_usd"))),
+                    ]
+                    for row in open_positions
+                ],
+            )
+        )
 
     def _executemany(self, query: str, rows: list[tuple[Any, ...]]) -> None:
         if not rows or not self.enabled:

--- a/tests/test_kraken_smart_dca_trade_reports.py
+++ b/tests/test_kraken_smart_dca_trade_reports.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_local_module(module_name: str):
+    script_dir = Path(__file__).resolve().parents[1] / "kraken" / "smart-dca-bot" / "scripts"
+    script_dir_str = str(script_dir)
+    sys.path[:] = [script_dir_str, *[path for path in sys.path if path != script_dir_str]]
+    for cached_name in ("agent", "serendb_store", "normalized_trade_store"):
+        sys.modules.pop(cached_name, None)
+    spec = importlib.util.spec_from_file_location(
+        f"test_kraken_smart_dca_{module_name}",
+        script_dir / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_no_db_session_still_emits_trade_report(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTHONUNBUFFERED", "1")
+    store_module = _load_local_module("serendb_store")
+    store = store_module.SerenDBStore(None)
+    session_id = "run-001"
+
+    store.create_session(session_id, "single_asset", {"dry_run": True})
+    store.persist_execution(
+        {
+            "execution_id": "exec-1",
+            "mode": "single_asset",
+            "asset": "XBTUSD",
+            "target_amount_usd": 50.0,
+            "executed_amount_usd": 50.0,
+            "executed_price": 50000.0,
+            "vwap_at_execution": 50010.0,
+            "savings_vs_naive_bps": 8,
+            "strategy": "simple",
+            "window_start": "2026-03-20T00:00:00Z",
+            "window_end": "2026-03-20T00:05:00Z",
+            "executed_at": "2026-03-20T00:05:00Z",
+            "status": "filled",
+            "kraken_order_id": "ord-1",
+            "metadata": {
+                "session_id": session_id,
+                "decision": {"side": "buy", "order_type": "market"},
+            },
+        }
+    )
+    store.persist_portfolio_snapshot(
+        {
+            "session_id": session_id,
+            "snapshot_id": "snap-1",
+            "total_value_usd": 1500.0,
+            "allocations": {"XBTUSD": 1.0},
+            "target_allocations": {"XBTUSD": 1.0},
+            "drift_max_pct": 0.0,
+            "created_at": "2026-03-20T00:06:00Z",
+        }
+    )
+    store.close_session(
+        session_id=session_id,
+        status="completed",
+        total_invested_usd=50.0,
+        total_savings_bps=8,
+    )
+
+    report_path = tmp_path / "logs" / "trade_reports.jsonl"
+    report = json.loads(report_path.read_text(encoding="utf-8").strip())
+    assert report["skill_slug"] == "kraken-smart-dca-bot"
+    assert report["status"] == "completed"
+    assert report["cycle_summary"]["fill_count"] == 1
+    assert report["open_positions"][0]["symbol"] == "XBTUSD"
+    assert report["trades"][0]["order_id"] == "ord-1"
+
+    stdout = capsys.readouterr().out
+    assert "[trade-report] kraken-smart-dca-bot" in stdout


### PR DESCRIPTION
Closes #195

## Summary
- add structured `logs/trade_reports.jsonl` emission plus unbuffered stdout tables to the shared normalized trading store path
- wire the smart-DCA, grid-trader, and Alpaca short-trader persistence layers into the same post-cycle reporting contract
- add focused coverage for the normalized/no-DB DCA path, legacy grid cycle reports, and Alpaca terminal run reports

## Verification
- `pytest tests/test_kraken_smart_dca_trade_reports.py kraken/grid-trader/tests/test_grid_trade_reports.py alpaca/saas-short-trader/tests/test_alpaca_trade_reports.py coinbase/grid-trader/scripts/test_serendb_store.py`
- `python3 -m compileall alphagrowth/euler-base-vault-bot/scripts curve/curve-gauge-yield-trader/scripts spectra/spectra-pt-yield-trader/scripts polymarket/maker-rebate-bot/scripts polymarket/paired-market-basis-maker/scripts polymarket/high-throughput-paired-basis-maker/scripts polymarket/liquidity-paired-basis-maker/scripts kraken/smart-dca-bot/scripts coinbase/smart-dca-bot/scripts kraken/grid-trader/scripts coinbase/grid-trader/scripts alpaca/saas-short-trader/scripts alpaca/sass-short-trader-delta-neutral/scripts`