### PR TITLE
feat(polymarket): deprioritize stale 50/50 markets in ranking heuristic (#236)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -93,6 +93,7 @@ class TradingAgent:
         self.candidate_limit = int(self.config.get('candidate_limit', 20))
         self.analyze_limit = int(self.config.get('analyze_limit', self.candidate_limit))
         self.min_liquidity = float(self.config.get('min_liquidity', 100.0))
+        self.stale_price_demotion = float(self.config.get('stale_price_demotion', 0.1))
 
         print(f"✓ Agent initialized (Dry-run: {dry_run})")
         print(f"  Bankroll: ${self.bankroll:.2f}")
@@ -177,12 +178,32 @@ class TradingAgent:
         """
         import math
 
+        stale_demotion = self.stale_price_demotion
+
+        def _parse_price_asymmetry(m: Dict) -> float:
+            """Return abs(p1 - p2) from outcomePrices string, or -1 if unparseable."""
+            raw = m.get('outcomePrices', '')
+            if not raw:
+                return -1.0
+            try:
+                parts = raw.split(',')
+                p1, p2 = float(parts[0]), float(parts[1])
+                return abs(p1 - p2)
+            except (IndexError, ValueError, TypeError):
+                return -1.0
+
         def score(m: Dict) -> float:
             liquidity = float(m.get('liquidity', 0))
             volume = float(m.get('volume', 0))
             liq_score = math.log1p(liquidity)
             vol_score = math.log1p(volume)
-            return liq_score + vol_score * 2
+            base = liq_score + vol_score * 2
+
+            # Demote markets whose outcomePrices are still at the Gamma 0.5/0.5 default
+            asymmetry = _parse_price_asymmetry(m)
+            if 0 <= asymmetry < 0.02:
+                return base * stale_demotion
+            return base
 
         ranked = sorted(markets, key=score, reverse=True)
 

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -44,6 +44,7 @@ class TestResolutionDateFilter:
 
         agent = MagicMock()
         agent.max_resolution_days = max_resolution_days
+        agent.stale_price_demotion = 0.1
         agent.polymarket = MagicMock()
         agent.polymarket.get_midpoint = MagicMock(return_value=0.4)
 
@@ -254,6 +255,7 @@ class TestStaleGammaPriceRejection:
 
         agent = MagicMock()
         agent.max_resolution_days = max_resolution_days
+        agent.stale_price_demotion = 0.1
         agent.polymarket = MagicMock()
         agent.rank_candidates = types.MethodType(TradingAgent.rank_candidates, agent)
         return agent
@@ -304,3 +306,80 @@ class TestStaleGammaPriceRejection:
         assert len(result) == 1
         assert result[0]['price'] == pytest.approx(0.72, abs=0.001)
         assert result[0]['price_source'] == 'clob_midpoint'
+
+
+class TestStalePriceDemotion:
+    """Test that markets with 0.5/0.5 outcomePrices are deprioritized in ranking."""
+
+    def _make_agent_with_config(self, stale_price_demotion=0.1, max_resolution_days=180):
+        from unittest.mock import MagicMock
+        from agent import TradingAgent
+        import types
+
+        agent = MagicMock()
+        agent.max_resolution_days = max_resolution_days
+        agent.stale_price_demotion = stale_price_demotion
+        agent.polymarket = MagicMock()
+        agent.polymarket.get_midpoint = MagicMock(return_value=0.4)
+        agent.rank_candidates = types.MethodType(TradingAgent.rank_candidates, agent)
+        return agent
+
+    @staticmethod
+    def _iso(days_from_now: int) -> str:
+        return (datetime.now(timezone.utc) + timedelta(days=days_from_now)).isoformat().replace('+00:00', 'Z')
+
+    def test_stale_price_demoted_in_ranking(self):
+        """Market at 0.5/0.5 ranks below a market at 0.7/0.3 even with higher liquidity."""
+        agent = self._make_agent_with_config()
+        markets = [
+            {
+                'question': 'Stale market',
+                'end_date': self._iso(30),
+                'liquidity': 50000,
+                'volume': 100000,
+                'token_id': 'tok_stale',
+                'outcomePrices': '0.5,0.5',
+            },
+            {
+                'question': 'Real market',
+                'end_date': self._iso(30),
+                'liquidity': 5000,
+                'volume': 10000,
+                'token_id': 'tok_real',
+                'outcomePrices': '0.7,0.3',
+            },
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Real market' in questions
+        assert 'Stale market' in questions
+        assert questions.index('Real market') < questions.index('Stale market')
+
+    def test_real_price_not_demoted(self):
+        """Market at 0.85/0.15 keeps its full ranking score."""
+        agent = self._make_agent_with_config()
+        import math
+
+        market = {
+            'question': 'Strong signal',
+            'end_date': self._iso(30),
+            'liquidity': 10000,
+            'volume': 20000,
+            'token_id': 'tok_strong',
+            'outcomePrices': '0.85,0.15',
+        }
+        markets = [market]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 1
+
+        stale_market = {
+            'question': 'Stale low liq',
+            'end_date': self._iso(30),
+            'liquidity': 9000,
+            'volume': 18000,
+            'token_id': 'tok_stale2',
+            'outcomePrices': '0.50,0.50',
+        }
+        result2 = agent.rank_candidates([market, stale_market], limit=10)
+        questions = [m['question'] for m in result2]
+        assert questions.index('Strong signal') < questions.index('Stale low liq')


### PR DESCRIPTION
## Summary
- Add stale_price_demotion config (default 0.1) that penalizes markets with outcomePrices near 0.5/0.5
- Markets with real price asymmetry (e.g. 0.7/0.3) keep full ranking score
- Ensures LLM evaluation slots go to markets with real price discovery instead of NBA/FIFA long-tail
- 2 new tests, all 19 passing

## Test plan
- [x] test_stale_price_demoted_in_ranking
- [x] test_real_price_not_demoted

Closes #236

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com