### PR TITLE
fix: reject stale fallback prices in polymarket scan

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -214,18 +214,34 @@ class TradingAgent:
 
         pre_selected = time_filtered[:limit]
 
-        # Enrich with live CLOB midpoint prices
+        # Enrich with live CLOB midpoint prices. If CLOB is unavailable, keep only
+        # markets that already have a non-fallback Gamma price.
         enriched = []
+        stale_price_skips = 0
         for m in pre_selected:
+            live_mid = None
             try:
                 live_mid = self.polymarket.get_midpoint(m['token_id'])
-                if live_mid and 0.01 < live_mid < 0.99:
-                    m['price'] = live_mid
             except Exception:
-                pass
-            enriched.append(m)
+                live_mid = None
+
+            if live_mid and 0.01 < live_mid < 0.99:
+                m['price'] = live_mid
+                m['price_source'] = 'clob_midpoint'
+                enriched.append(m)
+                continue
+
+            if m.get('price_source') == 'gamma':
+                enriched.append(m)
+                continue
+
+            stale_price_skips += 1
+            question = m.get('question', '')[:60]
+            print(f"  Skipping stale-priced market: {question}")
 
         dropped = len(markets) - len(enriched)
+        if stale_price_skips:
+            print(f"  Skipped {stale_price_skips} markets with fallback 50% prices and no valid CLOB midpoint")
         print(f"  Ranked {len(markets)} markets → kept top {len(enriched)} candidates (dropped {dropped})")
         return enriched
 

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -99,11 +99,27 @@ class PolymarketClient:
             yes_token_id = token_ids[0]
             no_token_id = token_ids[1] if len(token_ids) > 1 else None
 
-            outcome_prices = market_data.get('outcomePrices', ['0.5'])
-            try:
-                price = float(outcome_prices[0]) if outcome_prices else 0.5
-            except Exception:
-                price = 0.5
+            raw_outcome_prices = market_data.get('outcomePrices')
+            price = 0.5
+            price_source = 'gamma_fallback'
+
+            if isinstance(raw_outcome_prices, str):
+                try:
+                    outcome_prices = json.loads(raw_outcome_prices)
+                except Exception:
+                    outcome_prices = []
+            elif isinstance(raw_outcome_prices, list):
+                outcome_prices = raw_outcome_prices
+            else:
+                outcome_prices = []
+
+            if outcome_prices:
+                try:
+                    price = float(outcome_prices[0])
+                    price_source = 'gamma'
+                except Exception:
+                    price = 0.5
+                    price_source = 'gamma_fallback'
 
             volume = float(market_data.get('volume', 0))
             liquidity = float(market_data.get('liquidity', 0))
@@ -118,6 +134,7 @@ class PolymarketClient:
                 'token_id': yes_token_id,
                 'no_token_id': no_token_id,
                 'price': price,
+                'price_source': price_source,
                 'volume': volume,
                 'liquidity': liquidity,
                 'end_date': end_date,

--- a/polymarket/bot/scripts/test_buy_no_token.py
+++ b/polymarket/bot/scripts/test_buy_no_token.py
@@ -63,6 +63,26 @@ class TestGetMarketsExposesNoTokenId:
         markets = client.get_markets(limit=10)
         assert markets[0]["no_token_id"] is None
 
+    def test_marks_missing_outcome_prices_as_gamma_fallback(self):
+        seren = _mock_seren()
+        seren.call_publisher.return_value = {
+            "body": [
+                {
+                    "conditionId": "0xabc",
+                    "question": "Will X happen?",
+                    "clobTokenIds": '["YES_TOKEN", "NO_TOKEN"]',
+                    "volume": "5000",
+                    "liquidity": "10000",
+                    "endDateIso": "2026-12-31",
+                    "active": True,
+                }
+            ]
+        }
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+        markets = client.get_markets(limit=10)
+        assert markets[0]["price"] == 0.5
+        assert markets[0]["price_source"] == "gamma_fallback"
+
 
 class TestBookLevelFallback:
     def test_get_book_levels_uses_raw_when_parsed_empty(self, monkeypatch):

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -45,7 +45,7 @@ class TestResolutionDateFilter:
         agent = MagicMock()
         agent.max_resolution_days = max_resolution_days
         agent.polymarket = MagicMock()
-        agent.polymarket.get_midpoint = MagicMock(return_value=0.5)
+        agent.polymarket.get_midpoint = MagicMock(return_value=0.4)
 
         # Import the actual rank_candidates and bind it
         from agent import TradingAgent
@@ -103,6 +103,35 @@ class TestResolutionDateFilter:
         questions = [m['question'] for m in result]
         assert 'Bad date' not in questions
         assert questions == ['Near market']
+
+    def test_skips_fallback_50_price_when_clob_midpoint_unavailable(self):
+        agent = self._make_agent_with_config(max_resolution_days=180)
+        agent.polymarket.get_midpoint.side_effect = RuntimeError("missing CLOB creds")
+        markets = [
+            {'question': 'Fallback price', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'price': 0.5, 'price_source': 'gamma_fallback'},
+            {'question': 'Valid gamma price', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 4000, 'token_id': 'tok2',
+             'price': 0.18, 'price_source': 'gamma'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Fallback price' not in questions
+        assert questions == ['Valid gamma price']
+
+    def test_prefers_valid_clob_midpoint_over_gamma_price(self):
+        agent = self._make_agent_with_config(max_resolution_days=180)
+        agent.polymarket.get_midpoint.return_value = 0.22
+        markets = [
+            {'question': 'Near market', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'price': 0.5, 'price_source': 'gamma_fallback'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 1
+        assert result[0]['price'] == pytest.approx(0.22, abs=0.001)
+        assert result[0]['price_source'] == 'clob_midpoint'
 
 
 class TestEvaluateOpportunityGuards:


### PR DESCRIPTION
## Summary
- tag Gamma-discovered prices as either real feed values or fallback placeholders instead of silently treating missing data as tradable 50% prices
- fail closed in candidate ranking by skipping markets whose only price is the fallback 50% seed when CLOB midpoint enrichment is unavailable
- add focused regressions for fallback tagging, fallback rejection, and valid CLOB midpoint overwrite behavior

## Testing
- pytest polymarket/bot/scripts/test_buy_no_token.py polymarket/bot/scripts/test_safety_guards.py

Closes #231