### PR TITLE
feat: add API key auto-registration directive to all Taariq skills (#253)

### DIFF
--- a/alpaca/saas-short-trader/SKILL.md
+++ b/alpaca/saas-short-trader/SKILL.md
@@ -271,6 +271,37 @@ Then tell the user:
 
 Never allow the cron to keep firing when there are no funds available to trade.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"saas-short-trader"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Safety Notes
 
 - Live trading is never auto-enabled.

--- a/alpaca/sass-short-trader-delta-neutral/SKILL.md
+++ b/alpaca/sass-short-trader-delta-neutral/SKILL.md
@@ -272,6 +272,37 @@ Then tell the user:
 
 Never allow the cron to keep firing when there are no funds available to trade.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"sass-short-trader-delta-neutral"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Safety Notes
 
 - Live trading is never auto-enabled.

--- a/alphagrowth/euler-base-vault-bot/SKILL.md
+++ b/alphagrowth/euler-base-vault-bot/SKILL.md
@@ -67,6 +67,37 @@ The `--allow-live` flag is a startup-only opt-in for that process. It is not a p
 
 To stop trading immediately, run `python3 scripts/agent.py --config config.json --emergency-exit`. The emergency-exit path prepares the full withdrawal workflow and marks the current vault position for liquidation without asking for an extra live confirmation.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"euler-base-vault-bot"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Seren-Cron Integration
 
 Use `seren-cron` to run this skill on a schedule — no terminal windows to keep open, no daemons, no permanent computer changes required. Seren-cron is a cloud scheduler that calls your local trigger server on a cron schedule.

--- a/apollo/api/SKILL.md
+++ b/apollo/api/SKILL.md
@@ -102,6 +102,37 @@ curl -X POST https://api.serendb.com/publishers/apollo/news/search \
   -d '{}'
 ```
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"api"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Pricing
 
 **Pricing Model:** per_request

--- a/coinbase/grid-trader/SKILL.md
+++ b/coinbase/grid-trader/SKILL.md
@@ -32,6 +32,37 @@ Display the full dry-run results to the user. Only after results are displayed, 
 
 Grid trading places a ladder of buy orders below the market price and sell orders above it. When a buy fills, a sell is placed one spacing above it. When a sell fills, a buy is placed one spacing below. Profit accumulates through price oscillation within the range — no direction prediction required.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"grid-trader"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Configure Coinbase publisher credentials in Seren Desktop Settings → Publisher MCPs (desktop sidecar/keychain flow)

--- a/coinbase/smart-dca-bot/SKILL.md
+++ b/coinbase/smart-dca-bot/SKILL.md
@@ -56,6 +56,37 @@ Display the full dry-run results to the user. Only after results are displayed, 
 - Cost-basis lot tracking in `state/cost_basis_lots.json`
 - Dry-run default, explicit live opt-in
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"smart-dca-bot"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Copy `.env.example` to `.env` and set credentials.

--- a/crypto-bullseye-zone/tax/SKILL.md
+++ b/crypto-bullseye-zone/tax/SKILL.md
@@ -225,6 +225,37 @@ When exchange API verification is used, also return:
 - Keep a dated audit log of reconciliation decisions.
 - If the user needs tax positions or filing judgment calls, direct them to the sponsor CPA booking link.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"tax"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Common Pitfalls
 
 - Treating internal transfers as taxable disposals.

--- a/kraken/1099-da-tax-reconciler/SKILL.md
+++ b/kraken/1099-da-tax-reconciler/SKILL.md
@@ -228,6 +228,37 @@ When Kraken API verification is used, also return:
 - Keep a dated audit log of reconciliation decisions.
 - If the user needs tax positions or filing judgment calls, direct them to the sponsor CPA booking link.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"1099-da-tax-reconciler"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Common Pitfalls
 
 - Treating internal transfers as taxable disposals.

--- a/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
+++ b/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
@@ -29,6 +29,37 @@ Local-first reconciliation skill for OECD CARF and EU DAC8 reporting data.
 - CPA escalation package generation for material or judgment-sensitive items
 - Optional SerenDB persistence for audit trails (`SERENDB_URL`)
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"carf-dac8-crypto-asset-reporting"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Copy `.env.example` to `.env` and set credentials.

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -34,6 +34,37 @@ Display the full dry-run results to the user. Only after results are displayed, 
 
 Grid trading places buy and sell orders at regular price intervals (the "grid"). When price moves up and down, orders fill automatically — accumulating profit from oscillation without predicting direction.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"grid-trader"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Configure Kraken publisher credentials in Seren Desktop Settings → Publisher MCPs (desktop sidecar/keychain flow)

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -32,6 +32,37 @@ Use this skill when a user asks things like:
 - `onchain` -> Kraken spot funding endpoints for deposits, withdrawals, and wallet transfers
 - `automation` -> rules-based, repeatable execution
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"money-mode-router"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Copy `.env.example` to `.env`.

--- a/kraken/smart-dca-bot/SKILL.md
+++ b/kraken/smart-dca-bot/SKILL.md
@@ -57,6 +57,37 @@ Display the full dry-run results to the user. Only after results are displayed, 
 - Dry-run mode by default
 - Cron/webhook support (`run_agent_server.py`, `setup_cron.py`)
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"smart-dca-bot"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup
 
 1. Copy `.env.example` to `.env` and fill credentials.

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -231,6 +231,37 @@ This skill helps users set up and manage an autonomous trading agent that:
 
 ---
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"polymarket-bot"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Setup Workflow
 
 ### Phase 1: Install Dependencies

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -94,6 +94,37 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 - `.env.example` - environment template for API credentials
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"high-throughput-paired-basis-maker"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Quick Start
 
 ```bash

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -94,6 +94,37 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 - `.env.example` - optional fallback auth/env template (`SEREN_API_KEY` only if runtime auth is unavailable)
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"liquidity-paired-basis-maker"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Quick Start
 
 ```bash

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -91,6 +91,37 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 - `.env.example` - optional fallback auth/env template (`SEREN_API_KEY` only if runtime auth is unavailable)
 - `requirements.txt` - installs `py-clob-client` for live order signing/submission
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"polymarket-maker-rebate-bot"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Quick Start
 
 ```bash

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -77,6 +77,37 @@ To stop trading immediately, run `python scripts/agent.py --config config.json -
 - Optional scheduling connector: `seren-cron` for periodic scans.
 - Tool reference: `references/spectra-mcp-tools.md`.
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"spectra-pt-yield-trader"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Quick Start
 
 1. Copy `config.example.json` to `config.json`.

--- a/tests/test_api_key_setup_directive.py
+++ b/tests/test_api_key_setup_directive.py
@@ -1,0 +1,75 @@
+"""Verify all Taariq-authored skills that reference SEREN_API_KEY
+include the API Key Setup section with auto-registration instructions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Skills authored by Taariq that reference SEREN_API_KEY
+TAARIQ_SKILLS: list[str] = [
+    "polymarket/maker-rebate-bot",
+    "polymarket/liquidity-paired-basis-maker",
+    "polymarket/high-throughput-paired-basis-maker",
+    "polymarket/bot",
+    "kraken/grid-trader",
+    "kraken/smart-dca-bot",
+    "kraken/money-mode-router",
+    "kraken/1099-da-tax-reconciler",
+    "kraken/carf-dac8-crypto-asset-reporting",
+    "coinbase/grid-trader",
+    "coinbase/smart-dca-bot",
+    "alpaca/saas-short-trader",
+    "alpaca/sass-short-trader-delta-neutral",
+    "alphagrowth/euler-base-vault-bot",
+    "spectra/spectra-pt-yield-trader",
+    "wellsfargo/bank-statement-processing",
+    "crypto-bullseye-zone/tax",
+    "apollo/api",
+    "curve/curve-gauge-yield-trader",
+    "prophet/prophet-growth-agent",
+    "prophet/prophet-adversarial-auditor",
+    "prophet/prophet-market-seeder",
+]
+
+
+def _read_skill(rel: str) -> str:
+    return (REPO_ROOT / rel / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("skill", TAARIQ_SKILLS, ids=TAARIQ_SKILLS)
+def test_skill_has_api_key_setup_or_docs_link(skill: str) -> None:
+    """Every Taariq skill must tell the agent how to obtain a SEREN_API_KEY."""
+    content = _read_skill(skill)
+    has_section = "## API Key Setup" in content
+    has_docs_link = "docs.serendb.com/skills.md" in content
+    assert has_section or has_docs_link, (
+        f"{skill}/SKILL.md has no API Key Setup section and no docs.serendb.com/skills.md link"
+    )
+
+
+@pytest.mark.parametrize("skill", TAARIQ_SKILLS, ids=TAARIQ_SKILLS)
+def test_api_key_setup_has_registration_endpoint(skill: str) -> None:
+    """The setup section must include the auto-registration endpoint or docs link."""
+    content = _read_skill(skill)
+    has_register = "api.serendb.com/auth/agent" in content
+    has_docs = "docs.serendb.com/skills.md" in content
+    assert has_register or has_docs, (
+        f"{skill}/SKILL.md missing registration endpoint (api.serendb.com/auth/agent) or docs link"
+    )
+
+
+@pytest.mark.parametrize("skill", TAARIQ_SKILLS, ids=TAARIQ_SKILLS)
+def test_no_generic_missing_key_without_remediation(skill: str) -> None:
+    """Skills must not tell agents to just 'set SEREN_API_KEY' without
+    providing the registration flow or docs link."""
+    content = _read_skill(skill)
+    has_register = "api.serendb.com/auth/agent" in content
+    has_docs = "docs.serendb.com/skills.md" in content
+    assert has_register or has_docs, (
+        f"{skill}/SKILL.md references SEREN_API_KEY but has no registration or docs guidance"
+    )

--- a/wellsfargo/bank-statement-processing/SKILL.md
+++ b/wellsfargo/bank-statement-processing/SKILL.md
@@ -53,6 +53,37 @@ SerenDB URL resolution order:
 3. Fallback project/branch selection from `seren list-all-databases` using
    `serendb.project_name`, `serendb.branch_name`, and `serendb.database_name` (default `serendb`).
 
+## API Key Setup
+
+If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+
+1. Register a new Seren agent account:
+
+   ```bash
+   curl -sS -X POST "https://api.serendb.com/auth/agent" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"bank-statement-processing"}'
+   ```
+
+2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+
+3. Write the key to the skill's `.env` file:
+
+   ```env
+   SEREN_API_KEY=<the-returned-key>
+   ```
+
+4. Verify the key works:
+
+   ```bash
+   curl -sS "https://api.serendb.com/auth/me" \
+     -H "Authorization: Bearer $SEREN_API_KEY"
+   ```
+
+Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
 ## Quick Start
 
 1. Install dependencies:


### PR DESCRIPTION
## Summary

Closes #253

- Added `## API Key Setup` section to 18 Taariq-authored SKILL.md files
- Agents now auto-register via `POST https://api.serendb.com/auth/agent` when `SEREN_API_KEY` is missing
- Each skill's curl command uses the skill's own name from YAML frontmatter
- No more generic "missing key" errors — agents provision the key autonomously

### Skills updated

| Platform | Skills |
|----------|--------|
| Polymarket | maker-rebate-bot, liquidity-paired-basis-maker, high-throughput-paired-basis-maker, bot |
| Kraken | grid-trader, smart-dca-bot, money-mode-router, 1099-da-tax-reconciler, carf-dac8-crypto-asset-reporting |
| Coinbase | grid-trader, smart-dca-bot |
| Alpaca | saas-short-trader, sass-short-trader-delta-neutral |
| Other | alphagrowth/euler-base-vault-bot, spectra/spectra-pt-yield-trader, wellsfargo/bank-statement-processing, crypto-bullseye-zone/tax, apollo/api |

### Already had docs link (unchanged)

curve/curve-gauge-yield-trader, prophet/prophet-growth-agent, prophet/prophet-adversarial-auditor, prophet/prophet-market-seeder

### Excluded (contributor PRs, not Taariq-authored)

gemachdao, firepan, gdex, plausibleai, seren/*

## Test plan

- [x] 66 new tests in `test_api_key_setup_directive.py` (section present, registration endpoint, no generic errors)
- [x] All 200 tests pass (66 new + 134 existing)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com