### PR TITLE
fix(polymarket): hard-filter stale 50/50 Gamma markets before LLM evaluation

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -192,6 +192,11 @@ class TradingAgent:
             except (IndexError, ValueError, TypeError):
                 return -1.0
 
+        def _is_stale_gamma(m: Dict) -> bool:
+            """True if outcomePrices is the Gamma 0.5/0.5 default seed."""
+            asymmetry = _parse_price_asymmetry(m)
+            return 0 <= asymmetry < 0.02
+
         def score(m: Dict) -> float:
             liquidity = float(m.get('liquidity', 0))
             volume = float(m.get('volume', 0))
@@ -200,12 +205,17 @@ class TradingAgent:
             base = liq_score + vol_score * 2
 
             # Demote markets whose outcomePrices are still at the Gamma 0.5/0.5 default
-            asymmetry = _parse_price_asymmetry(m)
-            if 0 <= asymmetry < 0.02:
+            if _is_stale_gamma(m):
                 return base * stale_demotion
             return base
 
-        ranked = sorted(markets, key=score, reverse=True)
+        # Hard-filter stale 50/50 Gamma markets before ranking — they waste LLM budget
+        stale_gamma_filtered = [m for m in markets if not _is_stale_gamma(m)]
+        stale_gamma_pre_filter = len(markets) - len(stale_gamma_filtered)
+        if stale_gamma_pre_filter:
+            print(f"  Filtered {stale_gamma_pre_filter} stale 50/50 Gamma-seeded markets")
+
+        ranked = sorted(stale_gamma_filtered, key=score, reverse=True)
 
         # Filter out markets resolving too far in the future
         from datetime import datetime, timezone

--- a/polymarket/bot/scripts/test_safety_guards.py
+++ b/polymarket/bot/scripts/test_safety_guards.py
@@ -294,8 +294,8 @@ class TestStaleGammaPriceRejection:
         assert result[0]['question'] == 'Real price market'
         assert result[0]['price'] == pytest.approx(0.85, abs=0.01)
 
-    def test_stale_gamma_overridden_by_clob(self):
-        """Market with outcomePrices '0.5,0.5' but real CLOB midpoint uses CLOB price."""
+    def test_stale_gamma_hard_filtered_even_with_clob(self):
+        """Stale 50/50 markets are removed before CLOB enrichment (#250)."""
         agent = self._make_agent_with_config()
         agent.polymarket.get_midpoint.return_value = 0.72
         markets = [
@@ -305,9 +305,7 @@ class TestStaleGammaPriceRejection:
              'price': 0.5, 'price_source': 'gamma'},
         ]
         result = agent.rank_candidates(markets, limit=10)
-        assert len(result) == 1
-        assert result[0]['price'] == pytest.approx(0.72, abs=0.001)
-        assert result[0]['price_source'] == 'clob_midpoint'
+        assert len(result) == 0
 
     def test_stale_gamma_rejected_when_clob_confirms_fifty(self):
         """Market with outcomePrices '0.5,0.5' AND CLOB mid ~0.50 is rejected (#243)."""
@@ -350,8 +348,8 @@ class TestStaleGammaPriceRejection:
         assert len(result) == 0
 
 
-class TestStalePriceDemotion:
-    """Test that markets with 0.5/0.5 outcomePrices are deprioritized in ranking."""
+class TestStalePriceHardFilter:
+    """Test that markets with 0.5/0.5 outcomePrices are hard-filtered (#250)."""
 
     def _make_agent_with_config(self, stale_price_demotion=0.1, max_resolution_days=180):
         from unittest.mock import MagicMock
@@ -370,8 +368,8 @@ class TestStalePriceDemotion:
     def _iso(days_from_now: int) -> str:
         return (datetime.now(timezone.utc) + timedelta(days=days_from_now)).isoformat().replace('+00:00', 'Z')
 
-    def test_stale_price_demoted_in_ranking(self):
-        """Market at 0.5/0.5 ranks below a market at 0.7/0.3 even with higher liquidity."""
+    def test_stale_price_excluded_from_candidates(self):
+        """Market at 0.5/0.5 is removed entirely, not just demoted (#250)."""
         agent = self._make_agent_with_config()
         markets = [
             {
@@ -394,13 +392,11 @@ class TestStalePriceDemotion:
         result = agent.rank_candidates(markets, limit=10)
         questions = [m['question'] for m in result]
         assert 'Real market' in questions
-        assert 'Stale market' in questions
-        assert questions.index('Real market') < questions.index('Stale market')
+        assert 'Stale market' not in questions
 
-    def test_real_price_not_demoted(self):
-        """Market at 0.85/0.15 keeps its full ranking score."""
+    def test_real_price_not_filtered(self):
+        """Market at 0.85/0.15 passes through; stale market does not."""
         agent = self._make_agent_with_config()
-        import math
 
         market = {
             'question': 'Strong signal',
@@ -410,10 +406,6 @@ class TestStalePriceDemotion:
             'token_id': 'tok_strong',
             'outcomePrices': '0.85,0.15',
         }
-        markets = [market]
-        result = agent.rank_candidates(markets, limit=10)
-        assert len(result) == 1
-
         stale_market = {
             'question': 'Stale low liq',
             'end_date': self._iso(30),
@@ -422,6 +414,7 @@ class TestStalePriceDemotion:
             'token_id': 'tok_stale2',
             'outcomePrices': '0.50,0.50',
         }
-        result2 = agent.rank_candidates([market, stale_market], limit=10)
-        questions = [m['question'] for m in result2]
-        assert questions.index('Strong signal') < questions.index('Stale low liq')
+        result = agent.rank_candidates([market, stale_market], limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Strong signal' in questions
+        assert 'Stale low liq' not in questions

--- a/polymarket/bot/scripts/test_stale_gamma_filter.py
+++ b/polymarket/bot/scripts/test_stale_gamma_filter.py
@@ -1,0 +1,198 @@
+"""
+Tests for #250 — stale 50/50 Gamma price filtering.
+
+Verifies the end-to-end chain: polymarket_client builds the outcomePrices CSV,
+agent.py parses it, and stale markets are excluded before LLM evaluation.
+"""
+
+import sys
+import types
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+def _make_agent(clob_midpoint=None):
+    """Create a mock agent with rank_candidates bound."""
+    from agent import TradingAgent
+
+    agent = MagicMock()
+    agent.max_resolution_days = 180
+    agent.stale_price_demotion = 0.1
+    agent.polymarket = MagicMock()
+    if clob_midpoint is not None:
+        agent.polymarket.get_midpoint = MagicMock(return_value=clob_midpoint)
+    else:
+        agent.polymarket.get_midpoint = MagicMock(side_effect=Exception("no CLOB"))
+    agent.rank_candidates = types.MethodType(TradingAgent.rank_candidates, agent)
+    return agent
+
+
+def _end_date(days=30):
+    return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat().replace('+00:00', 'Z')
+
+
+def _market(question, outcome_csv, liquidity=1_000_000, volume=500_000, price=None, price_source='gamma'):
+    """Build a market dict matching polymarket_client output."""
+    if price is None:
+        parts = outcome_csv.split(',') if outcome_csv else []
+        price = float(parts[0]) if parts else 0.5
+    return {
+        'market_id': f'mkt-{question[:8]}',
+        'question': question,
+        'token_id': f'tok-{question[:8]}',
+        'no_token_id': f'no-{question[:8]}',
+        'outcomePrices': outcome_csv,
+        'price': price,
+        'price_source': price_source,
+        'volume': volume,
+        'liquidity': liquidity,
+        'end_date': _end_date(30),
+    }
+
+
+class TestStaleGammaPreFilter:
+    """Stale 50/50 markets must be removed before they reach LLM evaluation."""
+
+    def test_stale_5050_excluded_from_candidates(self):
+        agent = _make_agent(clob_midpoint=None)
+        markets = [
+            _market('Real market', '0.35,0.65'),
+            _market('Stale longshot', '0.5,0.5'),
+            _market('Another stale', '0.50,0.50'),
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Real market' in questions
+        assert 'Stale longshot' not in questions
+        assert 'Another stale' not in questions
+
+    def test_non_stale_market_passes_through(self):
+        agent = _make_agent(clob_midpoint=0.35)
+        markets = [
+            _market('Legit low', '0.05,0.95'),
+            _market('Legit mid', '0.40,0.60'),
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        assert len(result) == 2
+
+    def test_missing_outcome_prices_uses_fallback_guard(self):
+        """Markets with no outcomePrices and gamma_fallback source are rejected."""
+        agent = _make_agent(clob_midpoint=None)
+        markets = [
+            _market('No prices', '', price=0.5, price_source='gamma_fallback'),
+            _market('Has prices', '0.30,0.70'),
+        ]
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+        assert 'Has prices' in questions
+        # 'No prices' should be rejected by the fallback guard (stale_price_skips)
+        assert 'No prices' not in questions
+
+
+class TestOutcomePricesPassthrough:
+    """polymarket_client must pass outcomePrices as comma-separated floats."""
+
+    def test_json_array_string_parsed_to_csv(self):
+        """Gamma API returns outcomePrices as JSON string '["0.5","0.5"]'."""
+        import json
+        from polymarket_client import PolymarketClient
+
+        client = PolymarketClient.__new__(PolymarketClient)
+        client.seren = MagicMock()
+        client._trader = None
+
+        raw_api_response = [
+            {
+                'conditionId': 'cond-1',
+                'question': 'Test stale',
+                'clobTokenIds': json.dumps(['yes-tok', 'no-tok']),
+                'outcomePrices': json.dumps(['0.5', '0.5']),
+                'volume': '1000',
+                'liquidity': '5000',
+                'endDateIso': _end_date(30),
+            },
+            {
+                'conditionId': 'cond-2',
+                'question': 'Test real',
+                'clobTokenIds': json.dumps(['yes-tok-2', 'no-tok-2']),
+                'outcomePrices': json.dumps(['0.03', '0.97']),
+                'volume': '2000',
+                'liquidity': '8000',
+                'endDateIso': _end_date(30),
+            },
+        ]
+
+        client.seren = MagicMock()
+        client.seren.call_publisher = MagicMock(return_value={'body': raw_api_response})
+
+        markets = client.get_markets(limit=10, active=True)
+
+        stale = next(m for m in markets if m['question'] == 'Test stale')
+        assert stale['outcomePrices'] == '0.5,0.5'
+        assert stale['price'] == 0.5
+        assert stale['price_source'] == 'gamma'
+
+        real = next(m for m in markets if m['question'] == 'Test real')
+        assert real['outcomePrices'] == '0.03,0.97'
+        assert real['price'] == 0.03
+        assert real['price_source'] == 'gamma'
+
+    def test_list_format_parsed_to_csv(self):
+        """Some API responses return outcomePrices as a native list."""
+        import json
+        from polymarket_client import PolymarketClient
+
+        client = PolymarketClient.__new__(PolymarketClient)
+        client.seren = MagicMock()
+        client._trader = None
+
+        raw_api_response = [
+            {
+                'conditionId': 'cond-3',
+                'question': 'List format',
+                'clobTokenIds': json.dumps(['tok-a', 'tok-b']),
+                'outcomePrices': [0.5, 0.5],
+                'volume': '3000',
+                'liquidity': '6000',
+                'endDateIso': _end_date(30),
+            },
+        ]
+
+        client.seren.call_publisher = MagicMock(return_value={'body': raw_api_response})
+        markets = client.get_markets(limit=10, active=True)
+
+        m = markets[0]
+        assert m['outcomePrices'] == '0.5,0.5'
+        assert m['price'] == 0.5
+
+
+class TestEndToEnd:
+    """Full chain: polymarket_client output → agent.rank_candidates → filtered."""
+
+    def test_stale_market_never_reaches_llm(self):
+        """A stale 50/50 market with high liquidity must not appear in candidates."""
+        agent = _make_agent(clob_midpoint=None)
+
+        # Simulate what polymarket_client returns for a mix of markets
+        markets = [
+            _market('Will Curacao win FIFA World Cup?', '0.5,0.5', liquidity=2_000_000),
+            _market('Will Haiti win FIFA World Cup?', '0.5,0.5', liquidity=1_800_000),
+            _market('Russia Ukraine ceasefire by April?', '0.15,0.85', liquidity=500_000),
+            _market('BTC above 100k end of Q2?', '0.62,0.38', liquidity=300_000),
+        ]
+
+        result = agent.rank_candidates(markets, limit=10)
+        questions = [m['question'] for m in result]
+
+        # Stale markets excluded despite massive liquidity
+        assert 'Will Curacao win FIFA World Cup?' not in questions
+        assert 'Will Haiti win FIFA World Cup?' not in questions
+
+        # Real markets survive
+        assert 'Russia Ukraine ceasefire by April?' in questions
+        assert 'BTC above 100k end of Q2?' in questions


### PR DESCRIPTION
## Summary

- Hard-filter stale 50/50 Gamma-seeded markets out of the candidate pool before ranking, preventing them from consuming LLM budget (~$1.50/scan wasted on longshot markets priced at 50%)
- Update 3 existing tests from soft-demotion to hard-filter assertions
- Add 6 new end-to-end tests covering the `polymarket_client → agent.py` chain

## Root cause

Commits #232-#244 added stale-price guards in `agent.py` that read `outcomePrices` from the market dict, but `polymarket_client.py` didn't pass that field through until #249. Even after #249, the soft demotion (`score * 0.1`) was insufficient — stale markets with $1M+ liquidity still ranked in the top 80 and got sent to Perplexity + Claude.

## Test plan

- [x] 30/30 tests pass (`test_safety_guards.py` + `test_stale_gamma_filter.py`)
- [x] Stale 50/50 markets excluded regardless of liquidity
- [x] Real-priced markets unaffected
- [x] Missing outcomePrices rejected by fallback guard
- [x] polymarket_client JSON and list format passthrough verified

Closes #250

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
