### PR TITLE
fix: preserve polymarket bot outcomePrices for stale Gamma guard

### DIFF
--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -102,12 +102,13 @@ class PolymarketClient:
             raw_outcome_prices = market_data.get('outcomePrices')
             price = 0.5
             price_source = 'gamma_fallback'
+            outcome_prices_csv = ''
 
             if isinstance(raw_outcome_prices, str):
                 try:
                     outcome_prices = json.loads(raw_outcome_prices)
                 except Exception:
-                    outcome_prices = []
+                    outcome_prices = [p.strip() for p in raw_outcome_prices.split(',') if p.strip()]
             elif isinstance(raw_outcome_prices, list):
                 outcome_prices = raw_outcome_prices
             else:
@@ -115,8 +116,10 @@ class PolymarketClient:
 
             if outcome_prices:
                 try:
-                    price = float(outcome_prices[0])
+                    parsed_outcome_prices = [float(str(price_part).strip()) for price_part in outcome_prices]
+                    price = parsed_outcome_prices[0]
                     price_source = 'gamma'
+                    outcome_prices_csv = ','.join(str(price_part) for price_part in parsed_outcome_prices)
                 except Exception:
                     price = 0.5
                     price_source = 'gamma_fallback'
@@ -133,6 +136,7 @@ class PolymarketClient:
                 'question': question,
                 'token_id': yes_token_id,
                 'no_token_id': no_token_id,
+                'outcomePrices': outcome_prices_csv,
                 'price': price,
                 'price_source': price_source,
                 'volume': volume,

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -5,12 +5,14 @@ Tests for #220 — annualized return gate, resolution date filter, exit liquidit
 import sys
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 import kelly
+from polymarket_client import PolymarketClient
 
 
 class TestAnnualizedReturn:
@@ -318,6 +320,33 @@ class TestStaleGammaPriceRejection:
              'price': 0.5, 'price_source': 'gamma'},
         ]
         result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 0
+
+    def test_get_markets_output_keeps_stale_gamma_signal_for_downstream_rejection(self):
+        """Regression: stale Gamma 50/50 prices must survive market discovery."""
+        seren = MagicMock()
+        seren.call_publisher.return_value = {
+            "body": [
+                {
+                    "conditionId": "0xabc",
+                    "question": "Stale market",
+                    "clobTokenIds": '["YES_TOKEN", "NO_TOKEN"]',
+                    "outcomePrices": '["0.5", "0.5"]',
+                    "volume": "5000",
+                    "liquidity": "1000",
+                    "endDateIso": self._iso(30),
+                    "active": True,
+                }
+            ]
+        }
+        client = PolymarketClient(seren_client=seren, dry_run=True)
+        markets = client.get_markets(limit=10)
+
+        agent = self._make_agent_with_config()
+        agent.polymarket.get_midpoint.side_effect = RuntimeError("no CLOB")
+        result = agent.rank_candidates(markets, limit=10)
+
+        assert markets[0]["outcomePrices"] == "0.5,0.5"
         assert len(result) == 0
 
 


### PR DESCRIPTION
Closes #248.

## Summary
- preserve normalized `outcomePrices` in `polymarket/bot/scripts/polymarket_client.py`
- keep the stale Gamma `0.5/0.5` signal available to downstream ranking guards
- add one regression test covering the real `get_markets() -> rank_candidates()` seam

## Test
- `pytest -q polymarket/bot/scripts/test_safety_guards.py -q`
- `pytest -q polymarket/bot/scripts/test_buy_no_token.py -q`
