### PR TITLE
fix(ci): allow trading-skill-safety base ref refresh

### DIFF
--- a/.github/workflows/trading-skill-safety.yml
+++ b/.github/workflows/trading-skill-safety.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Fetch pull request base branch
         if: github.event_name == 'pull_request'
-        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" --depth=1
+        run: git fetch origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" --depth=1
 
       - name: Validate changed trading skills
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Regression after #246.

## Summary
- force-update the PR base remote-tracking ref in `trading-skill-safety.yml`
- avoid non-fast-forward fetch failures when `origin/main` already exists locally in the checkout

## Validation
- git fetch origin "+refs/heads/main:refs/remotes/origin/main" --depth=1
- git diff --check