### PR TITLE
feat: move kraken adaptive runtime persistence to serendb

### DIFF
--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -223,24 +223,24 @@ All operations logged to `logs/` directory as JSONL files:
 - `orders.jsonl` - Order placements/cancellations
 - `fills.jsonl` - Trade executions
 - `positions.jsonl` - Position snapshots
-- `metrics.jsonl` - Per-cycle adaptive telemetry and rolling windows
-- `weekly_reviews.jsonl` - Weekly review summaries
-- `alerts.jsonl` - Safety incidents and repeated failures
 - `errors.jsonl` - Errors and warnings
 
-Adaptive state persists in `state/adaptive_state.json`, including accepted parameters, shadow scores, recent cycles, and known open orders for one-shot cron execution.
+Adaptive runtime state, telemetry, review references, and the shared cron lease now persist in SerenDB. This includes accepted parameters, shadow scores, recent cycles, known open orders, `live_risk_state`, runtime events, and the lock record used to fail closed on overlapping one-shot invocations.
 
 ## SerenDB Persistence
 
-When `seren-mcp` is available, the bot also persists to SerenDB:
+When `seren-mcp` is available, the bot persists to SerenDB:
 
 - `kraken_grid_sessions`
 - `kraken_grid_orders`
 - `kraken_grid_fills`
 - `kraken_grid_positions`
 - `kraken_grid_events`
+- `trading.runtime_state`
+- `trading.runtime_events`
+- `trading.runtime_locks`
 
-SerenDB persistence is best-effort; if unavailable, trading continues with local logs.
+Adaptive mode requires SerenDB persistence. If the MCP-backed store is unavailable, the adaptive runtime fails closed instead of silently falling back to local state files.
 
 ## Safety Features
 
@@ -248,7 +248,7 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 2. **Daily Loss Caps + Cooldowns**: New buys pause after loss streaks or daily drawdown breaches
 3. **Position/Open Order Limits**: Prevents overexposure and runaway order spam
 4. **Shadow Promotion Gate**: Candidate settings must outperform the baseline before promotion
-5. **Audit Trail**: Every cycle, review, fill, and alert is logged
+5. **Audit Trail**: Every cycle, review, fill, alert, and runtime lease transition is persisted
 6. **Graceful Shutdown**: Cancels all orders on exit
 
 ## seren-cron

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -27,8 +27,8 @@ Display the full dry-run results to the user. Only after results are displayed, 
 - Pair selection support (single pair or candidate list)
 - Adaptive grid centering, spacing/order-size tuning, and persistent learning state
 - Shadow evaluation with gated promotion and rollback
-- JSONL logs for setup, metrics, orders, fills, positions, weekly reviews, alerts, and errors
-- MCP-native SerenDB persistence for sessions, events, orders, fills, and position snapshots
+- JSONL logs for setup, orders, fills, positions, and errors
+- MCP-native SerenDB persistence for sessions, events, orders, fills, position snapshots, adaptive runtime state, telemetry, reviews, and runtime locks
 
 ## What is Grid Trading?
 
@@ -84,11 +84,11 @@ Set these optional environment variables in `.env`:
 - `SERENDB_AUTO_CREATE` (default: `true`)
 - `SEREN_MCP_COMMAND` (default: `seren-mcp`)
 
-Persistence is best-effort: if SerenDB/MCP is unavailable, trading still runs and logs locally.
+Adaptive mode requires SerenDB/MCP. If the persistence layer is unavailable, the runtime fails closed rather than falling back to local adaptive state files.
 
 ## Configuration
 
-See `config.example.json` for available parameters including grid spacing, order size, trading pair selection, daily loss caps, cooldowns, shadow thresholds, and adaptive state paths.
+See `config.example.json` for available parameters including grid spacing, order size, trading pair selection, daily loss caps, cooldowns, shadow thresholds, and adaptive lock lease settings.
 
 ## Disclaimer
 

--- a/kraken/grid-trader/config.example.json
+++ b/kraken/grid-trader/config.example.json
@@ -38,9 +38,8 @@
   },
   "adaptive": {
     "enabled": true,
-    "state_path": "state/adaptive_state.json",
-    "lock_path": "state/runtime.lock",
     "slippage_buffer_pct": 0.2,
+    "lock_ttl_seconds": 120,
     "min_spacing_percent": 0.0,
     "max_spacing_multiplier": 2.5,
     "min_order_size_multiplier": 0.25,
@@ -53,10 +52,6 @@
     "shadow_min_samples": 5,
     "shadow_improvement_threshold_pct": 5.0,
     "shadow_rollback_degradation_pct": 10.0,
-    "metrics_log_path": "logs/metrics.jsonl",
-    "review_log_path": "logs/weekly_reviews.jsonl",
-    "review_output_dir": "logs/reviews",
-    "alert_log_path": "logs/alerts.jsonl",
     "max_failure_count_before_alert": 3
   }
 }

--- a/kraken/grid-trader/scripts/adaptive_runtime.py
+++ b/kraken/grid-trader/scripts/adaptive_runtime.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import fcntl
-import json
 import math
-import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from statistics import mean
 from typing import Any, Iterator
 
@@ -19,8 +15,6 @@ ROUND_TRIP_FEE_PCT = 0.32
 
 DEFAULT_ADAPTIVE_SETTINGS: dict[str, Any] = {
     "enabled": True,
-    "state_path": "state/adaptive_state.json",
-    "lock_path": "state/runtime.lock",
     "slippage_buffer_pct": 0.2,
     "min_spacing_percent": 0.0,
     "max_spacing_multiplier": 2.5,
@@ -34,11 +28,8 @@ DEFAULT_ADAPTIVE_SETTINGS: dict[str, Any] = {
     "shadow_min_samples": 5,
     "shadow_improvement_threshold_pct": 5.0,
     "shadow_rollback_degradation_pct": 10.0,
-    "metrics_log_path": "logs/metrics.jsonl",
-    "review_log_path": "logs/weekly_reviews.jsonl",
-    "review_output_dir": "logs/reviews",
-    "alert_log_path": "logs/alerts.jsonl",
     "max_failure_count_before_alert": 3,
+    "lock_ttl_seconds": 120,
 }
 
 
@@ -74,24 +65,12 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def _json_append(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, sort_keys=True) + "\n")
-
-
 def resolve_adaptive_settings(config: dict[str, Any]) -> dict[str, Any]:
     raw = config.get("adaptive", {})
     settings = dict(DEFAULT_ADAPTIVE_SETTINGS)
     if isinstance(raw, dict):
         settings.update(raw)
     settings["enabled"] = bool(settings.get("enabled", True))
-    settings["state_path"] = str(settings.get("state_path", DEFAULT_ADAPTIVE_SETTINGS["state_path"]))
-    settings["lock_path"] = str(settings.get("lock_path", DEFAULT_ADAPTIVE_SETTINGS["lock_path"]))
-    settings["metrics_log_path"] = str(settings.get("metrics_log_path", DEFAULT_ADAPTIVE_SETTINGS["metrics_log_path"]))
-    settings["review_log_path"] = str(settings.get("review_log_path", DEFAULT_ADAPTIVE_SETTINGS["review_log_path"]))
-    settings["review_output_dir"] = str(settings.get("review_output_dir", DEFAULT_ADAPTIVE_SETTINGS["review_output_dir"]))
-    settings["alert_log_path"] = str(settings.get("alert_log_path", DEFAULT_ADAPTIVE_SETTINGS["alert_log_path"]))
     settings["slippage_buffer_pct"] = _safe_float(settings.get("slippage_buffer_pct"), 0.2)
     settings["min_spacing_percent"] = _safe_float(settings.get("min_spacing_percent"), 0.0)
     settings["max_spacing_multiplier"] = max(_safe_float(settings.get("max_spacing_multiplier"), 2.5), 1.0)
@@ -123,28 +102,27 @@ def resolve_adaptive_settings(config: dict[str, Any]) -> dict[str, Any]:
     settings["max_failure_count_before_alert"] = max(
         int(_safe_float(settings.get("max_failure_count_before_alert"), 3)), 1
     )
+    settings["lock_ttl_seconds"] = max(int(_safe_float(settings.get("lock_ttl_seconds"), 120)), 30)
     return settings
 
 
 @contextmanager
-def runtime_lock(lock_path: str | Path) -> Iterator[None]:
-    path = Path(lock_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a+", encoding="utf-8") as handle:
-        try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            raise RuntimeLockError(f"another kraken-grid-trader adaptive run is already active ({path})") from exc
-        handle.seek(0)
-        handle.truncate()
-        handle.write(json.dumps({"pid": os.getpid(), "acquired_at": _now_iso()}, sort_keys=True))
-        handle.flush()
-        try:
-            yield
-        finally:
-            handle.seek(0)
-            handle.truncate()
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+def runtime_lock(*, persistence: Any, lock_key: str, owner_id: str, ttl_seconds: int) -> Iterator[None]:
+    if persistence is None:
+        raise RuntimeLockError("adaptive runtime requires SerenDB-backed persistence")
+    acquired = bool(
+        persistence.acquire_lock(
+            lock_key=lock_key,
+            owner_id=owner_id,
+            ttl_seconds=ttl_seconds,
+        )
+    )
+    if not acquired:
+        raise RuntimeLockError(f"another kraken-grid-trader adaptive run is already active ({lock_key})")
+    try:
+        yield
+    finally:
+        persistence.release_lock(lock_key=lock_key, owner_id=owner_id)
 
 
 def _default_state() -> dict[str, Any]:
@@ -169,28 +147,24 @@ def _default_state() -> dict[str, Any]:
         "daily_pnl": {"date": None, "equity_start_usd": None, "equity_end_usd": None, "net_change_usd": 0.0},
         "failure_state": {"count": 0, "last_error": "", "last_failure_at": None},
         "review_reports": [],
+        "live_risk_state": {},
     }
 
 
 class AdaptiveStateStore:
     """Persist adaptive trading state across grid-trader restarts."""
 
-    def __init__(self, settings: dict[str, Any]) -> None:
+    def __init__(self, settings: dict[str, Any], persistence: Any | None = None) -> None:
         self.settings = settings
-        self.path = Path(settings["state_path"])
-        self.metrics_log_path = Path(settings["metrics_log_path"])
-        self.review_log_path = Path(settings["review_log_path"])
-        self.review_output_dir = Path(settings["review_output_dir"])
-        self.alert_log_path = Path(settings["alert_log_path"])
+        self.persistence = persistence
         self.state = self._load()
 
     def _load(self) -> dict[str, Any]:
-        try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            payload = {}
-        except json.JSONDecodeError:
-            payload = {}
+        payload = {}
+        if self.persistence is not None:
+            loaded = self.persistence.load_state()
+            if isinstance(loaded, dict):
+                payload = loaded
         state = _default_state()
         if isinstance(payload, dict):
             state.update(payload)
@@ -205,12 +179,13 @@ class AdaptiveStateStore:
         state.setdefault("daily_pnl", {"date": None, "equity_start_usd": None, "equity_end_usd": None, "net_change_usd": 0.0})
         state.setdefault("baseline_summary", {"scores": [], "rolling_score": 0.0})
         state.setdefault("candidate_summary", {"scores": [], "rolling_score": 0.0, "candidate_params": {}})
+        state.setdefault("live_risk_state", {})
         return state
 
     def save(self) -> None:
         self.state["updated_at"] = _now_iso()
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(self.state, sort_keys=True, indent=2), encoding="utf-8")
+        if self.persistence is not None:
+            self.persistence.save_state(self.state)
 
     def accepted_params(self, fallback: dict[str, Any]) -> dict[str, Any]:
         params = self.state.get("last_accepted_params")
@@ -218,6 +193,14 @@ class AdaptiveStateStore:
             params = dict(fallback)
             self.state["last_accepted_params"] = dict(params)
         return dict(params)
+
+    def record_event(self, event_type: str, payload: dict[str, Any]) -> str | None:
+        if self.persistence is None:
+            return None
+        return self.persistence.append_event(event_type, payload)
+
+    def record_metric(self, payload: dict[str, Any]) -> str | None:
+        return self.record_event("metrics", payload)
 
     def append_fill(self, fill_event: dict[str, Any]) -> None:
         recent_fills = list(self.state.get("recent_fills", []))
@@ -228,7 +211,7 @@ class AdaptiveStateStore:
         recent_cycles = list(self.state.get("recent_cycles", []))
         recent_cycles.append(cycle_snapshot)
         self.state["recent_cycles"] = recent_cycles[-200:]
-        _json_append(self.metrics_log_path, cycle_snapshot)
+        self.record_metric(cycle_snapshot)
 
     def note_incident(self, incident_type: str, payload: dict[str, Any]) -> None:
         incidents = list(self.state.get("risk_incidents", []))
@@ -240,8 +223,8 @@ class AdaptiveStateStore:
             }
         )
         self.state["risk_incidents"] = incidents[-100:]
-        _json_append(
-            self.alert_log_path,
+        self.record_event(
+            "alert",
             {
                 "recorded_at": _now_iso(),
                 "kind": "risk_incident",
@@ -262,8 +245,8 @@ class AdaptiveStateStore:
         )
         self.state["failure_state"] = failure_state
         if count >= int(self.settings["max_failure_count_before_alert"]):
-            _json_append(
-                self.alert_log_path,
+            self.record_event(
+                "alert",
                 {
                     "recorded_at": _now_iso(),
                     "kind": "repeated_failures",
@@ -305,15 +288,12 @@ class AdaptiveStateStore:
     def clear_cooldown(self) -> None:
         self.state["cooldown_until"] = None
 
-    def record_review(self, report: dict[str, Any]) -> Path:
-        self.review_output_dir.mkdir(parents=True, exist_ok=True)
-        report_path = self.review_output_dir / f"weekly_review_{_now().strftime('%Y%m%dT%H%M%SZ')}.json"
-        report_path.write_text(json.dumps(report, sort_keys=True, indent=2), encoding="utf-8")
-        _json_append(self.review_log_path, report)
+    def record_review(self, report: dict[str, Any]) -> str:
+        reference = self.record_event("review", report) or f"review:{report['generated_at']}"
         review_reports = list(self.state.get("review_reports", []))
-        review_reports.append({"generated_at": report["generated_at"], "path": str(report_path)})
+        review_reports.append({"generated_at": report["generated_at"], "reference": reference})
         self.state["review_reports"] = review_reports[-20:]
-        return report_path
+        return reference
 
 
 @dataclass

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -19,7 +19,7 @@ import signal
 import sys
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 from pathlib import Path
 from dotenv import load_dotenv
@@ -45,7 +45,6 @@ from urllib.request import Request, urlopen
 
 
 LIVE_SAFETY_VERSION = "2026-03-16.kraken-coinbase-live-safety-v1"
-LIVE_RISK_STATE_PATH = Path("state/live_risk.json")
 
 
 class LiveRiskError(RuntimeError):
@@ -132,11 +131,7 @@ class KrakenGridTrader:
         self.tracker = None
         self.running = False
         self.active_orders = {}  # order_id -> order_details
-        self.live_risk_state = self._load_live_risk_state()
         self.adaptive_settings = resolve_adaptive_settings(self.config)
-        self.adaptive_store = AdaptiveStateStore(self.adaptive_settings)
-        self.current_adaptive_decision = None
-        self._cycle_deadline_at: Optional[float] = None
 
         try:
             self.store = _build_store_from_env()
@@ -145,9 +140,23 @@ class KrakenGridTrader:
             print(f"WARNING: SerenDB persistence unavailable: {exc}", file=sys.stderr)
             self.store = None
 
+        if self.adaptive_settings.get('enabled', True) and self.store is None:
+            raise ValueError(
+                "Adaptive runtime requires SerenDB persistence. "
+                "Set SEREN_API_KEY and ensure seren-mcp can reach SerenDB."
+            )
+
+        self.adaptive_store = self._build_adaptive_store()
+        self.live_risk_state = self._load_live_risk_state()
+        self.current_adaptive_decision = None
+        self._cycle_deadline_at: Optional[float] = None
+
     def close(self):
         """Close any external resources."""
-        self.adaptive_store.save()
+        try:
+            self.adaptive_store.save()
+        except Exception:
+            pass
         if self.store is None:
             return
         try:
@@ -167,6 +176,36 @@ class KrakenGridTrader:
                 self.store.close()
             finally:
                 self.store = None
+            if self.adaptive_settings.get('enabled', True):
+                raise RuntimeError(
+                    "Adaptive runtime lost required SerenDB persistence."
+                ) from exc
+
+    def _build_adaptive_store(self) -> AdaptiveStateStore:
+        pair = self.config.get('trading_pair')
+        persistence = None
+        if self.adaptive_settings.get('enabled', True):
+            if self.store is None:
+                raise ValueError("Adaptive runtime requires SerenDB persistence.")
+            if pair:
+                persistence = self.store.adaptive_runtime(
+                    runtime_key=self._adaptive_runtime_key(pair),
+                    lock_key=self._adaptive_lock_key(pair),
+                )
+        return AdaptiveStateStore(self.adaptive_settings, persistence=persistence)
+
+    def _refresh_adaptive_store(self) -> None:
+        self.adaptive_store.save()
+        self.adaptive_store = self._build_adaptive_store()
+        self.live_risk_state = self._load_live_risk_state()
+
+    def _adaptive_runtime_key(self, pair: Optional[str] = None) -> str:
+        runtime_pair = str(pair or self.config.get('trading_pair') or 'pending').strip()
+        campaign = str(self.config.get('campaign_name') or 'grid').strip()
+        return f"{campaign}:{runtime_pair}"
+
+    def _adaptive_lock_key(self, pair: Optional[str] = None) -> str:
+        return f"adaptive:{self._adaptive_runtime_key(pair)}"
 
     def _ensure_session_started(self):
         """Create a persistence session once a trading pair is known."""
@@ -253,12 +292,7 @@ class KrakenGridTrader:
         self.backtest_optimization = summary
 
     def _load_live_risk_state(self) -> Dict[str, Any]:
-        try:
-            payload = json.loads(LIVE_RISK_STATE_PATH.read_text(encoding='utf-8'))
-        except FileNotFoundError:
-            payload = {}
-        except json.JSONDecodeError:
-            payload = {}
+        payload = self.adaptive_store.state.get('live_risk_state', {})
         if not isinstance(payload, dict):
             payload = {}
         payload.setdefault('runtime_version', LIVE_SAFETY_VERSION)
@@ -267,16 +301,13 @@ class KrakenGridTrader:
     def _persist_live_risk_state(self, payload: Dict[str, Any]) -> None:
         state = dict(payload)
         state['runtime_version'] = LIVE_SAFETY_VERSION
-        state['updated_at'] = datetime.utcnow().isoformat()
-        LIVE_RISK_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        LIVE_RISK_STATE_PATH.write_text(
-            json.dumps(state, sort_keys=True, indent=2),
-            encoding='utf-8',
-        )
+        state['updated_at'] = datetime.now(timezone.utc).isoformat()
+        self.adaptive_store.state['live_risk_state'] = state
+        self.adaptive_store.save()
         self.live_risk_state = state
 
     def _adaptive_lock_path(self) -> str:
-        return str(self.adaptive_settings.get('lock_path', 'state/runtime.lock'))
+        return self._adaptive_lock_key()
 
     def _current_grid_parameters(self) -> Dict[str, Any]:
         strategy = self.config['strategy']
@@ -538,6 +569,7 @@ class KrakenGridTrader:
                 )
 
         self.config['trading_pair'] = best_pair
+        self._refresh_adaptive_store()
         print(f"\n✓ Selected pair: {best_pair} (score: {best_score['score']:.3f})\n")
         self._ensure_session_started()
         self._store_call(
@@ -748,7 +780,7 @@ class KrakenGridTrader:
                 f"atr={market_metrics['atr_pct']:.4f}% "
                 f"rolling_vol={market_metrics['rolling_stddev_pct']:.4f}%"
             )
-            self.logger.log_metrics_snapshot(
+            self.adaptive_store.record_metric(
                 {
                     'timestamp': datetime.utcnow().isoformat() + 'Z',
                     'pair': pair,
@@ -827,7 +859,12 @@ class KrakenGridTrader:
 
     def run_cycle(self) -> Dict[str, Any]:
         """Execute exactly one adaptive cycle under the shared runtime lock."""
-        with runtime_lock(self._adaptive_lock_path()):
+        with runtime_lock(
+            persistence=self.adaptive_store.persistence,
+            lock_key=self._adaptive_lock_path(),
+            owner_id=self.session_id,
+            ttl_seconds=int(self.adaptive_settings.get('lock_ttl_seconds', 120)),
+        ):
             self._trading_cycle()
             recent_cycles = list(self.adaptive_store.state.get('recent_cycles', []))
             if recent_cycles:
@@ -836,28 +873,37 @@ class KrakenGridTrader:
 
     def build_review(self) -> Dict[str, Any]:
         """Generate and persist the weekly adaptive review report."""
-        with runtime_lock(self._adaptive_lock_path()):
+        with runtime_lock(
+            persistence=self.adaptive_store.persistence,
+            lock_key=self._adaptive_lock_path(),
+            owner_id=self.session_id,
+            ttl_seconds=int(self.adaptive_settings.get('lock_ttl_seconds', 120)),
+        ):
             report = build_review_report(self.adaptive_store)
-            report_path = self.adaptive_store.record_review(report)
+            report_ref = self.adaptive_store.record_review(report)
             self.adaptive_store.save()
-            self.logger.log_review_report({**report, 'report_path': str(report_path)})
             self._store_call(
                 'adaptive_review_event',
                 lambda: self.store.save_event(
                     self.session_id,
                     'adaptive_review_generated',
                     {
-                        'report_path': str(report_path),
+                        'report_reference': report_ref,
                         'cycle_count': report['cycle_count'],
                         'rolling_windows': report['rolling_windows'],
                     },
                 ),
             )
-            return {**report, 'report_path': str(report_path)}
+            return {**report, 'report_reference': report_ref}
 
     def run_safety_check(self) -> Dict[str, Any]:
         """Run a one-shot safety evaluation and optionally surface cooldown alerts."""
-        with runtime_lock(self._adaptive_lock_path()):
+        with runtime_lock(
+            persistence=self.adaptive_store.persistence,
+            lock_key=self._adaptive_lock_path(),
+            owner_id=self.session_id,
+            ttl_seconds=int(self.adaptive_settings.get('lock_ttl_seconds', 120)),
+        ):
             pair = self.config['trading_pair']
             market_snapshot = self._get_market_snapshot(pair)
             current_price = float(market_snapshot['current_price'])
@@ -900,7 +946,6 @@ class KrakenGridTrader:
             }
             if issues:
                 self.adaptive_store.note_incident('safety_check', payload)
-                self.logger.log_alert('safety_check', payload)
             self.adaptive_store.save()
             return payload
 
@@ -983,14 +1028,6 @@ class KrakenGridTrader:
                         'reasons': decision.reasons,
                         'candidate_score': decision.candidate_score,
                         'baseline_score': decision.baseline_score,
-                    },
-                )
-                self.logger.log_alert(
-                    incident_type,
-                    {
-                        'pair': pair,
-                        'current_price': current_price,
-                        'reasons': decision.reasons,
                     },
                 )
 
@@ -1094,7 +1131,7 @@ class KrakenGridTrader:
             self._persist_known_open_orders()
             self.adaptive_store.save()
             rolling_windows = self._rolling_window_metrics()
-            self.logger.log_metrics_snapshot(
+            self.adaptive_store.record_metric(
                 {
                     **cycle_snapshot,
                     'rolling_windows': rolling_windows,

--- a/kraken/grid-trader/scripts/serendb_store.py
+++ b/kraken/grid-trader/scripts/serendb_store.py
@@ -25,6 +25,49 @@ class DBTarget:
     endpoint_id: Optional[str] = None
 
 
+@dataclass
+class AdaptiveRuntimePersistence:
+    store: "SerenDBStore"
+    runtime_key: str
+    lock_key: str
+    skill_slug: str = "kraken-grid-trader"
+
+    def load_state(self) -> Dict[str, Any]:
+        return self.store.load_runtime_state(skill_slug=self.skill_slug, runtime_key=self.runtime_key)
+
+    def save_state(self, state: Dict[str, Any]) -> None:
+        self.store.save_runtime_state(
+            skill_slug=self.skill_slug,
+            runtime_key=self.runtime_key,
+            state=state,
+        )
+
+    def append_event(self, event_type: str, payload: Dict[str, Any]) -> str:
+        event_id = self.store.append_runtime_event(
+            skill_slug=self.skill_slug,
+            runtime_key=self.runtime_key,
+            event_type=event_type,
+            payload=payload,
+        )
+        return f"serendb://trading.runtime_events/{event_id}"
+
+    def acquire_lock(self, *, lock_key: str, owner_id: str, ttl_seconds: int) -> bool:
+        return self.store.acquire_runtime_lock(
+            skill_slug=self.skill_slug,
+            lock_key=lock_key,
+            owner_id=owner_id,
+            ttl_seconds=ttl_seconds,
+            metadata={"runtime_key": self.runtime_key},
+        )
+
+    def release_lock(self, *, lock_key: str, owner_id: str) -> None:
+        self.store.release_runtime_lock(
+            skill_slug=self.skill_slug,
+            lock_key=lock_key,
+            owner_id=owner_id,
+        )
+
+
 class _SerenMCPClient:
     def __init__(self, api_key: str, mcp_command: str = "seren-mcp", timeout_seconds: int = 30):
         self.api_key = api_key
@@ -399,6 +442,39 @@ class SerenDBStore:
 
         CREATE INDEX IF NOT EXISTS idx_pnl_periods_run_end
             ON trading.pnl_periods (run_id, period_end DESC);
+
+        CREATE TABLE IF NOT EXISTS trading.runtime_state (
+            skill_slug TEXT NOT NULL,
+            runtime_key TEXT NOT NULL,
+            state JSONB NOT NULL DEFAULT '{}'::jsonb,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (skill_slug, runtime_key)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_runtime_state_skill_updated
+            ON trading.runtime_state (skill_slug, updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS trading.runtime_events (
+            id BIGSERIAL PRIMARY KEY,
+            skill_slug TEXT NOT NULL,
+            runtime_key TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_runtime_events_key_time
+            ON trading.runtime_events (skill_slug, runtime_key, created_at DESC);
+
+        CREATE TABLE IF NOT EXISTS trading.runtime_locks (
+            skill_slug TEXT NOT NULL,
+            lock_key TEXT NOT NULL,
+            owner_id TEXT NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (skill_slug, lock_key)
+        );
         """
         self._execute_sql(ddl)
 
@@ -680,6 +756,113 @@ class SerenDBStore:
             """
         self._execute_sql(query)
 
+    def adaptive_runtime(self, *, runtime_key: str, lock_key: str) -> AdaptiveRuntimePersistence:
+        return AdaptiveRuntimePersistence(store=self, runtime_key=runtime_key, lock_key=lock_key)
+
+    def load_runtime_state(self, *, skill_slug: str, runtime_key: str) -> Dict[str, Any]:
+        query = f"""
+        SELECT state
+        FROM trading.runtime_state
+        WHERE skill_slug = {self._sql_text(skill_slug)}
+          AND runtime_key = {self._sql_text(runtime_key)}
+        LIMIT 1;
+        """
+        rows = self._extract_rows(self._query_sql(query))
+        if not rows:
+            return {}
+        payload = rows[0].get("state", {})
+        if isinstance(payload, str):
+            try:
+                decoded = json.loads(payload)
+            except json.JSONDecodeError:
+                return {}
+            return decoded if isinstance(decoded, dict) else {}
+        return payload if isinstance(payload, dict) else {}
+
+    def save_runtime_state(self, *, skill_slug: str, runtime_key: str, state: Dict[str, Any]) -> None:
+        query = f"""
+        INSERT INTO trading.runtime_state (skill_slug, runtime_key, state, updated_at)
+        VALUES (
+            {self._sql_text(skill_slug)},
+            {self._sql_text(runtime_key)},
+            {self._sql_json(state)},
+            NOW()
+        )
+        ON CONFLICT (skill_slug, runtime_key) DO UPDATE SET
+            state = EXCLUDED.state,
+            updated_at = NOW();
+        """
+        self._execute_sql(query)
+
+    def append_runtime_event(
+        self,
+        *,
+        skill_slug: str,
+        runtime_key: str,
+        event_type: str,
+        payload: Dict[str, Any],
+    ) -> int:
+        query = f"""
+        INSERT INTO trading.runtime_events (skill_slug, runtime_key, event_type, payload)
+        VALUES (
+            {self._sql_text(skill_slug)},
+            {self._sql_text(runtime_key)},
+            {self._sql_text(event_type)},
+            {self._sql_json(payload)}
+        )
+        RETURNING id;
+        """
+        rows = self._extract_rows(self._query_sql(query))
+        if not rows:
+            raise SerenMCPError("runtime event insert returned no rows")
+        return int(rows[0].get("id", 0))
+
+    def acquire_runtime_lock(
+        self,
+        *,
+        skill_slug: str,
+        lock_key: str,
+        owner_id: str,
+        ttl_seconds: int,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        query = f"""
+        WITH attempted AS (
+            INSERT INTO trading.runtime_locks (skill_slug, lock_key, owner_id, expires_at, metadata, updated_at)
+            VALUES (
+                {self._sql_text(skill_slug)},
+                {self._sql_text(lock_key)},
+                {self._sql_text(owner_id)},
+                NOW() + ({int(ttl_seconds)} * INTERVAL '1 second'),
+                {self._sql_json(metadata or {})},
+                NOW()
+            )
+            ON CONFLICT (skill_slug, lock_key) DO UPDATE SET
+                owner_id = EXCLUDED.owner_id,
+                expires_at = EXCLUDED.expires_at,
+                metadata = EXCLUDED.metadata,
+                updated_at = NOW()
+            WHERE trading.runtime_locks.expires_at <= NOW()
+               OR trading.runtime_locks.owner_id = EXCLUDED.owner_id
+            RETURNING 1 AS acquired
+        )
+        SELECT COALESCE(MAX(acquired), 0) AS acquired
+        FROM attempted;
+        """
+        rows = self._extract_rows(self._query_sql(query))
+        if not rows:
+            return False
+        return int(rows[0].get("acquired", 0)) == 1
+
+    def release_runtime_lock(self, *, skill_slug: str, lock_key: str, owner_id: str) -> None:
+        query = f"""
+        DELETE FROM trading.runtime_locks
+        WHERE skill_slug = {self._sql_text(skill_slug)}
+          AND lock_key = {self._sql_text(lock_key)}
+          AND owner_id = {self._sql_text(owner_id)};
+        """
+        self._execute_sql(query)
+
     def _execute_sql(self, query: str) -> None:
         target = self._resolve_target()
         last_error: Optional[Exception] = None
@@ -700,6 +883,26 @@ class SerenDBStore:
                 self._attempt_endpoint_recovery(target)
                 time.sleep(2)
         raise SerenMCPError(f"run_sql failed after retries: {last_error}")
+
+    def _query_sql(self, query: str) -> Dict[str, Any]:
+        target = self._resolve_target()
+        last_error: Optional[Exception] = None
+        for _ in range(3):
+            try:
+                return self._mcp.call_tool(
+                    "run_sql",
+                    {
+                        "project_id": target.project_id,
+                        "branch_id": target.branch_id,
+                        "database": target.database,
+                        "query": query,
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                self._attempt_endpoint_recovery(target)
+                time.sleep(2)
+        raise SerenMCPError(f"run_sql query failed after retries: {last_error}")
 
     def _resolve_target(self) -> DBTarget:
         if self._target is not None:
@@ -942,6 +1145,25 @@ class SerenDBStore:
     def _sql_json(value: Any) -> str:
         encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False).replace("'", "''")
         return f"'{encoded}'::jsonb"
+
+    @staticmethod
+    def _extract_rows(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not isinstance(result, dict):
+            return []
+        body = result.get("body", result)
+        if isinstance(body, str):
+            try:
+                body = json.loads(body)
+            except json.JSONDecodeError:
+                return []
+        if isinstance(body, dict):
+            for key in ("rows", "data", "result"):
+                value = body.get(key)
+                if isinstance(value, list):
+                    return [row for row in value if isinstance(row, dict)]
+        if isinstance(body, list):
+            return [row for row in body if isinstance(row, dict)]
+        return []
 
     @staticmethod
     def _normalize_name(value: Any) -> str:

--- a/kraken/grid-trader/tests/test_adaptive_runtime.py
+++ b/kraken/grid-trader/tests/test_adaptive_runtime.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 
 _SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
@@ -37,21 +40,46 @@ def _load_local_module(module_name: str):
 adaptive_runtime = _load_local_module("adaptive_runtime")
 
 
-def test_shadow_gate_promotes_better_candidate(tmp_path) -> None:
+class FakeAdaptivePersistence:
+    def __init__(self, initial_state=None) -> None:
+        self.state = dict(initial_state or {})
+        self.events = []
+        self.locks = {}
+
+    def load_state(self):
+        return json.loads(json.dumps(self.state))
+
+    def save_state(self, state):
+        self.state = json.loads(json.dumps(state))
+
+    def append_event(self, event_type, payload):
+        ref = f"event:{len(self.events) + 1}"
+        self.events.append({"type": event_type, "payload": payload, "reference": ref})
+        return ref
+
+    def acquire_lock(self, *, lock_key, owner_id, ttl_seconds):
+        del ttl_seconds
+        existing = self.locks.get(lock_key)
+        if existing is not None and existing != owner_id:
+            return False
+        self.locks[lock_key] = owner_id
+        return True
+
+    def release_lock(self, *, lock_key, owner_id):
+        if self.locks.get(lock_key) == owner_id:
+            self.locks.pop(lock_key, None)
+
+
+def test_shadow_gate_promotes_better_candidate() -> None:
     settings = adaptive_runtime.resolve_adaptive_settings(
         {
             "adaptive": {
-                "state_path": str(tmp_path / "state" / "adaptive_state.json"),
-                "metrics_log_path": str(tmp_path / "logs" / "metrics.jsonl"),
-                "review_log_path": str(tmp_path / "logs" / "reviews.jsonl"),
-                "review_output_dir": str(tmp_path / "logs" / "reviews"),
-                "alert_log_path": str(tmp_path / "logs" / "alerts.jsonl"),
                 "shadow_min_samples": 2,
                 "shadow_improvement_threshold_pct": 0.0,
             }
         }
     )
-    store = adaptive_runtime.AdaptiveStateStore(settings)
+    store = adaptive_runtime.AdaptiveStateStore(settings, persistence=FakeAdaptivePersistence())
     store.state["recent_cycles"] = [
         {"market_price": 100.0, "fill_rate": 1.0, "net_pnl_usd": 15.0},
         {"market_price": 102.0, "fill_rate": 0.9, "net_pnl_usd": 12.0},
@@ -85,19 +113,50 @@ def test_shadow_gate_promotes_better_candidate(tmp_path) -> None:
     assert store.state["last_accepted_params"]["grid_spacing_percent"] == decision.candidate_params["grid_spacing_percent"]
 
 
-def test_review_report_uses_rolling_50_and_200_windows(tmp_path) -> None:
-    settings = adaptive_runtime.resolve_adaptive_settings(
-        {
-            "adaptive": {
-                "state_path": str(tmp_path / "state" / "adaptive_state.json"),
-                "metrics_log_path": str(tmp_path / "logs" / "metrics.jsonl"),
-                "review_log_path": str(tmp_path / "logs" / "reviews.jsonl"),
-                "review_output_dir": str(tmp_path / "logs" / "reviews"),
-                "alert_log_path": str(tmp_path / "logs" / "alerts.jsonl"),
-            }
-        }
+def test_store_persists_state_and_review_via_backend() -> None:
+    persistence = FakeAdaptivePersistence()
+    store = adaptive_runtime.AdaptiveStateStore(
+        adaptive_runtime.resolve_adaptive_settings({"adaptive": {}}),
+        persistence=persistence,
     )
-    store = adaptive_runtime.AdaptiveStateStore(settings)
+    store.state["last_accepted_params"] = {"grid_spacing_percent": 2.25}
+    store.save()
+    store.record_metric({"timestamp": "2026-03-20T00:00:00Z", "market_price": 101.0})
+    reference = store.record_review({"generated_at": "2026-03-20T00:00:00Z", "cycle_count": 1})
+    store.save()
+
+    assert persistence.state["last_accepted_params"]["grid_spacing_percent"] == 2.25
+    assert [event["type"] for event in persistence.events] == ["metrics", "review"]
+    assert store.state["review_reports"][-1]["reference"] == reference
+
+
+def test_runtime_lock_uses_backend_lease() -> None:
+    persistence = FakeAdaptivePersistence()
+
+    with adaptive_runtime.runtime_lock(
+        persistence=persistence,
+        lock_key="adaptive:Grid_2026:XBTUSD",
+        owner_id="owner-a",
+        ttl_seconds=120,
+    ):
+        assert persistence.locks["adaptive:Grid_2026:XBTUSD"] == "owner-a"
+        with pytest.raises(adaptive_runtime.RuntimeLockError):
+            with adaptive_runtime.runtime_lock(
+                persistence=persistence,
+                lock_key="adaptive:Grid_2026:XBTUSD",
+                owner_id="owner-b",
+                ttl_seconds=120,
+            ):
+                pass
+
+    assert "adaptive:Grid_2026:XBTUSD" not in persistence.locks
+
+
+def test_review_report_uses_rolling_50_and_200_windows() -> None:
+    store = adaptive_runtime.AdaptiveStateStore(
+        adaptive_runtime.resolve_adaptive_settings({"adaptive": {}}),
+        persistence=FakeAdaptivePersistence(),
+    )
 
     for idx in range(60):
         adaptive_runtime.update_cycle_state(


### PR DESCRIPTION
## Summary
- move kraken grid trader adaptive runtime state, events, and lock leases into SerenDB
- require adaptive mode to fail closed when MCP-backed persistence is unavailable
- update focused tests and docs/config for the SerenDB-backed adaptive runtime

## Testing
- python3 -m py_compile kraken/grid-trader/scripts/agent.py kraken/grid-trader/scripts/adaptive_runtime.py kraken/grid-trader/scripts/serendb_store.py
- pytest kraken/grid-trader/tests/test_adaptive_runtime.py kraken/grid-trader/tests/test_live_safety.py

Closes #227