### PR TITLE
fix(polymarket): reject CLOB midpoints that confirm stale Gamma 50/50 seed

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -263,6 +263,14 @@ class TradingAgent:
                 live_mid = None
 
             if live_mid and 0.01 < live_mid < 0.99:
+                # If Gamma seeded this market at 50/50 and the CLOB also returns
+                # ~50%, the midpoint is likely derived from a thin/symmetric book
+                # on a market that has never traded.  Reject it.
+                if stale_gamma_price and abs(live_mid - 0.5) <= 0.03:
+                    stale_gamma_skips += 1
+                    question = m.get('question', '')[:60]
+                    print(f"  Skipping stale 50/50 market (CLOB mid ≈ Gamma seed): {question}")
+                    continue
                 m['price'] = live_mid
                 m['price_source'] = 'clob_midpoint'
                 enriched.append(m)

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -307,6 +307,19 @@ class TestStaleGammaPriceRejection:
         assert result[0]['price'] == pytest.approx(0.72, abs=0.001)
         assert result[0]['price_source'] == 'clob_midpoint'
 
+    def test_stale_gamma_rejected_when_clob_confirms_fifty(self):
+        """Market with outcomePrices '0.5,0.5' AND CLOB mid ~0.50 is rejected (#243)."""
+        agent = self._make_agent_with_config()
+        agent.polymarket.get_midpoint.return_value = 0.50
+        markets = [
+            {'question': 'Thin book mirror', 'end_date': self._iso(30),
+             'liquidity': 1000, 'volume': 5000, 'token_id': 'tok1',
+             'outcomePrices': '0.5,0.5',
+             'price': 0.5, 'price_source': 'gamma'},
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 0
+
 
 class TestStalePriceDemotion:
     """Test that markets with 0.5/0.5 outcomePrices are deprioritized in ranking."""


### PR DESCRIPTION
## Summary

- Cross-check `stale_gamma_price` flag against CLOB midpoint in the enrichment path
- Reject markets where Gamma seeded at 50/50 and CLOB returns ~50% (within 3% tolerance)
- Prevents ~25 fake long-shot opportunities from surfacing per scan

Closes #243

## Test plan

- [x] Existing 22 safety guard tests pass
- [x] New test `test_stale_gamma_rejected_when_clob_confirms_fifty` validates the fix
- [ ] Next dry-run scan should show stale 50/50 markets rejected with new log message

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com