### PR TITLE
fix(grid-trader): remove stale local adaptive telemetry surface

### DIFF
--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -28,7 +28,7 @@ With 15 fills per day: **$252/day or $7,560/month** (75.6% monthly return)
 - **Risk Management**: Stop-loss, daily loss caps, position limits, open-order caps, and cooldowns after loss streaks
 - **Cost Efficient**: 0.16% maker fees via Kraken
 - **Always Active**: Always has opportunities (unlike prediction markets)
-- **Audit Trail**: JSONL logs for setup, metrics, fills, reviews, and alerts
+- **Audit Trail**: JSONL logs for core trading activity plus SerenDB-backed adaptive runtime telemetry
 - **Dry-Run Adaptive Path**: Test adaptive decisions without placing real orders
 
 ## Quick Start
@@ -107,7 +107,7 @@ Bot will:
 - Place buy orders below current price
 - Place sell orders above current price
 - Automatically replace filled orders
-- Log all trades to `logs/` directory
+- Log core trade activity to `logs/` and adaptive runtime telemetry to SerenDB
 - Stop if bankroll drops below stop-loss threshold
 
 Press `Ctrl+C` to stop trading.
@@ -217,7 +217,7 @@ python scripts/agent.py stop --config config.json
 
 ## Logs
 
-All operations logged to `logs/` directory as JSONL files:
+Core trading operations are logged to `logs/` as JSONL files:
 
 - `grid_setup.jsonl` - Grid initialization
 - `orders.jsonl` - Order placements/cancellations
@@ -225,7 +225,7 @@ All operations logged to `logs/` directory as JSONL files:
 - `positions.jsonl` - Position snapshots
 - `errors.jsonl` - Errors and warnings
 
-Adaptive runtime state, telemetry, review references, and the shared cron lease now persist in SerenDB. This includes accepted parameters, shadow scores, recent cycles, known open orders, `live_risk_state`, runtime events, and the lock record used to fail closed on overlapping one-shot invocations.
+Adaptive runtime state, telemetry, review references, and alert events persist in SerenDB. This includes accepted parameters, shadow scores, recent cycles, known open orders, `live_risk_state`, runtime events, and the lock record used to fail closed on overlapping one-shot invocations.
 
 ## SerenDB Persistence
 
@@ -240,7 +240,7 @@ When `seren-mcp` is available, the bot persists to SerenDB:
 - `trading.runtime_events`
 - `trading.runtime_locks`
 
-Adaptive mode requires SerenDB persistence. If the MCP-backed store is unavailable, the adaptive runtime fails closed instead of silently falling back to local state files.
+Adaptive mode requires SerenDB persistence. If the MCP-backed store is unavailable, the adaptive runtime fails closed instead of silently falling back to local state files, runtime lock files, or local review/alert telemetry artifacts.
 
 ## Safety Features
 
@@ -248,7 +248,7 @@ Adaptive mode requires SerenDB persistence. If the MCP-backed store is unavailab
 2. **Daily Loss Caps + Cooldowns**: New buys pause after loss streaks or daily drawdown breaches
 3. **Position/Open Order Limits**: Prevents overexposure and runaway order spam
 4. **Shadow Promotion Gate**: Candidate settings must outperform the baseline before promotion
-5. **Audit Trail**: Every cycle, review, fill, alert, and runtime lease transition is persisted
+5. **Audit Trail**: Every cycle, review, fill, alert, and runtime lease transition is persisted, with adaptive telemetry stored in SerenDB
 6. **Graceful Shutdown**: Cancels all orders on exit
 
 ## seren-cron

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -84,7 +84,7 @@ Set these optional environment variables in `.env`:
 - `SERENDB_AUTO_CREATE` (default: `true`)
 - `SEREN_MCP_COMMAND` (default: `seren-mcp`)
 
-Adaptive mode requires SerenDB/MCP. If the persistence layer is unavailable, the runtime fails closed rather than falling back to local adaptive state files.
+Adaptive mode requires SerenDB/MCP. If the persistence layer is unavailable, the runtime fails closed rather than falling back to local adaptive state files, runtime lock files, or local review/alert telemetry files.
 
 ## Configuration
 

--- a/kraken/grid-trader/scripts/logger.py
+++ b/kraken/grid-trader/scripts/logger.py
@@ -1,5 +1,5 @@
 """
-Kraken Grid Trader Logger - Logs all trading activity
+Kraken Grid Trader Logger - Logs core trading activity.
 
 Maintains JSONL log files:
 1. grid_setup.jsonl - Grid initialization and updates
@@ -203,22 +203,6 @@ class GridTraderLogger:
             'error_message': error_message,
             'context': context or {}
         }, extra))
-
-    def log_metrics_snapshot(self, payload: Dict[str, Any]) -> None:
-        self._append_jsonl('metrics.jsonl', {**payload, 'phase': 'metrics'})
-
-    def log_review_report(self, payload: Dict[str, Any]) -> None:
-        self._append_jsonl('weekly_reviews.jsonl', {**payload, 'phase': 'review'})
-
-    def log_alert(self, alert_type: str, payload: Dict[str, Any]) -> None:
-        self._append_jsonl(
-            'alerts.jsonl',
-            {
-                'phase': 'alert',
-                'alert_type': alert_type,
-                **payload,
-            },
-        )
 
     def get_recent_logs(self, log_type: str, limit: int = 10) -> list:
         """

--- a/kraken/grid-trader/tests/test_adaptive_runtime.py
+++ b/kraken/grid-trader/tests/test_adaptive_runtime.py
@@ -130,6 +130,26 @@ def test_store_persists_state_and_review_via_backend() -> None:
     assert store.state["review_reports"][-1]["reference"] == reference
 
 
+def test_store_persists_alert_events_via_backend() -> None:
+    persistence = FakeAdaptivePersistence()
+    store = adaptive_runtime.AdaptiveStateStore(
+        adaptive_runtime.resolve_adaptive_settings(
+            {"adaptive": {"max_failure_count_before_alert": 2}}
+        ),
+        persistence=persistence,
+    )
+
+    store.note_incident("daily_loss_cap", {"cap_usd": 50.0})
+    store.register_failure("kraken request failed")
+    store.register_failure("kraken request failed again")
+    store.save()
+
+    assert persistence.state["risk_incidents"][-1]["incident_type"] == "daily_loss_cap"
+    assert [event["type"] for event in persistence.events] == ["alert", "alert"]
+    assert persistence.events[0]["payload"]["kind"] == "risk_incident"
+    assert persistence.events[1]["payload"]["kind"] == "repeated_failures"
+
+
 def test_runtime_lock_uses_backend_lease() -> None:
     persistence = FakeAdaptivePersistence()
 


### PR DESCRIPTION
## Summary
- remove unused local logger methods for adaptive metrics, review reports, and alerts
- document that adaptive runtime telemetry, reviews, alerts, state, and locks are SerenDB-backed
- add focused coverage for alert persistence through the adaptive backend

## Testing
- pytest kraken/grid-trader/tests/test_adaptive_runtime.py
- pytest kraken/grid-trader/tests/test_grid_trade_reports.py

Closes #226