### PR TITLE
feat: add adaptive self-learning runtime to Kraken grid trader

### DIFF
--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -23,11 +23,13 @@ With 15 fills per day: **$252/day or $7,560/month** (75.6% monthly return)
 ## Features
 
 - **Mechanical Strategy**: No predictions, just profit from volatility
-- **Risk Management**: Stop-loss, position limits, bankroll protection
+- **Adaptive Runtime**: Re-centers the grid, adjusts spacing/order size, and persists accepted parameters across runs
+- **Shadow Evaluation**: Scores candidate settings in the background before promotion or rollback
+- **Risk Management**: Stop-loss, daily loss caps, position limits, open-order caps, and cooldowns after loss streaks
 - **Cost Efficient**: 0.16% maker fees via Kraken
 - **Always Active**: Always has opportunities (unlike prediction markets)
-- **Audit Trail**: JSONL logs for every trade
-- **Dry-Run Mode**: Test strategy without risking capital
+- **Audit Trail**: JSONL logs for setup, metrics, fills, reviews, and alerts
+- **Dry-Run Adaptive Path**: Test adaptive decisions without placing real orders
 
 ## Quick Start
 
@@ -119,8 +121,20 @@ python scripts/agent.py setup --config config.json
 # Simulate trading (no real orders)
 python scripts/agent.py dry-run --config config.json --cycles 10
 
+# Run exactly one adaptive cycle
+python scripts/agent.py cycle --config config.json
+
+# Run one live adaptive cycle
+python scripts/agent.py cycle --config config.json --allow-live
+
 # Start live trading
-python scripts/agent.py start --config config.json
+python scripts/agent.py start --config config.json --allow-live
+
+# Generate weekly review JSON
+python scripts/agent.py review --config config.json
+
+# Run one-shot safety checks
+python scripts/agent.py safety-check --config config.json
 
 # Check current status
 python scripts/agent.py status --config config.json
@@ -165,6 +179,8 @@ python scripts/agent.py stop --config config.json
 - **price_range**: Min/max prices for grid (should span 20-30% range)
 - **scan_interval_seconds**: How often to check for fills (60s recommended)
 - **stop_loss_bankroll**: Auto-stop if value drops below this (80% of bankroll)
+- **daily_loss_cap_usd**: Pause new risk if realized + unrealized daily loss breaches the cap
+- **cooldown_after_consecutive_losses**: Number of losing cycles before adaptive cooldown kicks in
 
 ## Cost Analysis
 
@@ -207,7 +223,12 @@ All operations logged to `logs/` directory as JSONL files:
 - `orders.jsonl` - Order placements/cancellations
 - `fills.jsonl` - Trade executions
 - `positions.jsonl` - Position snapshots
+- `metrics.jsonl` - Per-cycle adaptive telemetry and rolling windows
+- `weekly_reviews.jsonl` - Weekly review summaries
+- `alerts.jsonl` - Safety incidents and repeated failures
 - `errors.jsonl` - Errors and warnings
+
+Adaptive state persists in `state/adaptive_state.json`, including accepted parameters, shadow scores, recent cycles, and known open orders for one-shot cron execution.
 
 ## SerenDB Persistence
 
@@ -224,10 +245,27 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 ## Safety Features
 
 1. **Stop-Loss**: Auto-stops if bankroll drops below threshold
-2. **Position Limits**: Prevents overexposure
-3. **Dry-Run Mode**: Test without risking capital
-4. **Audit Trail**: Every trade logged
-5. **Graceful Shutdown**: Cancels all orders on exit
+2. **Daily Loss Caps + Cooldowns**: New buys pause after loss streaks or daily drawdown breaches
+3. **Position/Open Order Limits**: Prevents overexposure and runaway order spam
+4. **Shadow Promotion Gate**: Candidate settings must outperform the baseline before promotion
+5. **Audit Trail**: Every cycle, review, fill, and alert is logged
+6. **Graceful Shutdown**: Cancels all orders on exit
+
+## seren-cron
+
+The preferred automation path is one-shot scheduling:
+
+```bash
+python scripts/run_agent_server.py --config config.json --port 8787
+python scripts/setup_cron.py create \
+  --runner-url "https://YOUR_PUBLIC_RUNNER_URL" \
+  --webhook-secret "$KRAKEN_GRID_WEBHOOK_SECRET"
+```
+
+This creates three jobs by default:
+- `kraken-grid-trader-cycle`
+- `kraken-grid-trader-safety-check`
+- `kraken-grid-trader-weekly-review`
 
 ## Troubleshooting
 

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -16,7 +16,7 @@ Automated grid trading bot for Kraken that profits from BTC volatility using a m
 **Immediately run a dry-run grid simulation without asking.** Do not present a menu of modes. Execute:
 
 ```bash
-cd ~/.config/seren/skills/grid-trader && source .venv/bin/activate && python3 scripts/agent.py --config config.json
+cd ~/.config/seren/skills/grid-trader && source .venv/bin/activate && python3 scripts/agent.py dry-run --config config.json --cycles 5
 ```
 
 Display the full dry-run results to the user. Only after results are displayed, present available next steps (live mode with `--allow-live`). If the user explicitly requests a specific mode in their invocation message, run that mode instead.
@@ -25,7 +25,9 @@ Display the full dry-run results to the user. Only after results are displayed, 
 
 - Automated Kraken grid trading with dry-run and live modes
 - Pair selection support (single pair or candidate list)
-- JSONL logs for setup, orders, fills, positions, and errors
+- Adaptive grid centering, spacing/order-size tuning, and persistent learning state
+- Shadow evaluation with gated promotion and rollback
+- JSONL logs for setup, metrics, orders, fills, positions, weekly reviews, alerts, and errors
 - MCP-native SerenDB persistence for sessions, events, orders, fills, and position snapshots
 
 ## What is Grid Trading?
@@ -62,6 +64,7 @@ Dependency validation is required before live trading. Verify `SEREN_API_KEY`, K
 Default mode is dry-run. Live trading requires:
 
 - `python scripts/agent.py start --config config.json --allow-live`
+- or `python scripts/agent.py cycle --config config.json --allow-live`
 - the normal startup risk checks to pass
 
 The `--allow-live` flag is a startup-only opt-in for that process. It is not a per-order approval prompt.
@@ -85,7 +88,7 @@ Persistence is best-effort: if SerenDB/MCP is unavailable, trading still runs an
 
 ## Configuration
 
-See `config.example.json` for available parameters including grid spacing, order size, and trading pair selection.
+See `config.example.json` for available parameters including grid spacing, order size, trading pair selection, daily loss caps, cooldowns, shadow thresholds, and adaptive state paths.
 
 ## Disclaimer
 
@@ -93,7 +96,7 @@ This bot trades real money. Use at your own risk. Past performance does not guar
 
 ## Seren-Cron Integration
 
-Use `seren-cron` to run this skill on a schedule — no terminal windows to keep open, no daemons, no permanent computer changes required. Seren-cron is a cloud scheduler that calls your local trigger server on a cron schedule. Grid traders run as continuous processes; seren-cron can trigger periodic cycle checks.
+Use `seren-cron` to run this skill on a schedule. The preferred automation path is one-shot scheduling: a fast adaptive `cycle`, a `safety-check`, and a weekly `review`. All three share a runtime lock so overlapping cron invocations fail closed instead of double-submitting orders.
 
 **Requirements:** Seren Desktop login or a valid `SEREN_API_KEY`.
 
@@ -136,7 +139,8 @@ If jobs for this skill already exist, show them to the user and ask:
 Start the webhook server that seren-cron will call on each scheduled tick:
 
 ```bash
-SEREN_API_KEY="$SEREN_API_KEY" python3 scripts/run_agent_server.py --config config.json --port 8080
+SEREN_API_KEY="$SEREN_API_KEY" KRAKEN_GRID_WEBHOOK_SECRET="$KRAKEN_GRID_WEBHOOK_SECRET" \
+python3 scripts/run_agent_server.py --config config.json --port 8080
 ```
 
 This process runs in your terminal session. When you close the terminal, it stops — **that is expected and correct**. Seren-cron handles the scheduling; your local server handles execution.
@@ -145,47 +149,42 @@ This process runs in your terminal session. When you close the terminal, it stop
 
 With the server running, create the scheduled job:
 
-```text
-publisher: seren-cron
-path:      /jobs
-method:    POST
-body: {
-  "name":            "kraken-grid-trader-live",
-  "url":             "http://localhost:8080/run",
-  "method":          "POST",
-  "cron_expression": "*/5 * * * *",
-  "timezone":        "UTC",
-  "enabled":         true,
-  "timeout_seconds": 60
-}
+```bash
+python3 scripts/setup_cron.py create \
+  --runner-url "https://YOUR_PUBLIC_RUNNER_URL" \
+  --webhook-secret "$KRAKEN_GRID_WEBHOOK_SECRET"
 ```
 
-Save the returned `job_id` — you need it to pause, resume, or delete the job later.
+This creates or updates:
+
+- `kraken-grid-trader-cycle`
+- `kraken-grid-trader-safety-check`
+- `kraken-grid-trader-weekly-review`
 
 ### Step 5 — Manage the schedule
 
 **List all active jobs:**
 
-```text
-publisher: seren-cron, path: /jobs, method: GET
+```bash
+python3 scripts/setup_cron.py list
 ```
 
 **Pause:**
 
-```text
-publisher: seren-cron, path: /jobs/{job_id}/pause, method: POST
+```bash
+python3 scripts/setup_cron.py pause --job-id <job_id>
 ```
 
 **Resume:**
 
-```text
-publisher: seren-cron, path: /jobs/{job_id}/resume, method: POST
+```bash
+python3 scripts/setup_cron.py resume --job-id <job_id>
 ```
 
 **Stop permanently:**
 
-```text
-publisher: seren-cron, path: /jobs/{job_id}, method: DELETE
+```bash
+python3 scripts/setup_cron.py delete --job-id <job_id>
 ```
 
 ### Insufficient Funds Guard

--- a/kraken/grid-trader/config.example.json
+++ b/kraken/grid-trader/config.example.json
@@ -35,5 +35,28 @@
     "cancel_on_error": true,
     "operation_timeout_seconds": 30,
     "cycle_timeout_seconds": 90
+  },
+  "adaptive": {
+    "enabled": true,
+    "state_path": "state/adaptive_state.json",
+    "lock_path": "state/runtime.lock",
+    "slippage_buffer_pct": 0.2,
+    "min_spacing_percent": 0.0,
+    "max_spacing_multiplier": 2.5,
+    "min_order_size_multiplier": 0.25,
+    "max_order_size_multiplier": 1.0,
+    "min_risk_multiplier": 0.35,
+    "max_risk_multiplier": 1.0,
+    "cooldown_after_consecutive_losses": 3,
+    "cooldown_minutes": 60,
+    "daily_loss_cap_usd": 150.0,
+    "shadow_min_samples": 5,
+    "shadow_improvement_threshold_pct": 5.0,
+    "shadow_rollback_degradation_pct": 10.0,
+    "metrics_log_path": "logs/metrics.jsonl",
+    "review_log_path": "logs/weekly_reviews.jsonl",
+    "review_output_dir": "logs/reviews",
+    "alert_log_path": "logs/alerts.jsonl",
+    "max_failure_count_before_alert": 3
   }
 }

--- a/kraken/grid-trader/scripts/adaptive_runtime.py
+++ b/kraken/grid-trader/scripts/adaptive_runtime.py
@@ -1,0 +1,749 @@
+"""Adaptive runtime helpers for kraken/grid-trader."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import math
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterator
+
+
+UTC = timezone.utc
+ROUND_TRIP_FEE_PCT = 0.32
+
+DEFAULT_ADAPTIVE_SETTINGS: dict[str, Any] = {
+    "enabled": True,
+    "state_path": "state/adaptive_state.json",
+    "lock_path": "state/runtime.lock",
+    "slippage_buffer_pct": 0.2,
+    "min_spacing_percent": 0.0,
+    "max_spacing_multiplier": 2.5,
+    "min_order_size_multiplier": 0.25,
+    "max_order_size_multiplier": 1.0,
+    "min_risk_multiplier": 0.35,
+    "max_risk_multiplier": 1.0,
+    "cooldown_after_consecutive_losses": 3,
+    "cooldown_minutes": 60,
+    "daily_loss_cap_usd": 0.0,
+    "shadow_min_samples": 5,
+    "shadow_improvement_threshold_pct": 5.0,
+    "shadow_rollback_degradation_pct": 10.0,
+    "metrics_log_path": "logs/metrics.jsonl",
+    "review_log_path": "logs/weekly_reviews.jsonl",
+    "review_output_dir": "logs/reviews",
+    "alert_log_path": "logs/alerts.jsonl",
+    "max_failure_count_before_alert": 3,
+}
+
+
+class RuntimeLockError(RuntimeError):
+    """Raised when another adaptive runtime already owns the mutation lock."""
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_append(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def resolve_adaptive_settings(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("adaptive", {})
+    settings = dict(DEFAULT_ADAPTIVE_SETTINGS)
+    if isinstance(raw, dict):
+        settings.update(raw)
+    settings["enabled"] = bool(settings.get("enabled", True))
+    settings["state_path"] = str(settings.get("state_path", DEFAULT_ADAPTIVE_SETTINGS["state_path"]))
+    settings["lock_path"] = str(settings.get("lock_path", DEFAULT_ADAPTIVE_SETTINGS["lock_path"]))
+    settings["metrics_log_path"] = str(settings.get("metrics_log_path", DEFAULT_ADAPTIVE_SETTINGS["metrics_log_path"]))
+    settings["review_log_path"] = str(settings.get("review_log_path", DEFAULT_ADAPTIVE_SETTINGS["review_log_path"]))
+    settings["review_output_dir"] = str(settings.get("review_output_dir", DEFAULT_ADAPTIVE_SETTINGS["review_output_dir"]))
+    settings["alert_log_path"] = str(settings.get("alert_log_path", DEFAULT_ADAPTIVE_SETTINGS["alert_log_path"]))
+    settings["slippage_buffer_pct"] = _safe_float(settings.get("slippage_buffer_pct"), 0.2)
+    settings["min_spacing_percent"] = _safe_float(settings.get("min_spacing_percent"), 0.0)
+    settings["max_spacing_multiplier"] = max(_safe_float(settings.get("max_spacing_multiplier"), 2.5), 1.0)
+    settings["min_order_size_multiplier"] = _clamp(
+        _safe_float(settings.get("min_order_size_multiplier"), 0.25), 0.05, 1.0
+    )
+    settings["max_order_size_multiplier"] = _clamp(
+        _safe_float(settings.get("max_order_size_multiplier"), 1.0), settings["min_order_size_multiplier"], 1.0
+    )
+    settings["min_risk_multiplier"] = _clamp(_safe_float(settings.get("min_risk_multiplier"), 0.35), 0.05, 1.0)
+    settings["max_risk_multiplier"] = _clamp(
+        _safe_float(settings.get("max_risk_multiplier"), 1.0),
+        settings["min_risk_multiplier"],
+        1.0,
+    )
+    settings["cooldown_after_consecutive_losses"] = max(
+        int(_safe_float(settings.get("cooldown_after_consecutive_losses"), 3)),
+        1,
+    )
+    settings["cooldown_minutes"] = max(int(_safe_float(settings.get("cooldown_minutes"), 60)), 1)
+    settings["daily_loss_cap_usd"] = max(_safe_float(settings.get("daily_loss_cap_usd"), 0.0), 0.0)
+    settings["shadow_min_samples"] = max(int(_safe_float(settings.get("shadow_min_samples"), 5)), 2)
+    settings["shadow_improvement_threshold_pct"] = max(
+        _safe_float(settings.get("shadow_improvement_threshold_pct"), 5.0), 0.0
+    )
+    settings["shadow_rollback_degradation_pct"] = max(
+        _safe_float(settings.get("shadow_rollback_degradation_pct"), 10.0), 0.0
+    )
+    settings["max_failure_count_before_alert"] = max(
+        int(_safe_float(settings.get("max_failure_count_before_alert"), 3)), 1
+    )
+    return settings
+
+
+@contextmanager
+def runtime_lock(lock_path: str | Path) -> Iterator[None]:
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeLockError(f"another kraken-grid-trader adaptive run is already active ({path})") from exc
+        handle.seek(0)
+        handle.truncate()
+        handle.write(json.dumps({"pid": os.getpid(), "acquired_at": _now_iso()}, sort_keys=True))
+        handle.flush()
+        try:
+            yield
+        finally:
+            handle.seek(0)
+            handle.truncate()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _default_state() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "updated_at": None,
+        "ema_volatility_pct": 0.0,
+        "current_risk_multiplier": 1.0,
+        "win_streak": 0,
+        "loss_streak": 0,
+        "cooldown_until": None,
+        "latest_regime_tag": "range",
+        "last_accepted_params": {},
+        "baseline_summary": {"scores": [], "rolling_score": 0.0},
+        "candidate_summary": {"scores": [], "rolling_score": 0.0, "candidate_params": {}},
+        "recent_cycles": [],
+        "recent_fills": [],
+        "known_open_orders": {},
+        "parameter_history": [],
+        "promotion_history": [],
+        "risk_incidents": [],
+        "daily_pnl": {"date": None, "equity_start_usd": None, "equity_end_usd": None, "net_change_usd": 0.0},
+        "failure_state": {"count": 0, "last_error": "", "last_failure_at": None},
+        "review_reports": [],
+    }
+
+
+class AdaptiveStateStore:
+    """Persist adaptive trading state across grid-trader restarts."""
+
+    def __init__(self, settings: dict[str, Any]) -> None:
+        self.settings = settings
+        self.path = Path(settings["state_path"])
+        self.metrics_log_path = Path(settings["metrics_log_path"])
+        self.review_log_path = Path(settings["review_log_path"])
+        self.review_output_dir = Path(settings["review_output_dir"])
+        self.alert_log_path = Path(settings["alert_log_path"])
+        self.state = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            payload = {}
+        except json.JSONDecodeError:
+            payload = {}
+        state = _default_state()
+        if isinstance(payload, dict):
+            state.update(payload)
+        state.setdefault("recent_cycles", [])
+        state.setdefault("recent_fills", [])
+        state.setdefault("known_open_orders", {})
+        state.setdefault("parameter_history", [])
+        state.setdefault("promotion_history", [])
+        state.setdefault("risk_incidents", [])
+        state.setdefault("review_reports", [])
+        state.setdefault("failure_state", {"count": 0, "last_error": "", "last_failure_at": None})
+        state.setdefault("daily_pnl", {"date": None, "equity_start_usd": None, "equity_end_usd": None, "net_change_usd": 0.0})
+        state.setdefault("baseline_summary", {"scores": [], "rolling_score": 0.0})
+        state.setdefault("candidate_summary", {"scores": [], "rolling_score": 0.0, "candidate_params": {}})
+        return state
+
+    def save(self) -> None:
+        self.state["updated_at"] = _now_iso()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.state, sort_keys=True, indent=2), encoding="utf-8")
+
+    def accepted_params(self, fallback: dict[str, Any]) -> dict[str, Any]:
+        params = self.state.get("last_accepted_params")
+        if not isinstance(params, dict) or not params:
+            params = dict(fallback)
+            self.state["last_accepted_params"] = dict(params)
+        return dict(params)
+
+    def append_fill(self, fill_event: dict[str, Any]) -> None:
+        recent_fills = list(self.state.get("recent_fills", []))
+        recent_fills.append(fill_event)
+        self.state["recent_fills"] = recent_fills[-200:]
+
+    def append_cycle(self, cycle_snapshot: dict[str, Any]) -> None:
+        recent_cycles = list(self.state.get("recent_cycles", []))
+        recent_cycles.append(cycle_snapshot)
+        self.state["recent_cycles"] = recent_cycles[-200:]
+        _json_append(self.metrics_log_path, cycle_snapshot)
+
+    def note_incident(self, incident_type: str, payload: dict[str, Any]) -> None:
+        incidents = list(self.state.get("risk_incidents", []))
+        incidents.append(
+            {
+                "incident_type": incident_type,
+                "payload": payload,
+                "recorded_at": _now_iso(),
+            }
+        )
+        self.state["risk_incidents"] = incidents[-100:]
+        _json_append(
+            self.alert_log_path,
+            {
+                "recorded_at": _now_iso(),
+                "kind": "risk_incident",
+                "incident_type": incident_type,
+                "payload": payload,
+            },
+        )
+
+    def register_failure(self, error_message: str) -> None:
+        failure_state = dict(self.state.get("failure_state", {}))
+        count = int(failure_state.get("count", 0)) + 1
+        failure_state.update(
+            {
+                "count": count,
+                "last_error": error_message,
+                "last_failure_at": _now_iso(),
+            }
+        )
+        self.state["failure_state"] = failure_state
+        if count >= int(self.settings["max_failure_count_before_alert"]):
+            _json_append(
+                self.alert_log_path,
+                {
+                    "recorded_at": _now_iso(),
+                    "kind": "repeated_failures",
+                    "count": count,
+                    "last_error": error_message,
+                },
+            )
+
+    def clear_failures(self) -> None:
+        self.state["failure_state"] = {"count": 0, "last_error": "", "last_failure_at": None}
+
+    def update_daily_pnl(self, *, equity_end_usd: float) -> dict[str, Any]:
+        daily = dict(self.state.get("daily_pnl", {}))
+        today = _now().date().isoformat()
+        start_equity = daily.get("equity_start_usd")
+        if daily.get("date") != today or start_equity is None:
+            daily = {
+                "date": today,
+                "equity_start_usd": float(equity_end_usd),
+                "equity_end_usd": float(equity_end_usd),
+                "net_change_usd": 0.0,
+            }
+        else:
+            daily["equity_end_usd"] = float(equity_end_usd)
+            daily["net_change_usd"] = float(equity_end_usd) - float(start_equity)
+        self.state["daily_pnl"] = daily
+        return daily
+
+    def in_cooldown(self, now: datetime | None = None) -> bool:
+        until = _parse_iso(self.state.get("cooldown_until"))
+        if until is None:
+            return False
+        reference = now or _now()
+        return reference < until
+
+    def set_cooldown(self, minutes: int) -> None:
+        self.state["cooldown_until"] = (_now() + timedelta(minutes=minutes)).isoformat()
+
+    def clear_cooldown(self) -> None:
+        self.state["cooldown_until"] = None
+
+    def record_review(self, report: dict[str, Any]) -> Path:
+        self.review_output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = self.review_output_dir / f"weekly_review_{_now().strftime('%Y%m%dT%H%M%SZ')}.json"
+        report_path.write_text(json.dumps(report, sort_keys=True, indent=2), encoding="utf-8")
+        _json_append(self.review_log_path, report)
+        review_reports = list(self.state.get("review_reports", []))
+        review_reports.append({"generated_at": report["generated_at"], "path": str(report_path)})
+        self.state["review_reports"] = review_reports[-20:]
+        return report_path
+
+
+@dataclass
+class AdaptiveDecision:
+    accepted_params: dict[str, Any]
+    candidate_params: dict[str, Any]
+    dynamic_center_price: float
+    dynamic_range: dict[str, float]
+    volatility_metrics: dict[str, float]
+    regime_tag: str
+    reasons: list[str]
+    cooldown_active: bool
+    baseline_score: float
+    candidate_score: float
+    promoted: bool
+    rolled_back: bool
+    daily_loss_triggered: bool
+
+
+def _window(items: list[dict[str, Any]], size: int) -> list[dict[str, Any]]:
+    return items[-size:]
+
+
+def _rolling_mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return mean(values)
+
+
+def _rolling_stddev(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    avg = _rolling_mean(values)
+    variance = sum((value - avg) ** 2 for value in values) / len(values)
+    return math.sqrt(max(variance, 0.0))
+
+
+def _compute_regime(price_history: list[float], rolling_stddev_pct: float) -> str:
+    if len(price_history) < 5:
+        return "range"
+    short = _rolling_mean(price_history[-5:])
+    long = _rolling_mean(price_history[-20:] if len(price_history) >= 20 else price_history)
+    if long <= 0:
+        return "range"
+    trend_pct = (short - long) / long * 100.0
+    threshold = max(rolling_stddev_pct * 0.35, 0.35)
+    if trend_pct >= threshold:
+        return "trend_up"
+    if trend_pct <= -threshold:
+        return "trend_down"
+    return "range"
+
+
+def compute_market_metrics(
+    *,
+    recent_cycles: list[dict[str, Any]],
+    current_price: float,
+    bid: float,
+    ask: float,
+    high: float,
+    low: float,
+) -> dict[str, float | str]:
+    price_history = [_safe_float(item.get("market_price")) for item in recent_cycles if item.get("market_price") is not None]
+    price_history.append(float(current_price))
+    atr_pct = 0.0
+    if current_price > 0:
+        atr_pct = max((float(high) - float(low)) / float(current_price) * 100.0, 0.0)
+    returns = []
+    for previous, current in zip(price_history[:-1], price_history[1:]):
+        if previous > 0:
+            returns.append((current - previous) / previous * 100.0)
+    rolling_stddev_pct = _rolling_stddev(returns)
+    regime_tag = _compute_regime(price_history, rolling_stddev_pct)
+    mid_price = (float(bid) + float(ask)) / 2.0 if float(ask) > 0 else float(current_price)
+    spread_pct = ((float(ask) - float(bid)) / mid_price * 100.0) if mid_price > 0 else 0.0
+    return {
+        "mid_price": round(mid_price, 6),
+        "spread_pct": round(max(spread_pct, 0.0), 6),
+        "atr_pct": round(atr_pct, 6),
+        "rolling_stddev_pct": round(max(rolling_stddev_pct, 0.0), 6),
+        "regime_tag": regime_tag,
+    }
+
+
+def _fee_floor_percent(settings: dict[str, Any]) -> float:
+    configured_min = max(_safe_float(settings.get("min_spacing_percent")), 0.0)
+    fee_floor = (2.0 * ROUND_TRIP_FEE_PCT) + _safe_float(settings.get("slippage_buffer_pct"), 0.2)
+    return max(configured_min, fee_floor)
+
+
+def _vwap_from_recent_fills(recent_fills: list[dict[str, Any]]) -> float | None:
+    samples = recent_fills[-20:]
+    total_notional = 0.0
+    total_qty = 0.0
+    for fill in samples:
+        price = _safe_float(fill.get("price"))
+        quantity = _safe_float(fill.get("quantity"))
+        if price <= 0 or quantity <= 0:
+            continue
+        total_notional += price * quantity
+        total_qty += quantity
+    if total_qty <= 0:
+        return None
+    return total_notional / total_qty
+
+
+def compute_adaptive_decision(
+    *,
+    store: AdaptiveStateStore,
+    config: dict[str, Any],
+    market_metrics: dict[str, float | str],
+    live_risk: dict[str, Any],
+    current_price: float,
+) -> AdaptiveDecision:
+    strategy = config.get("strategy", {})
+    risk_management = config.get("risk_management", {})
+    settings = store.settings
+    base_spacing = _safe_float(strategy.get("grid_spacing_percent"), 2.0)
+    base_order_size = _safe_float(strategy.get("order_size_percent"), 5.0)
+    base_max_open_orders = max(int(_safe_float(risk_management.get("max_open_orders"), 40)), 1)
+    fee_floor = _fee_floor_percent(settings)
+    rolling_stddev_pct = _safe_float(market_metrics.get("rolling_stddev_pct"))
+    atr_pct = _safe_float(market_metrics.get("atr_pct"))
+    regime_tag = str(market_metrics.get("regime_tag") or "range")
+    drawdown_pct = _safe_float(live_risk.get("drawdown_pct"))
+    loss_streak = int(store.state.get("loss_streak", 0))
+    win_streak = int(store.state.get("win_streak", 0))
+
+    risk_multiplier = 1.0
+    reasons: list[str] = []
+
+    if atr_pct >= 8.0 or rolling_stddev_pct >= 3.0:
+        risk_multiplier *= 0.7
+        reasons.append("high volatility widened spacing and reduced risk")
+    elif atr_pct <= 3.0 and rolling_stddev_pct <= 1.0:
+        risk_multiplier *= 1.0
+        reasons.append("low volatility allowed tighter spacing")
+
+    if regime_tag != "range":
+        risk_multiplier *= 0.85
+        reasons.append(f"{regime_tag} regime reduced aggressiveness")
+
+    if drawdown_pct >= 10.0:
+        risk_multiplier *= 0.6
+        reasons.append("drawdown exceeded 10% so risk was cut sharply")
+    elif drawdown_pct >= 5.0:
+        risk_multiplier *= 0.8
+        reasons.append("drawdown exceeded 5% so risk was reduced")
+
+    if loss_streak > 0:
+        risk_multiplier *= 0.85 ** loss_streak
+        reasons.append("losing streak applied additional cooldown pressure")
+    elif win_streak >= 3 and regime_tag == "range":
+        reasons.append("winning streak retained base risk but did not exceed configured caps")
+
+    risk_multiplier = _clamp(
+        risk_multiplier,
+        _safe_float(settings["min_risk_multiplier"]),
+        _safe_float(settings["max_risk_multiplier"]),
+    )
+
+    spacing_multiplier = 1.0 + min(max(atr_pct / 10.0, 0.0), 1.5)
+    if regime_tag == "range" and atr_pct <= 4.0:
+        spacing_multiplier *= 0.9
+    if regime_tag != "range":
+        spacing_multiplier *= 1.1
+
+    candidate_spacing = _clamp(
+        max(base_spacing * spacing_multiplier, fee_floor),
+        fee_floor,
+        max(base_spacing * _safe_float(settings["max_spacing_multiplier"], 2.5), fee_floor),
+    )
+    candidate_order_size = _clamp(
+        base_order_size * risk_multiplier,
+        base_order_size * _safe_float(settings["min_order_size_multiplier"], 0.25),
+        base_order_size * _safe_float(settings["max_order_size_multiplier"], 1.0),
+    )
+    candidate_max_open_orders = max(
+        2,
+        min(base_max_open_orders, int(round(base_max_open_orders * max(risk_multiplier, 0.5)))),
+    )
+
+    recent_fills = list(store.state.get("recent_fills", []))
+    dynamic_center_price = _vwap_from_recent_fills(recent_fills) or float(current_price)
+    base_min = _safe_float(strategy.get("price_range", {}).get("min"), current_price * 0.9)
+    base_max = _safe_float(strategy.get("price_range", {}).get("max"), current_price * 1.1)
+    base_half_width = max((base_max - base_min) / 2.0, float(current_price) * 0.05)
+    width_multiplier = _clamp(1.0 + (atr_pct / 20.0), 0.8, 1.8)
+    dynamic_half_width = max(base_half_width * width_multiplier, float(current_price) * 0.05)
+    dynamic_range = {
+        "min": round(max(dynamic_center_price - dynamic_half_width, 0.01), 2),
+        "max": round(dynamic_center_price + dynamic_half_width, 2),
+    }
+
+    baseline_params = store.accepted_params(
+        {
+            "grid_spacing_percent": base_spacing,
+            "order_size_percent": base_order_size,
+            "max_open_orders": base_max_open_orders,
+            "risk_multiplier": 1.0,
+            "dynamic_range": dynamic_range,
+        }
+    )
+    candidate_params = {
+        "grid_spacing_percent": round(candidate_spacing, 4),
+        "order_size_percent": round(candidate_order_size, 4),
+        "max_open_orders": candidate_max_open_orders,
+        "risk_multiplier": round(risk_multiplier, 6),
+        "dynamic_range": dynamic_range,
+    }
+
+    baseline_score = _shadow_score(
+        market_metrics=market_metrics,
+        drawdown_pct=drawdown_pct,
+        params=baseline_params,
+        recent_cycles=list(store.state.get("recent_cycles", [])),
+    )
+    candidate_score = _shadow_score(
+        market_metrics=market_metrics,
+        drawdown_pct=drawdown_pct,
+        params=candidate_params,
+        recent_cycles=list(store.state.get("recent_cycles", [])),
+    )
+
+    promoted = False
+    rolled_back = False
+    candidate_summary = dict(store.state.get("candidate_summary", {}))
+    baseline_summary = dict(store.state.get("baseline_summary", {}))
+    baseline_scores = list(baseline_summary.get("scores", []))
+    candidate_scores = list(candidate_summary.get("scores", []))
+    baseline_scores.append(round(baseline_score, 6))
+    candidate_scores.append(round(candidate_score, 6))
+    baseline_scores = baseline_scores[-200:]
+    candidate_scores = candidate_scores[-200:]
+    baseline_summary["scores"] = baseline_scores
+    candidate_summary["scores"] = candidate_scores
+    baseline_summary["rolling_score"] = round(_rolling_mean(baseline_scores[-50:]), 6)
+    candidate_summary["rolling_score"] = round(_rolling_mean(candidate_scores[-50:]), 6)
+    candidate_summary["candidate_params"] = candidate_params
+
+    improvement_threshold = 1.0 + (_safe_float(settings["shadow_improvement_threshold_pct"]) / 100.0)
+    rollback_threshold = 1.0 - (_safe_float(settings["shadow_rollback_degradation_pct"]) / 100.0)
+    minimum_samples = int(settings["shadow_min_samples"])
+
+    accepted_params = dict(baseline_params)
+    if len(candidate_scores) >= minimum_samples:
+        baseline_mean = _rolling_mean(baseline_scores[-minimum_samples:])
+        candidate_mean = _rolling_mean(candidate_scores[-minimum_samples:])
+        if candidate_mean > baseline_mean * improvement_threshold:
+            accepted_params = dict(candidate_params)
+            promoted = True
+            store.state["promotion_history"] = (
+                list(store.state.get("promotion_history", []))
+                + [
+                    {
+                        "promoted_at": _now_iso(),
+                        "baseline_mean": round(baseline_mean, 6),
+                        "candidate_mean": round(candidate_mean, 6),
+                        "accepted_params": accepted_params,
+                    }
+                ]
+            )[-50:]
+            baseline_summary = {"scores": candidate_scores[-200:], "rolling_score": round(candidate_mean, 6)}
+            candidate_summary = {"scores": [], "rolling_score": 0.0, "candidate_params": accepted_params}
+            reasons.append("shadow evaluation promoted the adaptive candidate")
+
+    if store.state.get("promotion_history"):
+        recent_promotion = store.state["promotion_history"][-1]
+        promoted_mean = _safe_float(recent_promotion.get("candidate_mean"), 0.0)
+        if promoted_mean > 0 and baseline_summary.get("rolling_score", 0.0) < promoted_mean * rollback_threshold:
+            accepted_params = dict(baseline_params)
+            rolled_back = True
+            reasons.append("candidate rollback triggered after degradation")
+            store.state["promotion_history"] = (
+                list(store.state.get("promotion_history", []))
+                + [
+                    {
+                        "rolled_back": True,
+                        "rolled_back_at": _now_iso(),
+                        "promoted_mean": round(promoted_mean, 6),
+                        "baseline_rolling_score": round(_safe_float(baseline_summary.get("rolling_score")), 6),
+                    }
+                ]
+            )[-50:]
+
+    daily = store.state.get("daily_pnl", {})
+    daily_loss_triggered = False
+    daily_loss_cap = _safe_float(settings["daily_loss_cap_usd"])
+    if daily_loss_cap > 0 and abs(_safe_float(daily.get("net_change_usd"))) >= daily_loss_cap and _safe_float(daily.get("net_change_usd")) < 0:
+        daily_loss_triggered = True
+        reasons.append("daily loss cap triggered a trading pause")
+
+    cooldown_active = store.in_cooldown()
+    if loss_streak >= int(settings["cooldown_after_consecutive_losses"]):
+        store.set_cooldown(int(settings["cooldown_minutes"]))
+        cooldown_active = True
+        reasons.append("loss streak triggered cooldown")
+
+    store.state["ema_volatility_pct"] = round(
+        (_safe_float(store.state.get("ema_volatility_pct")) * 0.7) + (rolling_stddev_pct * 0.3),
+        6,
+    )
+    store.state["current_risk_multiplier"] = round(_safe_float(accepted_params.get("risk_multiplier", risk_multiplier)), 6)
+    store.state["latest_regime_tag"] = regime_tag
+    store.state["baseline_summary"] = baseline_summary
+    store.state["candidate_summary"] = candidate_summary
+    store.state["last_accepted_params"] = accepted_params
+
+    return AdaptiveDecision(
+        accepted_params=accepted_params,
+        candidate_params=candidate_params,
+        dynamic_center_price=round(dynamic_center_price, 6),
+        dynamic_range=dynamic_range,
+        volatility_metrics={
+            "atr_pct": round(atr_pct, 6),
+            "rolling_stddev_pct": round(rolling_stddev_pct, 6),
+            "ema_volatility_pct": _safe_float(store.state.get("ema_volatility_pct")),
+        },
+        regime_tag=regime_tag,
+        reasons=reasons or ["adaptive engine retained prior parameters"],
+        cooldown_active=cooldown_active,
+        baseline_score=round(baseline_score, 6),
+        candidate_score=round(candidate_score, 6),
+        promoted=promoted,
+        rolled_back=rolled_back,
+        daily_loss_triggered=daily_loss_triggered,
+    )
+
+
+def _shadow_score(
+    *,
+    market_metrics: dict[str, float | str],
+    drawdown_pct: float,
+    params: dict[str, Any],
+    recent_cycles: list[dict[str, Any]],
+) -> float:
+    spacing = _safe_float(params.get("grid_spacing_percent"))
+    risk_multiplier = _safe_float(params.get("risk_multiplier"), 1.0)
+    fill_rate = _rolling_mean([_safe_float(item.get("fill_rate")) for item in recent_cycles[-20:] if item.get("fill_rate") is not None])
+    recent_net = _rolling_mean([_safe_float(item.get("net_pnl_usd")) for item in recent_cycles[-20:] if item.get("net_pnl_usd") is not None])
+    volatility = _safe_float(market_metrics.get("rolling_stddev_pct"))
+    regime = str(market_metrics.get("regime_tag") or "range")
+    ideal_spacing = max(_safe_float(market_metrics.get("atr_pct")) * 0.35, 0.75)
+    spacing_penalty = abs(spacing - ideal_spacing)
+    regime_bonus = 1.0 if regime == "range" else -0.5
+    return (recent_net * 0.1) + (fill_rate * 5.0) + regime_bonus - (drawdown_pct * 0.35) - spacing_penalty - ((1.0 - risk_multiplier) * 2.0) - volatility
+
+
+def update_cycle_state(
+    *,
+    store: AdaptiveStateStore,
+    cycle_snapshot: dict[str, Any],
+) -> None:
+    net_pnl = _safe_float(cycle_snapshot.get("net_pnl_usd"))
+    if net_pnl > 0:
+        store.state["win_streak"] = int(store.state.get("win_streak", 0)) + 1
+        store.state["loss_streak"] = 0
+        store.clear_cooldown()
+    elif net_pnl < 0:
+        store.state["loss_streak"] = int(store.state.get("loss_streak", 0)) + 1
+        store.state["win_streak"] = 0
+    store.update_daily_pnl(equity_end_usd=_safe_float(cycle_snapshot.get("equity_end_usd")))
+    store.append_cycle(cycle_snapshot)
+    parameter_history = list(store.state.get("parameter_history", []))
+    parameter_history.append(
+        {
+            "recorded_at": cycle_snapshot.get("timestamp"),
+            "regime_tag": cycle_snapshot.get("regime_tag"),
+            "grid_spacing_percent": cycle_snapshot.get("grid_spacing_percent"),
+            "order_size_percent": cycle_snapshot.get("order_size_percent"),
+            "max_open_orders": cycle_snapshot.get("max_open_orders"),
+            "risk_multiplier": cycle_snapshot.get("risk_multiplier"),
+            "dynamic_center_price": cycle_snapshot.get("dynamic_center_price"),
+        }
+    )
+    store.state["parameter_history"] = parameter_history[-200:]
+
+
+def build_review_report(store: AdaptiveStateStore) -> dict[str, Any]:
+    recent_cycles = list(store.state.get("recent_cycles", []))
+    recent_params = list(store.state.get("parameter_history", []))
+    recent_incidents = list(store.state.get("risk_incidents", []))
+    cycle_count = len(recent_cycles)
+    last_50 = _window(recent_cycles, 50)
+    report = {
+        "generated_at": _now_iso(),
+        "cycle_count": cycle_count,
+        "rolling_windows": {
+            "last_50": summarize_window(last_50),
+            "last_200": summarize_window(_window(recent_cycles, 200)),
+        },
+        "latest_regime_tag": store.state.get("latest_regime_tag", "range"),
+        "current_risk_multiplier": store.state.get("current_risk_multiplier", 1.0),
+        "accepted_params": dict(store.state.get("last_accepted_params", {})),
+        "candidate_summary": dict(store.state.get("candidate_summary", {})),
+        "baseline_summary": dict(store.state.get("baseline_summary", {})),
+        "recent_parameter_changes": recent_params[-20:],
+        "risk_incidents": recent_incidents[-20:],
+        "promotion_history": list(store.state.get("promotion_history", []))[-20:],
+        "rollback_actions": [
+            item
+            for item in list(store.state.get("promotion_history", []))[-20:]
+            if item.get("rolled_back")
+        ],
+    }
+    return report
+
+
+def summarize_window(window: list[dict[str, Any]]) -> dict[str, Any]:
+    if not window:
+        return {
+            "count": 0,
+            "net_pnl_per_fill": 0.0,
+            "fill_rate": 0.0,
+            "max_drawdown": 0.0,
+            "cancel_rate": 0.0,
+            "regime_specific_score": 0.0,
+        }
+    fill_counts = [_safe_float(item.get("fill_count")) for item in window]
+    fill_rates = [_safe_float(item.get("fill_rate")) for item in window]
+    net_pnls = [_safe_float(item.get("net_pnl_usd")) for item in window]
+    drawdowns = [_safe_float(item.get("drawdown_pct")) for item in window]
+    cancel_rates = [_safe_float(item.get("cancel_rate")) for item in window]
+    scores = [_safe_float(item.get("candidate_score")) for item in window]
+    total_fills = sum(fill_counts)
+    return {
+        "count": len(window),
+        "net_pnl_per_fill": round(sum(net_pnls) / total_fills, 6) if total_fills > 0 else 0.0,
+        "fill_rate": round(_rolling_mean(fill_rates), 6),
+        "max_drawdown": round(max(drawdowns), 6),
+        "cancel_rate": round(_rolling_mean(cancel_rates), 6),
+        "regime_specific_score": round(_rolling_mean(scores), 6),
+    }

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -24,6 +24,17 @@ from typing import Dict, Any, Optional
 from pathlib import Path
 from dotenv import load_dotenv
 
+from adaptive_runtime import (
+    AdaptiveStateStore,
+    RuntimeLockError,
+    build_review_report,
+    compute_adaptive_decision,
+    compute_market_metrics,
+    resolve_adaptive_settings,
+    runtime_lock,
+    summarize_window,
+    update_cycle_state,
+)
 from seren_client import SerenClient
 from grid_manager import GridManager, optimize_backtest_configuration
 from position_tracker import PositionTracker
@@ -122,6 +133,9 @@ class KrakenGridTrader:
         self.running = False
         self.active_orders = {}  # order_id -> order_details
         self.live_risk_state = self._load_live_risk_state()
+        self.adaptive_settings = resolve_adaptive_settings(self.config)
+        self.adaptive_store = AdaptiveStateStore(self.adaptive_settings)
+        self.current_adaptive_decision = None
         self._cycle_deadline_at: Optional[float] = None
 
         try:
@@ -133,6 +147,7 @@ class KrakenGridTrader:
 
     def close(self):
         """Close any external resources."""
+        self.adaptive_store.save()
         if self.store is None:
             return
         try:
@@ -210,6 +225,8 @@ class KrakenGridTrader:
         risk = config.setdefault('risk_management', {})
         risk.setdefault('min_quote_reserve_usd', 0.0)
         risk.setdefault('max_live_drawdown_pct', 0.0)
+        risk.setdefault('max_position_size', 1.0)
+        risk.setdefault('max_open_orders', 40)
 
         return config
 
@@ -257,6 +274,134 @@ class KrakenGridTrader:
             encoding='utf-8',
         )
         self.live_risk_state = state
+
+    def _adaptive_lock_path(self) -> str:
+        return str(self.adaptive_settings.get('lock_path', 'state/runtime.lock'))
+
+    def _current_grid_parameters(self) -> Dict[str, Any]:
+        strategy = self.config['strategy']
+        return {
+            'grid_levels': int(strategy['grid_levels']),
+            'grid_spacing_percent': float(strategy['grid_spacing_percent']),
+            'order_size_percent': float(strategy['order_size_percent']),
+            'max_open_orders': int(self.config['risk_management']['max_open_orders']),
+            'risk_multiplier': 1.0,
+            'dynamic_range': dict(strategy['price_range']),
+        }
+
+    def _build_grid_from_parameters(self, params: Dict[str, Any], price_range: Dict[str, float]) -> GridManager:
+        strategy = self.config['strategy']
+        grid_levels = int(params.get('grid_levels', strategy['grid_levels']))
+        order_size_percent = float(params.get('order_size_percent', strategy['order_size_percent']))
+        spacing_percent = float(params.get('grid_spacing_percent', strategy['grid_spacing_percent']))
+        order_size_usd = float(strategy['bankroll']) * (order_size_percent / 100.0)
+        return GridManager(
+            min_price=float(price_range['min']),
+            max_price=float(price_range['max']),
+            grid_levels=grid_levels,
+            spacing_percent=spacing_percent,
+            order_size_usd=order_size_usd,
+        )
+
+    def _sync_active_orders(self, current_open_orders: Dict[str, Any]) -> Dict[str, Any]:
+        previous_known = dict(self.adaptive_store.state.get('known_open_orders', {}))
+        hydrated: Dict[str, Dict[str, Any]] = {}
+        if self.tracker is not None:
+            self.tracker.open_orders = {}
+
+        for order_id, order_data in current_open_orders.items():
+            descr = order_data.get('descr', {})
+            prior = previous_known.get(order_id, {})
+            details = {
+                'side': descr.get('type') or prior.get('side') or 'buy',
+                'price': float(descr.get('price') or prior.get('price') or 0.0),
+                'volume': float(order_data.get('vol') or prior.get('volume') or 0.0),
+                'placed_at': prior.get('placed_at') or datetime.utcnow().isoformat(),
+            }
+            hydrated[order_id] = details
+            if self.tracker is not None:
+                self.tracker.open_orders[order_id] = dict(details)
+
+        self.active_orders = hydrated
+        return previous_known
+
+    def _persist_known_open_orders(self) -> None:
+        self.adaptive_store.state['known_open_orders'] = {
+            order_id: {
+                'side': details.get('side'),
+                'price': float(details.get('price', 0.0)),
+                'volume': float(details.get('volume', 0.0)),
+                'placed_at': details.get('placed_at') or datetime.utcnow().isoformat(),
+            }
+            for order_id, details in self.active_orders.items()
+        }
+
+    def _get_market_snapshot(self, pair: str) -> Dict[str, float]:
+        return self._call_with_timeout(
+            'get_market_snapshot',
+            lambda: self.seren.get_market_snapshot(pair),
+        )
+
+    def _apply_adaptive_grid(
+        self,
+        *,
+        current_price: float,
+        market_snapshot: Dict[str, float],
+        live_risk: Dict[str, Any],
+    ):
+        market_metrics = compute_market_metrics(
+            recent_cycles=list(self.adaptive_store.state.get('recent_cycles', [])),
+            current_price=current_price,
+            bid=float(market_snapshot.get('bid', current_price)),
+            ask=float(market_snapshot.get('ask', current_price)),
+            high=float(market_snapshot.get('high', current_price)),
+            low=float(market_snapshot.get('low', current_price)),
+        )
+        decision = compute_adaptive_decision(
+            store=self.adaptive_store,
+            config=self.config,
+            market_metrics=market_metrics,
+            live_risk=live_risk,
+            current_price=current_price,
+        )
+        accepted_params = dict(decision.accepted_params)
+        dynamic_range = dict(accepted_params.get('dynamic_range') or decision.dynamic_range)
+        self.grid = self._build_grid_from_parameters(accepted_params, dynamic_range)
+        self.current_adaptive_decision = decision
+        return decision, market_metrics
+
+    def _rolling_window_metrics(self) -> Dict[str, Any]:
+        recent_cycles = list(self.adaptive_store.state.get('recent_cycles', []))
+        return {
+            'last_50': summarize_window(recent_cycles[-50:]),
+            'last_200': summarize_window(recent_cycles[-200:]),
+        }
+
+    def _cancel_open_buy_orders(self) -> int:
+        if self.is_dry_run:
+            return 0
+        cancelled = 0
+        for order_id, details in list(self.active_orders.items()):
+            if details.get('side') != 'buy':
+                continue
+            self._call_with_timeout(
+                'cancel_order',
+                lambda order_id=order_id: self.seren.cancel_order(order_id),
+            )
+            cancelled += 1
+            self.logger.log_order(
+                order_id=order_id,
+                order_type='limit',
+                side='buy',
+                price=float(details.get('price', 0.0)),
+                volume=float(details.get('volume', 0.0)),
+                status='cancelled',
+                extra={'reason': 'adaptive_safety_pause'},
+            )
+            self.active_orders.pop(order_id, None)
+            if self.tracker is not None:
+                self.tracker.remove_open_order(order_id)
+        return cancelled
 
     def _operation_timeout_seconds(self) -> float:
         return float(self.config.get('execution', {}).get('operation_timeout_seconds', 30))
@@ -345,6 +490,7 @@ class KrakenGridTrader:
                 lambda: self.seren.cancel_all_orders(),
             )
             self.active_orders.clear()
+            self.adaptive_store.state['known_open_orders'] = {}
             self._store_call(
                 f"{reason}_cancelled_orders_event",
                 lambda: self.store.save_event(
@@ -428,10 +574,12 @@ class KrakenGridTrader:
         print(f"Campaign:        {campaign}")
         print(f"Trading Pair:    {pair}")
         print(f"Bankroll:        ${strategy['bankroll']:,.2f}")
+        accepted_params = self.adaptive_store.accepted_params(self._current_grid_parameters())
+        accepted_range = dict(accepted_params.get('dynamic_range') or strategy['price_range'])
         print(f"Grid Levels:     {strategy['grid_levels']}")
-        print(f"Grid Spacing:    {strategy['grid_spacing_percent']}%")
-        print(f"Order Size:      {strategy['order_size_percent']}% of bankroll")
-        print(f"Price Range:     ${strategy['price_range']['min']:,.0f} - ${strategy['price_range']['max']:,.0f}")
+        print(f"Grid Spacing:    {accepted_params.get('grid_spacing_percent', strategy['grid_spacing_percent'])}%")
+        print(f"Order Size:      {accepted_params.get('order_size_percent', strategy['order_size_percent'])}% of bankroll")
+        print(f"Price Range:     ${accepted_range['min']:,.0f} - ${accepted_range['max']:,.0f}")
         print(f"Scan Interval:   {strategy['scan_interval_seconds']}s")
         print(f"Stop Loss:       ${risk['stop_loss_bankroll']:,.2f}")
         if self.backtest_optimization and self.backtest_optimization.get('applied'):
@@ -443,23 +591,25 @@ class KrakenGridTrader:
             )
 
         # Initialize grid manager
-        order_size_usd = strategy['bankroll'] * (strategy['order_size_percent'] / 100)
-        self.grid = GridManager(
-            min_price=strategy['price_range']['min'],
-            max_price=strategy['price_range']['max'],
-            grid_levels=strategy['grid_levels'],
-            spacing_percent=strategy['grid_spacing_percent'],
-            order_size_usd=order_size_usd
-        )
+        self.grid = self._build_grid_from_parameters(accepted_params, accepted_range)
 
         # Initialize position tracker
         self.tracker = PositionTracker(initial_bankroll=strategy['bankroll'])
 
         # Get current price
         print("\nFetching current market data...")
-        current_price = self.seren.get_current_price(pair)  # Last trade price
+        market_snapshot = self._get_market_snapshot(pair)
+        current_price = float(market_snapshot['current_price'])
+        preview_live_risk = self._build_live_risk(current_price, 0.0, float(strategy['bankroll']))
+        decision, _ = self._apply_adaptive_grid(
+            current_price=current_price,
+            market_snapshot=market_snapshot,
+            live_risk=preview_live_risk,
+        )
 
         print(f"Current Price:   ${current_price:,.2f}")
+        print(f"Adaptive Regime: {decision.regime_tag}")
+        print(f"Risk Multiplier: {decision.accepted_params.get('risk_multiplier', 1.0):.2f}x")
 
         # Validate price range
         min_price = strategy['price_range']['min']
@@ -512,9 +662,9 @@ class KrakenGridTrader:
                     "campaign_name": campaign,
                     "pair": pair,
                     "grid_levels": strategy['grid_levels'],
-                    "grid_spacing_percent": strategy['grid_spacing_percent'],
-                    "order_size_percent": strategy['order_size_percent'],
-                    "price_range": strategy['price_range'],
+                    "grid_spacing_percent": decision.accepted_params.get('grid_spacing_percent', strategy['grid_spacing_percent']),
+                    "order_size_percent": decision.accepted_params.get('order_size_percent', strategy['order_size_percent']),
+                    "price_range": decision.dynamic_range,
                     "scan_interval_seconds": strategy['scan_interval_seconds'],
                     "stop_loss_bankroll": risk['stop_loss_bankroll'],
                     "current_price": current_price,
@@ -523,6 +673,8 @@ class KrakenGridTrader:
                 },
             ),
         )
+        self._persist_known_open_orders()
+        self.adaptive_store.save()
 
         print("\n✓ Setup complete!")
         print("\nNext steps:")
@@ -558,11 +710,22 @@ class KrakenGridTrader:
         for cycle in range(cycles):
             print(f"--- Cycle {cycle + 1}/{cycles} ---")
 
-            # Get current price
-            current_price = self.seren.get_current_price(pair)
+            market_snapshot = self._get_market_snapshot(pair)
+            current_price = float(market_snapshot['current_price'])
+            decision, market_metrics = self._apply_adaptive_grid(
+                current_price=current_price,
+                market_snapshot=market_snapshot,
+                live_risk=self._build_live_risk(current_price, 0.0, float(self.config['strategy']['bankroll'])),
+            )
             print(f"Current Price: ${current_price:,.2f}")
+            print(f"Adaptive Regime: {decision.regime_tag}")
+            print(
+                "Accepted Params: "
+                f"spacing={decision.accepted_params.get('grid_spacing_percent', self.config['strategy']['grid_spacing_percent'])}% "
+                f"order_size={decision.accepted_params.get('order_size_percent', self.config['strategy']['order_size_percent'])}% "
+                f"risk={decision.accepted_params.get('risk_multiplier', 1.0):.2f}x"
+            )
 
-            # Get required orders
             required_orders = self.grid.get_required_orders(current_price)
             num_buy_orders = len(required_orders['buy'])
             num_sell_orders = len(required_orders['sell'])
@@ -577,6 +740,30 @@ class KrakenGridTrader:
                 print(f"Next buy level:  ${next_buy:,.2f}")
             if next_sell:
                 print(f"Next sell level: ${next_sell:,.2f}")
+            print(
+                f"Dynamic Range:   ${decision.dynamic_range['min']:,.2f} - ${decision.dynamic_range['max']:,.2f}"
+            )
+            print(
+                f"Metrics:         spread={market_metrics['spread_pct']:.4f}% "
+                f"atr={market_metrics['atr_pct']:.4f}% "
+                f"rolling_vol={market_metrics['rolling_stddev_pct']:.4f}%"
+            )
+            self.logger.log_metrics_snapshot(
+                {
+                    'timestamp': datetime.utcnow().isoformat() + 'Z',
+                    'pair': pair,
+                    'mode': 'dry_run_preview',
+                    'cycle_index': cycle + 1,
+                    'market_price': round(current_price, 6),
+                    'regime_tag': decision.regime_tag,
+                    'grid_spacing_percent': decision.accepted_params.get('grid_spacing_percent'),
+                    'order_size_percent': decision.accepted_params.get('order_size_percent'),
+                    'dynamic_range': decision.dynamic_range,
+                    'candidate_score': decision.candidate_score,
+                    'baseline_score': decision.baseline_score,
+                    'reasons': decision.reasons,
+                }
+            )
 
             print()
             time.sleep(2)  # Short delay for readability
@@ -631,12 +818,91 @@ class KrakenGridTrader:
 
         try:
             while self.running:
-                self._trading_cycle()
+                self.run_cycle()
                 time.sleep(scan_interval)
 
         except KeyboardInterrupt:
             print("\n\nReceived stop signal...")
             self.stop()
+
+    def run_cycle(self) -> Dict[str, Any]:
+        """Execute exactly one adaptive cycle under the shared runtime lock."""
+        with runtime_lock(self._adaptive_lock_path()):
+            self._trading_cycle()
+            recent_cycles = list(self.adaptive_store.state.get('recent_cycles', []))
+            if recent_cycles:
+                return dict(recent_cycles[-1])
+            return {'status': 'ok', 'message': 'cycle completed without persisted telemetry'}
+
+    def build_review(self) -> Dict[str, Any]:
+        """Generate and persist the weekly adaptive review report."""
+        with runtime_lock(self._adaptive_lock_path()):
+            report = build_review_report(self.adaptive_store)
+            report_path = self.adaptive_store.record_review(report)
+            self.adaptive_store.save()
+            self.logger.log_review_report({**report, 'report_path': str(report_path)})
+            self._store_call(
+                'adaptive_review_event',
+                lambda: self.store.save_event(
+                    self.session_id,
+                    'adaptive_review_generated',
+                    {
+                        'report_path': str(report_path),
+                        'cycle_count': report['cycle_count'],
+                        'rolling_windows': report['rolling_windows'],
+                    },
+                ),
+            )
+            return {**report, 'report_path': str(report_path)}
+
+    def run_safety_check(self) -> Dict[str, Any]:
+        """Run a one-shot safety evaluation and optionally surface cooldown alerts."""
+        with runtime_lock(self._adaptive_lock_path()):
+            pair = self.config['trading_pair']
+            market_snapshot = self._get_market_snapshot(pair)
+            current_price = float(market_snapshot['current_price'])
+            if self.is_dry_run:
+                base_balance = float(self.tracker.btc_balance if self.tracker is not None else 0.0)
+                usd_balance = float(
+                    self.tracker.usd_balance
+                    if self.tracker is not None
+                    else self.config['strategy']['bankroll']
+                )
+                open_order_count = len(self.active_orders)
+            else:
+                balance = self.seren.get_balance()
+                balance_key = pair_selector.get_balance_key(pair, self.config.get('base_balance_key'))
+                base_balance = float(balance['result'].get(balance_key, 0))
+                usd_balance = float(balance['result'].get('ZUSD', 0))
+                open_orders_response = self.seren.get_open_orders()
+                open_order_count = len(open_orders_response['result']['open'])
+            live_risk = self._build_live_risk(current_price, base_balance, usd_balance)
+            daily_pnl = dict(self.adaptive_store.state.get('daily_pnl', {}))
+            cooldown_active = self.adaptive_store.in_cooldown()
+            issues = []
+            if float(live_risk.get('drawdown_pct', 0.0)) > float(self.config['risk_management'].get('max_live_drawdown_pct', 0.0) or 0.0):
+                issues.append('drawdown cap breached')
+            daily_loss_cap = float(self.adaptive_settings.get('daily_loss_cap_usd', 0.0))
+            if daily_loss_cap > 0 and float(daily_pnl.get('net_change_usd', 0.0)) <= -daily_loss_cap:
+                issues.append('daily loss cap breached')
+            if cooldown_active:
+                issues.append('cooldown active')
+            payload = {
+                'timestamp': datetime.utcnow().isoformat() + 'Z',
+                'pair': pair,
+                'current_price': current_price,
+                'open_order_count': open_order_count,
+                'live_risk': live_risk,
+                'daily_pnl': daily_pnl,
+                'cooldown_active': cooldown_active,
+                'failure_state': dict(self.adaptive_store.state.get('failure_state', {})),
+                'issues': issues,
+            }
+            if issues:
+                self.adaptive_store.note_incident('safety_check', payload)
+                self.logger.log_alert('safety_check', payload)
+            self.adaptive_store.save()
+            return payload
 
     def _trading_cycle(self):
         """Execute one trading cycle"""
@@ -645,75 +911,211 @@ class KrakenGridTrader:
 
         try:
             self._cycle_deadline_at = time.monotonic() + self._cycle_timeout_seconds()
-            # 1. Get current price
-            current_price = self._call_with_timeout(
-                'get_current_price',
-                lambda: self.seren.get_current_price(pair),
-            )
+            market_snapshot = self._get_market_snapshot(pair)
+            current_price = float(market_snapshot['current_price'])
 
-            # 2. Update balances
-            balance = self._call_with_timeout('get_balance', self.seren.get_balance)
-            balance_key = pair_selector.get_balance_key(
-                pair, self.config.get('base_balance_key')
-            )
-            base_balance = float(balance['result'].get(balance_key, 0))
-            usd_balance = float(balance['result'].get('ZUSD', 0))
-            self.tracker.update_balances(base_balance, usd_balance)
-            live_risk = self._enforce_live_risk(current_price, base_balance, usd_balance)
-
-            # 3. Check stop loss
-            if self.tracker.should_stop_loss(current_price, stop_loss):
-                print(f"\n⚠ STOP LOSS TRIGGERED at ${self.tracker.get_current_value(current_price):,.2f}")
-                self._store_call(
-                    "stop_loss_event",
-                    lambda: self.store.save_event(
-                        self.session_id,
-                        "stop_loss_triggered",
-                        {
-                            "pair": pair,
-                            "current_price": current_price,
-                            "portfolio_value": self.tracker.get_current_value(current_price),
-                            "stop_loss_bankroll": stop_loss,
-                            "live_risk": live_risk,
-                        },
-                    ),
+            if self.is_dry_run:
+                base_balance = float(self.tracker.btc_balance if self.tracker is not None else 0.0)
+                usd_balance = float(
+                    self.tracker.usd_balance
+                    if self.tracker is not None
+                    else self.config['strategy']['bankroll']
                 )
-                self.stop()
-                return
+                if self.tracker is not None:
+                    self.tracker.update_balances(base_balance, usd_balance)
+                live_risk = self._build_live_risk(current_price, base_balance, usd_balance)
+                previous_known_orders: Dict[str, Any] = {}
+                self.active_orders = {}
+                if self.tracker is not None:
+                    self.tracker.open_orders = {}
+            else:
+                balance = self._call_with_timeout('get_balance', self.seren.get_balance)
+                balance_key = pair_selector.get_balance_key(
+                    pair, self.config.get('base_balance_key')
+                )
+                base_balance = float(balance['result'].get(balance_key, 0))
+                usd_balance = float(balance['result'].get('ZUSD', 0))
+                self.tracker.update_balances(base_balance, usd_balance)
+                live_risk = self._enforce_live_risk(current_price, base_balance, usd_balance)
 
-            # 4. Get open orders from Kraken
-            open_orders_response = self._call_with_timeout(
-                'get_open_orders',
-                self.seren.get_open_orders,
+                if self.tracker.should_stop_loss(current_price, stop_loss):
+                    print(f"\n⚠ STOP LOSS TRIGGERED at ${self.tracker.get_current_value(current_price):,.2f}")
+                    self._store_call(
+                        "stop_loss_event",
+                        lambda: self.store.save_event(
+                            self.session_id,
+                            "stop_loss_triggered",
+                            {
+                                "pair": pair,
+                                "current_price": current_price,
+                                "portfolio_value": self.tracker.get_current_value(current_price),
+                                "stop_loss_bankroll": stop_loss,
+                                "live_risk": live_risk,
+                            },
+                        ),
+                    )
+                    self.stop()
+                    return
+
+                open_orders_response = self._call_with_timeout(
+                    'get_open_orders',
+                    self.seren.get_open_orders,
+                )
+                previous_known_orders = self._sync_active_orders(open_orders_response['result']['open'])
+
+            decision, market_metrics = self._apply_adaptive_grid(
+                current_price=current_price,
+                market_snapshot=market_snapshot,
+                live_risk=live_risk,
             )
-            current_open_orders = open_orders_response['result']['open']
 
-            # 5. Find filled orders
-            filled_order_ids = self.grid.find_filled_orders(
-                self.active_orders,
-                current_open_orders
-            )
+            if decision.promoted or decision.rolled_back or decision.daily_loss_triggered:
+                incident_type = 'adaptive_promotion'
+                if decision.rolled_back:
+                    incident_type = 'adaptive_rollback'
+                elif decision.daily_loss_triggered:
+                    incident_type = 'daily_loss_cap'
+                self.adaptive_store.note_incident(
+                    incident_type,
+                    {
+                        'pair': pair,
+                        'current_price': current_price,
+                        'reasons': decision.reasons,
+                        'candidate_score': decision.candidate_score,
+                        'baseline_score': decision.baseline_score,
+                    },
+                )
+                self.logger.log_alert(
+                    incident_type,
+                    {
+                        'pair': pair,
+                        'current_price': current_price,
+                        'reasons': decision.reasons,
+                    },
+                )
 
-            # 6. Process fills
+            cancelled_for_safety = 0
+            if (decision.cooldown_active or decision.daily_loss_triggered) and not self.is_dry_run:
+                cancelled_for_safety = self._cancel_open_buy_orders()
+
+            current_open_orders = {
+                order_id: {
+                    'descr': {
+                        'type': details.get('side'),
+                        'price': details.get('price'),
+                    },
+                    'vol': details.get('volume'),
+                }
+                for order_id, details in self.active_orders.items()
+            }
+            filled_order_ids = []
+            if not self.is_dry_run:
+                filled_order_ids = self.grid.find_filled_orders(
+                    previous_known_orders,
+                    current_open_orders,
+                )
+
             for order_id in filled_order_ids:
-                self._process_fill(order_id, current_price)
+                self._process_fill(
+                    order_id,
+                    current_price,
+                    order_details=previous_known_orders.get(order_id),
+                )
 
-            # 7. Get required orders for current price
+            current_open_orders = {
+                order_id: {
+                    'descr': {
+                        'type': details.get('side'),
+                        'price': details.get('price'),
+                    },
+                    'vol': details.get('volume'),
+                }
+                for order_id, details in self.active_orders.items()
+            }
             required_orders = self.grid.get_required_orders(current_price)
+            placement_summary = self._place_grid_orders(
+                required_orders,
+                current_open_orders,
+                usd_balance,
+                base_balance=base_balance,
+                skip_new_buys=decision.cooldown_active or decision.daily_loss_triggered,
+            )
 
-            # 8. Place new orders
-            self._place_grid_orders(required_orders, current_open_orders, usd_balance)
-
-            # 9. Log position update
             total_value_usd = self.tracker.get_current_value(current_price)
             unrealized_pnl = self.tracker.get_unrealized_pnl(current_price)
+            recent_cycles = list(self.adaptive_store.state.get('recent_cycles', []))
+            previous_equity = float(recent_cycles[-1]['equity_end_usd']) if recent_cycles else float(self.config['strategy']['bankroll'])
+            net_pnl_usd = total_value_usd - previous_equity
+            fill_count = len(filled_order_ids)
+            order_slots = max(len(previous_known_orders), 1)
+            fill_rate = fill_count / order_slots
+            cancel_rate = cancelled_for_safety / order_slots if order_slots > 0 else 0.0
+            cycle_snapshot = {
+                'timestamp': datetime.utcnow().isoformat() + 'Z',
+                'pair': pair,
+                'mode': 'dry_run' if self.is_dry_run else 'live',
+                'market_price': round(current_price, 6),
+                'bid': round(float(market_snapshot.get('bid', 0.0)), 6),
+                'ask': round(float(market_snapshot.get('ask', 0.0)), 6),
+                'spread_pct': round(float(market_metrics.get('spread_pct', 0.0)), 6),
+                'atr_pct': round(float(market_metrics.get('atr_pct', 0.0)), 6),
+                'rolling_stddev_pct': round(float(market_metrics.get('rolling_stddev_pct', 0.0)), 6),
+                'ema_volatility_pct': round(float(decision.volatility_metrics.get('ema_volatility_pct', 0.0)), 6),
+                'regime_tag': decision.regime_tag,
+                'grid_spacing_percent': round(float(decision.accepted_params.get('grid_spacing_percent', self.config['strategy']['grid_spacing_percent'])), 6),
+                'order_size_percent': round(float(decision.accepted_params.get('order_size_percent', self.config['strategy']['order_size_percent'])), 6),
+                'max_open_orders': int(decision.accepted_params.get('max_open_orders', self.config['risk_management']['max_open_orders'])),
+                'risk_multiplier': round(float(decision.accepted_params.get('risk_multiplier', 1.0)), 6),
+                'dynamic_center_price': round(float(decision.dynamic_center_price), 6),
+                'dynamic_range': dict(decision.dynamic_range),
+                'equity_end_usd': round(total_value_usd, 6),
+                'net_pnl_usd': round(net_pnl_usd, 6),
+                'unrealized_pnl_usd': round(unrealized_pnl, 6),
+                'realized_pnl_usd': round(self.tracker.get_realized_pnl(), 6),
+                'drawdown_pct': round(float(live_risk.get('drawdown_pct', 0.0)), 6),
+                'open_orders': len(self.active_orders),
+                'fill_count': fill_count,
+                'fill_rate': round(fill_rate, 6),
+                'cancel_rate': round(cancel_rate, 6),
+                'placed_buy_orders': placement_summary['placed_buy'],
+                'placed_sell_orders': placement_summary['placed_sell'],
+                'skipped_buy_orders': placement_summary['skipped_buy'],
+                'skipped_sell_orders': placement_summary['skipped_sell'],
+                'candidate_score': round(decision.candidate_score, 6),
+                'baseline_score': round(decision.baseline_score, 6),
+                'cooldown_active': decision.cooldown_active,
+                'daily_loss_triggered': decision.daily_loss_triggered,
+                'promoted': decision.promoted,
+                'rolled_back': decision.rolled_back,
+                'reasons': list(decision.reasons),
+            }
+            update_cycle_state(store=self.adaptive_store, cycle_snapshot=cycle_snapshot)
+            self.adaptive_store.clear_failures()
+            self._persist_known_open_orders()
+            self.adaptive_store.save()
+            rolling_windows = self._rolling_window_metrics()
+            self.logger.log_metrics_snapshot(
+                {
+                    **cycle_snapshot,
+                    'rolling_windows': rolling_windows,
+                }
+            )
             self.logger.log_position_update(
                 pair=pair,
                 btc_balance=base_balance,
                 usd_balance=usd_balance,
                 total_value_usd=total_value_usd,
                 unrealized_pnl=unrealized_pnl,
-                open_orders=len(self.active_orders)
+                open_orders=len(self.active_orders),
+                extra={
+                    'regime_tag': decision.regime_tag,
+                    'grid_spacing_percent': cycle_snapshot['grid_spacing_percent'],
+                    'order_size_percent': cycle_snapshot['order_size_percent'],
+                    'risk_multiplier': cycle_snapshot['risk_multiplier'],
+                    'rolling_windows': rolling_windows,
+                    'fill_count': fill_count,
+                    'cancelled_for_safety': cancelled_for_safety,
+                },
             )
             self._store_call(
                 "position_snapshot",
@@ -728,15 +1130,17 @@ class KrakenGridTrader:
                 ),
             )
 
-            # 10. Print status
             timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
             print(f"[{timestamp}] Price: ${current_price:,.2f} | "
+                  f"Regime: {decision.regime_tag} | "
                   f"Open Orders: {len(self.active_orders)} | "
                   f"Fills: {len(self.tracker.filled_orders)} | "
                   f"P&L: ${unrealized_pnl:,.2f}")
 
         except Exception as e:
             error_msg = str(e)
+            self.adaptive_store.register_failure(error_msg)
+            self.adaptive_store.save()
             print(f"ERROR in trading cycle: {error_msg}")
             self._halt_live_trading(
                 'trading_cycle_error',
@@ -749,25 +1153,63 @@ class KrakenGridTrader:
         finally:
             self._cycle_deadline_at = None
 
-    def _place_grid_orders(self, required_orders: Dict, current_open_orders: Dict, usd_balance: float):
+    def _place_grid_orders(
+        self,
+        required_orders: Dict,
+        current_open_orders: Dict,
+        usd_balance: float,
+        *,
+        base_balance: Optional[float] = None,
+        skip_new_buys: bool = False,
+    ):
         """Place grid orders that aren't already open"""
         pair = self.config['trading_pair']
-        min_quote_reserve = float(self.config.get('risk_management', {}).get('min_quote_reserve_usd', 0.0))
+        risk = self.config.get('risk_management', {})
+        min_quote_reserve = float(risk.get('min_quote_reserve_usd', 0.0))
+        max_position_size = float(risk.get('max_position_size', 1.0))
+        default_max_open_orders = int(risk.get('max_open_orders', 40))
+        accepted = self.current_adaptive_decision.accepted_params if self.current_adaptive_decision else {}
+        max_open_orders = int(accepted.get('max_open_orders', default_max_open_orders))
+        current_base_balance = float(
+            base_balance if base_balance is not None else (self.tracker.btc_balance if self.tracker is not None else 0.0)
+        )
+        summary = {
+            'placed_buy': 0,
+            'placed_sell': 0,
+            'skipped_buy': 0,
+            'skipped_sell': 0,
+        }
 
-        # Get currently open order prices
         open_prices = set()
         committed_buy_notional = 0.0
+        committed_buy_volume = 0.0
+        committed_sell_volume = 0.0
         for order_data in current_open_orders.values():
             descr = order_data['descr']
             price = float(descr['price'])
             open_prices.add(price)
             if descr.get('type') == 'buy':
-                committed_buy_notional += price * float(order_data.get('vol', 0.0))
+                volume = float(order_data.get('vol', 0.0))
+                committed_buy_notional += price * volume
+                committed_buy_volume += volume
+            elif descr.get('type') == 'sell':
+                committed_sell_volume += float(order_data.get('vol', 0.0))
 
-        # Place buy orders
+        current_open_count = len(current_open_orders)
+
         for order in required_orders['buy']:
             if order['price'] not in open_prices:
+                if skip_new_buys:
+                    summary['skipped_buy'] += 1
+                    continue
+                if current_open_count >= max_open_orders:
+                    summary['skipped_buy'] += 1
+                    continue
                 order_notional = float(order['price']) * float(order['volume'])
+                projected_position = current_base_balance + committed_buy_volume + float(order['volume'])
+                if projected_position > max_position_size:
+                    summary['skipped_buy'] += 1
+                    continue
                 available_buying_power = usd_balance - committed_buy_notional - min_quote_reserve
                 if (not self.is_dry_run) and order_notional > max(available_buying_power, 0.0):
                     print(
@@ -789,24 +1231,39 @@ class KrakenGridTrader:
                             },
                         ),
                     )
+                    summary['skipped_buy'] += 1
                     continue
-                self._place_order(
+                if self._place_order(
                     pair=pair,
                     side='buy',
                     price=order['price'],
                     volume=order['volume']
-                )
-                committed_buy_notional += order_notional
+                ):
+                    committed_buy_notional += order_notional
+                    committed_buy_volume += float(order['volume'])
+                    current_open_count += 1
+                    summary['placed_buy'] += 1
 
-        # Place sell orders
         for order in required_orders['sell']:
             if order['price'] not in open_prices:
-                self._place_order(
+                if current_open_count >= max_open_orders:
+                    summary['skipped_sell'] += 1
+                    continue
+                available_inventory = current_base_balance - committed_sell_volume
+                if (not self.is_dry_run) and float(order['volume']) > max(available_inventory, 0.0):
+                    summary['skipped_sell'] += 1
+                    continue
+                if self._place_order(
                     pair=pair,
                     side='sell',
                     price=order['price'],
                     volume=order['volume']
-                )
+                ):
+                    committed_sell_volume += float(order['volume'])
+                    current_open_count += 1
+                    summary['placed_sell'] += 1
+
+        return summary
 
     def _place_order(self, pair: str, side: str, price: float, volume: float):
         """Place a single limit order"""
@@ -814,7 +1271,7 @@ class KrakenGridTrader:
         try:
             if self.is_dry_run:
                 print(f"[DRY RUN] Would place {side} order: {volume:.8f} {base} @ ${price:,.2f}")
-                return
+                return True
 
             response = self._call_with_timeout(
                 'add_order',
@@ -832,7 +1289,8 @@ class KrakenGridTrader:
                 self.active_orders[order_id] = {
                     'side': side,
                     'price': price,
-                    'volume': volume
+                    'volume': volume,
+                    'placed_at': datetime.utcnow().isoformat(),
                 }
                 self.tracker.add_open_order(order_id, {
                     'side': side,
@@ -845,7 +1303,16 @@ class KrakenGridTrader:
                     side=side,
                     price=price,
                     volume=volume,
-                    status='placed'
+                    status='placed',
+                    extra={
+                        'pair': pair,
+                        'notional_usd': round(price * volume, 6),
+                        'risk_multiplier': (
+                            self.current_adaptive_decision.accepted_params.get('risk_multiplier', 1.0)
+                            if self.current_adaptive_decision
+                            else 1.0
+                        ),
+                    },
                 )
                 self._store_call(
                     "order_placed",
@@ -863,6 +1330,7 @@ class KrakenGridTrader:
                     ),
                 )
                 print(f"✓ Placed {side} order: {volume:.8f} {base} @ ${price:,.2f} (ID: {order_id})")
+                return True
 
         except Exception as e:
             error_msg = str(e)
@@ -888,20 +1356,29 @@ class KrakenGridTrader:
                     },
                 ),
             )
+        return False
 
-    def _process_fill(self, order_id: str, current_price: float):
+    def _process_fill(self, order_id: str, current_price: float, order_details: Optional[Dict[str, Any]] = None):
         """Process a filled order"""
-        if order_id not in self.active_orders:
+        order = order_details or self.active_orders.get(order_id)
+        if order is None:
             return
 
-        order = self.active_orders[order_id]
         side = order['side']
         price = order['price']
         volume = order['volume']
+        placed_at = order.get('placed_at')
 
         # Calculate fee (0.16% maker fee)
         cost = price * volume
         fee = cost * 0.0016
+        latency_seconds = None
+        if placed_at:
+            try:
+                placed_dt = datetime.fromisoformat(str(placed_at).replace('Z', '+00:00'))
+                latency_seconds = max((datetime.utcnow() - placed_dt.replace(tzinfo=None)).total_seconds(), 0.0)
+            except ValueError:
+                latency_seconds = None
 
         # Record fill
         self.tracker.record_fill(
@@ -919,7 +1396,13 @@ class KrakenGridTrader:
             price=price,
             volume=volume,
             fee=fee,
-            cost=cost
+            cost=cost,
+            extra={
+                'pair': self.config['trading_pair'],
+                'latency_seconds': round(latency_seconds, 6) if latency_seconds is not None else None,
+                'current_price': round(current_price, 6),
+                'slippage_vs_last_trade': round(current_price - price, 6),
+            },
         )
         self._store_call(
             "fill_recorded",
@@ -934,18 +1417,30 @@ class KrakenGridTrader:
                 payload={"pair": self.config['trading_pair']},
             ),
         )
+        self.adaptive_store.append_fill(
+            {
+                'timestamp': datetime.utcnow().isoformat() + 'Z',
+                'order_id': order_id,
+                'side': side,
+                'price': price,
+                'quantity': volume,
+                'fee_usd': fee,
+                'cost_usd': cost,
+                'latency_seconds': latency_seconds,
+                'current_price': current_price,
+            }
+        )
 
         # Remove from active orders
-        del self.active_orders[order_id]
+        self.active_orders.pop(order_id, None)
 
         base = pair_selector.get_base_symbol(self.config['trading_pair'])
         print(f"✓ FILLED {side.upper()}: {volume:.8f} {base} @ ${price:,.2f} (Fee: ${fee:.2f})")
 
     def status(self):
         """Show current trading status"""
-        if self.tracker is None:
-            print("ERROR: No active trading session")
-            return
+        if self.tracker is None or self.grid is None:
+            self.setup(optimize_backtest=False)
 
         pair = self.config['trading_pair']
 
@@ -979,6 +1474,7 @@ class KrakenGridTrader:
                 print("Cancelling all open orders...")
                 self._call_with_timeout('cancel_all_orders', self.seren.cancel_all_orders)
                 self.active_orders.clear()
+                self.adaptive_store.state['known_open_orders'] = {}
                 print("✓ All orders cancelled")
 
             except Exception as e:
@@ -1004,6 +1500,7 @@ class KrakenGridTrader:
             print(f"\n✓ Fills exported to {output_path}")
 
         print("\n✓ Trading stopped\n")
+        self.adaptive_store.save()
 
 
 
@@ -1084,6 +1581,20 @@ def main():
         help='Explicit startup-only opt-in for live trading.',
     )
 
+    cycle_parser = subparsers.add_parser('cycle', help='Run exactly one adaptive cycle')
+    cycle_parser.add_argument('--config', required=True, help='Path to config JSON file')
+    cycle_parser.add_argument(
+        '--allow-live',
+        action='store_true',
+        help='Opt into live order placement for the single cycle; otherwise runs as a dry adaptive preview.',
+    )
+
+    review_parser = subparsers.add_parser('review', help='Generate the weekly adaptive review report')
+    review_parser.add_argument('--config', required=True, help='Path to config JSON file')
+
+    safety_parser = subparsers.add_parser('safety-check', help='Run the one-shot adaptive safety checks')
+    safety_parser.add_argument('--config', required=True, help='Path to config JSON file')
+
     # Status command
     status_parser = subparsers.add_parser('status', help='Show current trading status')
     status_parser.add_argument('--config', required=True, help='Path to config JSON file')
@@ -1100,8 +1611,7 @@ def main():
 
     _require_live_confirmation(args.command, getattr(args, 'allow_live', False))
 
-    # Initialize agent
-    dry_run = (args.command == 'dry-run')
+    dry_run = (args.command == 'dry-run') or (args.command == 'cycle' and not getattr(args, 'allow_live', False))
     agent = KrakenGridTrader(config_path=args.config, dry_run=dry_run)
 
     # Execute command
@@ -1114,10 +1624,22 @@ def main():
         elif args.command == 'start':
             agent.setup(optimize_backtest=False)
             agent.start()
+        elif args.command == 'cycle':
+            agent.setup(optimize_backtest=False)
+            print(json.dumps(agent.run_cycle(), sort_keys=True, indent=2))
+        elif args.command == 'review':
+            agent.setup(optimize_backtest=False)
+            print(json.dumps(agent.build_review(), sort_keys=True, indent=2))
+        elif args.command == 'safety-check':
+            agent.setup(optimize_backtest=False)
+            print(json.dumps(agent.run_safety_check(), sort_keys=True, indent=2))
         elif args.command == 'status':
             agent.status()
         elif args.command == 'stop':
             agent.stop()
+    except RuntimeLockError as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}, sort_keys=True))
+        raise SystemExit(2) from exc
     finally:
         agent.close()
 

--- a/kraken/grid-trader/scripts/logger.py
+++ b/kraken/grid-trader/scripts/logger.py
@@ -10,7 +10,6 @@ Maintains JSONL log files:
 """
 
 import json
-import os
 from datetime import datetime
 from typing import Dict, Any, Optional
 from pathlib import Path
@@ -44,6 +43,12 @@ class GridTraderLogger:
         filepath = self.logs_dir / filename
         with open(filepath, 'a') as f:
             f.write(json.dumps(data) + '\n')
+
+    @staticmethod
+    def _merge_extra(payload: Dict[str, Any], extra: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not extra:
+            return payload
+        return {**payload, **extra}
 
     def log_grid_setup(
         self,
@@ -86,7 +91,8 @@ class GridTraderLogger:
         price: float,
         volume: float,
         status: str,
-        error: Optional[str] = None
+        error: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Log order placement or cancellation
@@ -100,7 +106,7 @@ class GridTraderLogger:
             status: 'placed', 'cancelled', or 'error'
             error: Error message (if failed)
         """
-        self._append_jsonl('orders.jsonl', {
+        self._append_jsonl('orders.jsonl', self._merge_extra({
             'phase': 'order',
             'order_id': order_id,
             'type': order_type,
@@ -109,7 +115,7 @@ class GridTraderLogger:
             'volume': volume,
             'status': status,
             'error': error
-        })
+        }, extra))
 
     def log_fill(
         self,
@@ -118,7 +124,8 @@ class GridTraderLogger:
         price: float,
         volume: float,
         fee: float,
-        cost: float
+        cost: float,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Log trade execution
@@ -131,7 +138,7 @@ class GridTraderLogger:
             fee: Trading fee (USD)
             cost: Total cost (USD)
         """
-        self._append_jsonl('fills.jsonl', {
+        self._append_jsonl('fills.jsonl', self._merge_extra({
             'phase': 'fill',
             'order_id': order_id,
             'side': side,
@@ -139,7 +146,7 @@ class GridTraderLogger:
             'volume': volume,
             'fee': fee,
             'cost': cost
-        })
+        }, extra))
 
     def log_position_update(
         self,
@@ -148,7 +155,8 @@ class GridTraderLogger:
         usd_balance: float,
         total_value_usd: float,
         unrealized_pnl: float,
-        open_orders: int
+        open_orders: int,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Log position snapshot
@@ -161,7 +169,7 @@ class GridTraderLogger:
             unrealized_pnl: Unrealized profit/loss
             open_orders: Number of open orders
         """
-        self._append_jsonl('positions.jsonl', {
+        self._append_jsonl('positions.jsonl', self._merge_extra({
             'phase': 'position',
             'pair': pair,
             'btc_balance': btc_balance,
@@ -169,14 +177,15 @@ class GridTraderLogger:
             'total_value_usd': total_value_usd,
             'unrealized_pnl': unrealized_pnl,
             'open_orders': open_orders
-        })
+        }, extra))
 
     def log_error(
         self,
         operation: str,
         error_type: str,
         error_message: str,
-        context: Optional[Dict] = None
+        context: Optional[Dict[str, Any]] = None,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Log error or warning
@@ -187,13 +196,29 @@ class GridTraderLogger:
             error_message: Error details
             context: Additional context
         """
-        self._append_jsonl('errors.jsonl', {
+        self._append_jsonl('errors.jsonl', self._merge_extra({
             'phase': 'error',
             'operation': operation,
             'error_type': error_type,
             'error_message': error_message,
             'context': context or {}
-        })
+        }, extra))
+
+    def log_metrics_snapshot(self, payload: Dict[str, Any]) -> None:
+        self._append_jsonl('metrics.jsonl', {**payload, 'phase': 'metrics'})
+
+    def log_review_report(self, payload: Dict[str, Any]) -> None:
+        self._append_jsonl('weekly_reviews.jsonl', {**payload, 'phase': 'review'})
+
+    def log_alert(self, alert_type: str, payload: Dict[str, Any]) -> None:
+        self._append_jsonl(
+            'alerts.jsonl',
+            {
+                'phase': 'alert',
+                'alert_type': alert_type,
+                **payload,
+            },
+        )
 
     def get_recent_logs(self, log_type: str, limit: int = 10) -> list:
         """

--- a/kraken/grid-trader/scripts/run_agent_server.py
+++ b/kraken/grid-trader/scripts/run_agent_server.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""HTTP trigger server for the adaptive Kraken grid trader."""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import os
+import time
+import traceback
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from dotenv import load_dotenv
+
+from agent import KrakenGridTrader
+
+
+UTC = timezone.utc
+
+
+def _config_scan_interval_seconds(config_path: str, fallback: int = 60) -> int:
+    try:
+        with open(config_path, 'r', encoding='utf-8') as handle:
+            body = json.load(handle)
+        return int(body.get('strategy', {}).get('scan_interval_seconds', fallback))
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
+def _run_action(*, action: str, config_path: str, allow_live: bool) -> dict:
+    dry_run = action == 'cycle' and not allow_live
+    trader = KrakenGridTrader(config_path=config_path, dry_run=dry_run)
+    try:
+        trader.setup(optimize_backtest=False)
+        if action == 'cycle':
+            return trader.run_cycle()
+        if action == 'review':
+            return trader.build_review()
+        if action == 'safety-check':
+            return trader.run_safety_check()
+        raise ValueError(f'unsupported action: {action}')
+    finally:
+        trader.close()
+
+
+class GridRequestHandler(BaseHTTPRequestHandler):
+    config_path = 'config.json'
+    allow_live = False
+    webhook_secret = ''
+    min_run_interval_seconds = 60
+    _last_run_monotonic: dict[str, float] = {}
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != '/health':
+            self.send_error(404, 'Endpoint not found')
+            return
+        payload = {
+            'status': 'ok',
+            'service': 'kraken-grid-trader',
+            'timestamp': datetime.now(tz=UTC).isoformat(),
+            'mode': 'live' if self.allow_live else 'dry_run',
+            'min_run_interval_seconds': self.min_run_interval_seconds,
+        }
+        self._send_json(200, payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        endpoint_map = {
+            '/run': 'cycle',
+            '/review': 'review',
+            '/safety-check': 'safety-check',
+        }
+        action = endpoint_map.get(self.path)
+        if action is None:
+            self.send_error(404, 'Endpoint not found')
+            return
+        if not self._authorize():
+            return
+        if action == 'cycle' and not self._within_rate_limit(self.path):
+            return
+        try:
+            result = _run_action(
+                action=action,
+                config_path=self.config_path,
+                allow_live=self.allow_live,
+            )
+            self._send_json(200, {'status': 'ok', 'action': action, 'result': result})
+        except Exception as exc:  # noqa: BLE001
+            traceback.print_exc()
+            self._send_json(500, {'status': 'error', 'action': action, 'error': str(exc)})
+
+    def _authorize(self) -> bool:
+        if not self.webhook_secret:
+            self._send_json(503, {'status': 'error', 'error': 'server_misconfigured'})
+            return False
+        received = self.headers.get('X-Webhook-Secret', '')
+        if not hmac.compare_digest(received, self.webhook_secret):
+            self._send_json(401, {'status': 'error', 'error': 'unauthorized'})
+            return False
+        return True
+
+    def _within_rate_limit(self, key: str) -> bool:
+        now = time.monotonic()
+        last_run = float(type(self)._last_run_monotonic.get(key, 0.0))
+        min_interval = max(float(type(self).min_run_interval_seconds), 1.0)
+        if now - last_run < min_interval:
+            self._send_json(
+                429,
+                {
+                    'status': 'error',
+                    'error': 'rate_limited',
+                    'retry_after_seconds': round(min_interval - (now - last_run), 2),
+                },
+            )
+            return False
+        type(self)._last_run_monotonic[key] = now
+        return True
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        timestamp = datetime.now(tz=UTC).isoformat()
+        print(f'[{timestamp}] {fmt % args}')
+
+    def _send_json(self, code: int, payload: dict) -> None:
+        raw = json.dumps(payload).encode('utf-8')
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Run HTTP trigger server for kraken-grid-trader')
+    parser.add_argument('--config', default='config.json')
+    parser.add_argument('--host', default='127.0.0.1')
+    parser.add_argument('--port', type=int, default=8787)
+    parser.add_argument('--allow-live', action='store_true')
+    parser.add_argument(
+        '--min-run-interval-seconds',
+        type=int,
+        default=0,
+        help='Minimum seconds between /run calls. Defaults to strategy.scan_interval_seconds from config.',
+    )
+    parser.add_argument(
+        '--webhook-secret',
+        default='',
+        help='Shared secret for POST endpoint authentication; can also come from KRAKEN_GRID_WEBHOOK_SECRET.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    GridRequestHandler.config_path = args.config
+    GridRequestHandler.allow_live = bool(args.allow_live)
+    GridRequestHandler.webhook_secret = args.webhook_secret or os.getenv('KRAKEN_GRID_WEBHOOK_SECRET', '')
+    if args.min_run_interval_seconds > 0:
+        GridRequestHandler.min_run_interval_seconds = int(args.min_run_interval_seconds)
+    else:
+        GridRequestHandler.min_run_interval_seconds = max(
+            1,
+            _config_scan_interval_seconds(args.config, fallback=60),
+        )
+    if not GridRequestHandler.webhook_secret:
+        raise SystemExit('Refusing to start webhook server without KRAKEN_GRID_WEBHOOK_SECRET.')
+
+    server = HTTPServer((args.host, args.port), GridRequestHandler)
+    print(f'Kraken Grid Trader server listening on {args.host}:{args.port}')
+    print(f'Health:  http://{args.host}:{args.port}/health')
+    print(f'Cycle:   http://{args.host}:{args.port}/run')
+    print(f'Review:  http://{args.host}:{args.port}/review')
+    print(f'Safety:  http://{args.host}:{args.port}/safety-check')
+    server.serve_forever()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/kraken/grid-trader/scripts/seren_client.py
+++ b/kraken/grid-trader/scripts/seren_client.py
@@ -172,6 +172,47 @@ class SerenClient:
 
         raise KeyError(f"No ticker data found for pair {pair}")
 
+    def get_market_snapshot(self, pair: str) -> Dict[str, float]:
+        """
+        Return a normalized top-of-book and range snapshot for a trading pair.
+
+        Args:
+            pair: Trading pair (e.g., 'XBTUSD')
+
+        Returns:
+            Dict with current_price, bid, ask, high, low, volume, and spread metrics.
+        """
+        ticker = self.get_ticker(pair)
+        result = ticker.get("result", {})
+        if pair in result:
+            payload = result[pair]
+        elif result:
+            payload = result[list(result.keys())[0]]
+        else:
+            raise KeyError(f"No ticker data found for pair {pair}")
+
+        bid = float(payload.get("b", [0.0])[0])
+        ask = float(payload.get("a", [0.0])[0])
+        current_price = float(payload.get("c", [bid or ask or 0.0])[0])
+        high_values = payload.get("h", [current_price, current_price])
+        low_values = payload.get("l", [current_price, current_price])
+        volume_values = payload.get("v", [0.0, 0.0])
+        high = float(high_values[-1])
+        low = float(low_values[-1])
+        volume = float(volume_values[-1])
+        mid_price = (bid + ask) / 2.0 if ask > 0 and bid > 0 else current_price
+        spread_pct = ((ask - bid) / mid_price * 100.0) if mid_price > 0 else 0.0
+        return {
+            "current_price": current_price,
+            "bid": bid,
+            "ask": ask,
+            "high": high,
+            "low": low,
+            "volume": volume,
+            "mid_price": mid_price,
+            "spread_pct": spread_pct,
+        }
+
     def get_asset_pairs(self, pair: str) -> Dict[str, Any]:
         """
         Get asset pair information

--- a/kraken/grid-trader/scripts/setup_cron.py
+++ b/kraken/grid-trader/scripts/setup_cron.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Create and manage seren-cron jobs for kraken-grid-trader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+import requests
+
+
+DEFAULT_GATEWAY_URL = "https://api.serendb.com"
+JOB_PREFIX = "kraken-grid-trader-"
+
+
+class CronSetup:
+    def __init__(self, api_key: str, gateway_url: str = DEFAULT_GATEWAY_URL):
+        self.base = f"{gateway_url.rstrip('/')}/publishers/seren-cron"
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        )
+
+    def call(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        url = f"{self.base}{path}"
+        kwargs: dict[str, Any] = {"timeout": 60}
+        if body is not None:
+            kwargs["json"] = body
+        response = self.session.request(method.upper(), url, **kwargs)
+        if response.status_code >= 400:
+            raise RuntimeError(f"{method} {path} failed: {response.status_code} {response.text[:200]}")
+        payload = response.json()
+        if isinstance(payload, dict) and "body" in payload:
+            return payload["body"]
+        return payload
+
+    @staticmethod
+    def extract_jobs(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        body = payload.get("body", payload)
+        if isinstance(body, dict) and isinstance(body.get("data"), list):
+            return body["data"]
+        if isinstance(payload.get("data"), list):
+            return payload["data"]
+        return []
+
+    def upsert_jobs(self, jobs: list[dict[str, Any]], dry_run: bool = False) -> list[dict[str, Any]]:
+        existing_payload = self.call("GET", "/api/v1/jobs")
+        existing = {job.get("name"): job for job in self.extract_jobs(existing_payload)}
+        results = []
+        for job in jobs:
+            prior = existing.get(job["name"])
+            if dry_run:
+                results.append({"name": job["name"], "operation": "update" if prior else "create"})
+                continue
+            if prior and prior.get("id"):
+                response = self.call("PUT", f"/api/v1/jobs/{prior['id']}", body=job)
+                results.append({"name": job["name"], "operation": "update", "response": response})
+            else:
+                response = self.call("POST", "/api/v1/jobs", body=job)
+                results.append({"name": job["name"], "operation": "create", "response": response})
+        return results
+
+
+def build_jobs(
+    *,
+    runner_url: str,
+    webhook_secret: str,
+    timezone: str,
+    cycle_schedule: str,
+    review_schedule: str,
+    safety_schedule: str,
+) -> list[dict[str, Any]]:
+    base_url = runner_url.rstrip("/")
+    headers = {"Content-Type": "application/json", "X-Webhook-Secret": webhook_secret}
+    return [
+        {
+            "name": f"{JOB_PREFIX}cycle",
+            "schedule": cycle_schedule,
+            "timezone": timezone,
+            "url": f"{base_url}/run",
+            "method": "POST",
+            "headers": headers,
+            "body": {"action": "cycle"},
+        },
+        {
+            "name": f"{JOB_PREFIX}safety-check",
+            "schedule": safety_schedule,
+            "timezone": timezone,
+            "url": f"{base_url}/safety-check",
+            "method": "POST",
+            "headers": headers,
+            "body": {"action": "safety-check"},
+        },
+        {
+            "name": f"{JOB_PREFIX}weekly-review",
+            "schedule": review_schedule,
+            "timezone": timezone,
+            "url": f"{base_url}/review",
+            "method": "POST",
+            "headers": headers,
+            "body": {"action": "review"},
+        },
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Manage seren-cron jobs for kraken-grid-trader")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create")
+    create.add_argument("--runner-url", required=True, help="Public runner URL, e.g. https://bot.example.com")
+    create.add_argument("--webhook-secret", required=True, help="X-Webhook-Secret value")
+    create.add_argument("--api-key", default=os.getenv("SEREN_API_KEY", ""), help="SEREN_API_KEY")
+    create.add_argument("--gateway-url", default=os.getenv("SEREN_GATEWAY_URL", DEFAULT_GATEWAY_URL))
+    create.add_argument("--timezone", default="America/New_York")
+    create.add_argument("--cycle-schedule", default="*/5 * * * *")
+    create.add_argument("--safety-schedule", default="*/30 * * * *")
+    create.add_argument("--review-schedule", default="0 7 * * 1")
+    create.add_argument("--dry-run", action="store_true")
+
+    list_parser = sub.add_parser("list")
+    list_parser.add_argument("--api-key", default=os.getenv("SEREN_API_KEY", ""), help="SEREN_API_KEY")
+    list_parser.add_argument("--gateway-url", default=os.getenv("SEREN_GATEWAY_URL", DEFAULT_GATEWAY_URL))
+
+    for command in ("pause", "resume", "delete"):
+        action = sub.add_parser(command)
+        action.add_argument("--job-id", required=True)
+        action.add_argument("--api-key", default=os.getenv("SEREN_API_KEY", ""), help="SEREN_API_KEY")
+        action.add_argument("--gateway-url", default=os.getenv("SEREN_GATEWAY_URL", DEFAULT_GATEWAY_URL))
+
+    return parser.parse_args()
+
+
+def _build_setup(api_key: str, gateway_url: str) -> CronSetup:
+    if not api_key:
+        raise SystemExit("SEREN_API_KEY is required (--api-key or env)")
+    return CronSetup(api_key=api_key, gateway_url=gateway_url)
+
+
+def main() -> None:
+    args = parse_args()
+    setup = _build_setup(args.api_key, args.gateway_url)
+
+    if args.command == "create":
+        jobs = build_jobs(
+            runner_url=args.runner_url,
+            webhook_secret=args.webhook_secret,
+            timezone=args.timezone,
+            cycle_schedule=args.cycle_schedule,
+            review_schedule=args.review_schedule,
+            safety_schedule=args.safety_schedule,
+        )
+        results = setup.upsert_jobs(jobs=jobs, dry_run=args.dry_run)
+        print(json.dumps(results, indent=2))
+        if args.dry_run:
+            return
+        listed = setup.call("GET", "/api/v1/jobs")
+        jobs = [
+            job for job in setup.extract_jobs(listed)
+            if str(job.get("name", "")).startswith(JOB_PREFIX)
+        ]
+        jobs.sort(key=lambda item: item.get("name", ""))
+        print("\nActive jobs:")
+        for job in jobs:
+            print(
+                f"- {job.get('name')} | id={job.get('id')} | cron={job.get('cron_expression')} "
+                f"| tz={job.get('timezone')} | enabled={job.get('enabled')} | next={job.get('next_run_time')}"
+            )
+        return
+
+    if args.command == "list":
+        payload = setup.call("GET", "/api/v1/jobs")
+        jobs = [
+            job for job in setup.extract_jobs(payload)
+            if str(job.get("name", "")).startswith(JOB_PREFIX)
+        ]
+        jobs.sort(key=lambda item: item.get("name", ""))
+        print(json.dumps(jobs, indent=2))
+        return
+
+    if args.command == "pause":
+        print(json.dumps(setup.call("POST", f"/api/v1/jobs/{args.job_id}/pause"), indent=2))
+        return
+
+    if args.command == "resume":
+        print(json.dumps(setup.call("POST", f"/api/v1/jobs/{args.job_id}/resume"), indent=2))
+        return
+
+    if args.command == "delete":
+        print(json.dumps(setup.call("DELETE", f"/api/v1/jobs/{args.job_id}"), indent=2))
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/kraken/grid-trader/tests/conftest.py
+++ b/kraken/grid-trader/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 MODULE_NAMES = (
+    "adaptive_runtime",
     "agent",
     "grid_manager",
     "logger",

--- a/kraken/grid-trader/tests/test_adaptive_runtime.py
+++ b/kraken/grid-trader/tests/test_adaptive_runtime.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+_MODULES_TO_CLEAR = (
+    "adaptive_runtime",
+    "agent",
+    "grid_manager",
+    "logger",
+    "pair_selector",
+    "position_tracker",
+    "seren_client",
+    "serendb_store",
+)
+
+
+def _load_local_module(module_name: str):
+    script_dir = str(_SCRIPT_DIR)
+    sys.path[:] = [script_dir, *[path for path in sys.path if path != script_dir]]
+    for cached_name in _MODULES_TO_CLEAR:
+        sys.modules.pop(cached_name, None)
+    spec = importlib.util.spec_from_file_location(
+        f"{Path(__file__).stem}_{module_name}",
+        _SCRIPT_DIR / f"{module_name}.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adaptive_runtime = _load_local_module("adaptive_runtime")
+
+
+def test_shadow_gate_promotes_better_candidate(tmp_path) -> None:
+    settings = adaptive_runtime.resolve_adaptive_settings(
+        {
+            "adaptive": {
+                "state_path": str(tmp_path / "state" / "adaptive_state.json"),
+                "metrics_log_path": str(tmp_path / "logs" / "metrics.jsonl"),
+                "review_log_path": str(tmp_path / "logs" / "reviews.jsonl"),
+                "review_output_dir": str(tmp_path / "logs" / "reviews"),
+                "alert_log_path": str(tmp_path / "logs" / "alerts.jsonl"),
+                "shadow_min_samples": 2,
+                "shadow_improvement_threshold_pct": 0.0,
+            }
+        }
+    )
+    store = adaptive_runtime.AdaptiveStateStore(settings)
+    store.state["recent_cycles"] = [
+        {"market_price": 100.0, "fill_rate": 1.0, "net_pnl_usd": 15.0},
+        {"market_price": 102.0, "fill_rate": 0.9, "net_pnl_usd": 12.0},
+    ]
+    store.state["baseline_summary"] = {"scores": [-0.45], "rolling_score": -0.45}
+    store.state["candidate_summary"] = {"scores": [-0.06], "rolling_score": -0.06, "candidate_params": {}}
+
+    decision = adaptive_runtime.compute_adaptive_decision(
+        store=store,
+        config={
+            "strategy": {
+                "grid_spacing_percent": 1.0,
+                "order_size_percent": 10.0,
+                "price_range": {"min": 90.0, "max": 110.0},
+            },
+            "risk_management": {"max_open_orders": 40},
+        },
+        market_metrics={
+            "mid_price": 105.0,
+            "spread_pct": 0.08,
+            "atr_pct": 10.0,
+            "rolling_stddev_pct": 3.2,
+            "regime_tag": "trend_up",
+        },
+        live_risk={"drawdown_pct": 1.0},
+        current_price=105.0,
+    )
+
+    assert decision.promoted is True
+    assert decision.candidate_score > decision.baseline_score
+    assert store.state["last_accepted_params"]["grid_spacing_percent"] == decision.candidate_params["grid_spacing_percent"]
+
+
+def test_review_report_uses_rolling_50_and_200_windows(tmp_path) -> None:
+    settings = adaptive_runtime.resolve_adaptive_settings(
+        {
+            "adaptive": {
+                "state_path": str(tmp_path / "state" / "adaptive_state.json"),
+                "metrics_log_path": str(tmp_path / "logs" / "metrics.jsonl"),
+                "review_log_path": str(tmp_path / "logs" / "reviews.jsonl"),
+                "review_output_dir": str(tmp_path / "logs" / "reviews"),
+                "alert_log_path": str(tmp_path / "logs" / "alerts.jsonl"),
+            }
+        }
+    )
+    store = adaptive_runtime.AdaptiveStateStore(settings)
+
+    for idx in range(60):
+        adaptive_runtime.update_cycle_state(
+            store=store,
+            cycle_snapshot={
+                "timestamp": f"2026-03-20T00:{idx:02d}:00Z",
+                "market_price": 100.0 + idx,
+                "net_pnl_usd": 1.0 if idx % 2 == 0 else -0.5,
+                "equity_end_usd": 1000.0 + idx,
+                "fill_count": 1,
+                "fill_rate": 0.5,
+                "drawdown_pct": 0.2,
+                "cancel_rate": 0.1,
+                "candidate_score": 0.8,
+                "regime_tag": "range",
+                "grid_spacing_percent": 2.0,
+                "order_size_percent": 5.0,
+                "max_open_orders": 40,
+                "risk_multiplier": 1.0,
+                "dynamic_center_price": 100.0 + idx,
+            },
+        )
+
+    report = adaptive_runtime.build_review_report(store)
+
+    assert report["cycle_count"] == 60
+    assert report["rolling_windows"]["last_50"]["count"] == 50
+    assert report["rolling_windows"]["last_200"]["count"] == 60

--- a/kraken/grid-trader/tests/test_live_safety.py
+++ b/kraken/grid-trader/tests/test_live_safety.py
@@ -9,6 +9,7 @@ import pytest
 
 _SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 _MODULES_TO_CLEAR = (
+    "adaptive_runtime",
     "agent",
     "grid_manager",
     "logger",
@@ -61,6 +62,24 @@ def _build_trader(tmp_path, monkeypatch) -> KrakenGridTrader:
     trader.running = True
     trader.session_id = "session"
     trader.store = None
+    trader.tracker = type(
+        "Tracker",
+        (),
+        {
+            "btc_balance": 0.0,
+            "remove_open_order": lambda *args, **kwargs: None,
+        },
+    )()
+    trader.adaptive_store = type(
+        "AdaptiveStore",
+        (),
+        {"state": {}, "save": lambda *args, **kwargs: None},
+    )()
+    trader.current_adaptive_decision = type(
+        "Decision",
+        (),
+        {"accepted_params": {"max_open_orders": 40}},
+    )()
     trader.logger = type("Logger", (), {"log_error": lambda *args, **kwargs: None})()
     trader._cycle_deadline_at = None
     trader._store_call = lambda context, fn: None
@@ -70,7 +89,7 @@ def _build_trader(tmp_path, monkeypatch) -> KrakenGridTrader:
 def test_quote_reserve_skips_buy_orders(tmp_path, monkeypatch) -> None:
     trader = _build_trader(tmp_path, monkeypatch)
     placed: list[tuple[str, float, float]] = []
-    trader._place_order = lambda pair, side, price, volume: placed.append((side, price, volume))
+    trader._place_order = lambda pair, side, price, volume: (placed.append((side, price, volume)) or True)
 
     trader._place_grid_orders(
         {"buy": [{"price": 95.0, "volume": 10.0}, {"price": 10.0, "volume": 1.0}], "sell": []},
@@ -79,6 +98,39 @@ def test_quote_reserve_skips_buy_orders(tmp_path, monkeypatch) -> None:
     )
 
     assert placed == [("buy", 10.0, 1.0)]
+
+
+def test_open_order_cap_blocks_new_orders(tmp_path, monkeypatch) -> None:
+    trader = _build_trader(tmp_path, monkeypatch)
+    trader.current_adaptive_decision.accepted_params = {"max_open_orders": 1}
+    trader._place_order = lambda *args, **kwargs: pytest.fail("should not place new orders")
+
+    summary = trader._place_grid_orders(
+        {"buy": [{"price": 95.0, "volume": 0.1}], "sell": []},
+        {"existing": {"descr": {"type": "buy", "price": "96.0"}, "vol": "0.1"}},
+        1000.0,
+    )
+
+    assert summary["placed_buy"] == 0
+    assert summary["skipped_buy"] == 1
+
+
+def test_position_cap_blocks_incremental_buys(tmp_path, monkeypatch) -> None:
+    trader = _build_trader(tmp_path, monkeypatch)
+    trader.config["risk_management"]["max_position_size"] = 0.5
+    placed: list[tuple[str, float, float]] = []
+    trader._place_order = lambda pair, side, price, volume: (placed.append((side, price, volume)) or True)
+
+    summary = trader._place_grid_orders(
+        {"buy": [{"price": 95.0, "volume": 0.1}], "sell": []},
+        {},
+        1000.0,
+        base_balance=0.45,
+    )
+
+    assert placed == []
+    assert summary["placed_buy"] == 0
+    assert summary["skipped_buy"] == 1
 
 
 def test_drawdown_guard_persists_peak_and_blocks(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Fixes #17

## Summary
- add persistent adaptive runtime state, rolling telemetry, shadow promotion/rollback, and one-shot cycle/review/safety commands
- enforce new hard safety caps for order placement and persist open-order context across cron-style runs
- add webhook + seren-cron orchestration scripts, config/docs updates, and focused adaptive runtime tests

## Testing
- pytest kraken/grid-trader/tests/test_live_safety.py kraken/grid-trader/tests/test_adaptive_runtime.py kraken/grid-trader/tests/test_backtest_optimizer.py kraken/grid-trader/tests/test_grid_trade_reports.py
- python3 -m py_compile kraken/grid-trader/scripts/agent.py kraken/grid-trader/scripts/run_agent_server.py kraken/grid-trader/scripts/setup_cron.py