### PR TITLE
fix(polymarket): reject stale 50% Gamma prices when CLOB unavailable (#235)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -218,9 +218,23 @@ class TradingAgent:
 
         # Enrich with live CLOB midpoint prices. If CLOB is unavailable, keep only
         # markets that already have a non-fallback Gamma price.
+        # Also reject markets where Gamma outcomePrices is the stale 0.5/0.5 default
+        # unless the CLOB provides a real midpoint.
         enriched = []
         stale_price_skips = 0
+        stale_gamma_skips = 0
         for m in pre_selected:
+            # Detect stale Gamma 50/50 default prices from outcomePrices field
+            stale_gamma_price = False
+            outcome_prices_str = m.get('outcomePrices', '')
+            if outcome_prices_str:
+                try:
+                    parts = [float(p.strip()) for p in outcome_prices_str.split(',')]
+                    if len(parts) == 2 and all(abs(p - 0.5) <= 0.01 for p in parts):
+                        stale_gamma_price = True
+                except (ValueError, TypeError):
+                    pass
+
             live_mid = None
             try:
                 live_mid = self.polymarket.get_midpoint(m['token_id'])
@@ -233,6 +247,13 @@ class TradingAgent:
                 enriched.append(m)
                 continue
 
+            # CLOB enrichment failed — check if Gamma price is trustworthy
+            if stale_gamma_price:
+                stale_gamma_skips += 1
+                question = m.get('question', '')[:60]
+                print(f"  Skipping stale 50/50 Gamma market (no CLOB): {question}")
+                continue
+
             if m.get('price_source') == 'gamma':
                 enriched.append(m)
                 continue
@@ -242,6 +263,8 @@ class TradingAgent:
             print(f"  Skipping stale-priced market: {question}")
 
         dropped = len(markets) - len(enriched)
+        if stale_gamma_skips:
+            print(f"  Skipped {stale_gamma_skips} markets with stale 50/50 Gamma prices and no valid CLOB midpoint")
         if stale_price_skips:
             print(f"  Skipped {stale_price_skips} markets with fallback 50% prices and no valid CLOB midpoint")
         print(f"  Ranked {len(markets)} markets → kept top {len(enriched)} candidates (dropped {dropped})")

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -241,3 +241,66 @@ class TestEvaluateOpportunityGuards:
             market, 'research', fair_value=0.60, confidence='high'
         )
         assert result is None
+
+
+class TestStaleGammaPriceRejection:
+    """Test that markets with stale Gamma 50/50 outcomePrices are rejected
+    when CLOB enrichment fails (#235)."""
+
+    def _make_agent_with_config(self, max_resolution_days=180):
+        from unittest.mock import MagicMock
+        from agent import TradingAgent
+        import types
+
+        agent = MagicMock()
+        agent.max_resolution_days = max_resolution_days
+        agent.polymarket = MagicMock()
+        agent.rank_candidates = types.MethodType(TradingAgent.rank_candidates, agent)
+        return agent
+
+    @staticmethod
+    def _iso(days_from_now: int) -> str:
+        return (datetime.now(timezone.utc) + timedelta(days=days_from_now)).isoformat().replace('+00:00', 'Z')
+
+    def test_stale_gamma_price_rejected_without_clob(self):
+        """Market with outcomePrices '0.5,0.5' and no CLOB data is skipped."""
+        agent = self._make_agent_with_config()
+        agent.polymarket.get_midpoint.side_effect = RuntimeError("no CLOB")
+        markets = [
+            {'question': 'Stale market', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'outcomePrices': '0.5,0.5',
+             'price': 0.5, 'price_source': 'gamma'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 0
+
+    def test_real_gamma_price_kept_without_clob(self):
+        """Market with outcomePrices '0.85,0.15' and no CLOB data is kept."""
+        agent = self._make_agent_with_config()
+        agent.polymarket.get_midpoint.side_effect = RuntimeError("no CLOB")
+        markets = [
+            {'question': 'Real price market', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'outcomePrices': '0.85,0.15',
+             'price': 0.85, 'price_source': 'gamma'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 1
+        assert result[0]['question'] == 'Real price market'
+        assert result[0]['price'] == pytest.approx(0.85, abs=0.01)
+
+    def test_stale_gamma_overridden_by_clob(self):
+        """Market with outcomePrices '0.5,0.5' but real CLOB midpoint uses CLOB price."""
+        agent = self._make_agent_with_config()
+        agent.polymarket.get_midpoint.return_value = 0.72
+        markets = [
+            {'question': 'CLOB override', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'outcomePrices': '0.5,0.5',
+             'price': 0.5, 'price_source': 'gamma'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 1
+        assert result[0]['price'] == pytest.approx(0.72, abs=0.001)
+        assert result[0]['price_source'] == 'clob_midpoint'


### PR DESCRIPTION
## Summary
- Skip markets where Gamma returns outcomePrices 0.5/0.5 AND CLOB enrichment fails
- Markets with real Gamma prices (e.g. 0.85/0.15) still pass through when CLOB is unavailable
- Markets with CLOB data always use CLOB midpoint regardless of Gamma price
- 3 new tests, all 20 passing

## Test plan
- [x] test_stale_gamma_price_rejected_without_clob
- [x] test_real_gamma_price_kept_without_clob
- [x] test_stale_gamma_overridden_by_clob

Closes #235

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com