### PR TITLE
fix: guard API key setup against duplicate registration (#255)

### DIFF
--- a/alpaca/saas-short-trader/SKILL.md
+++ b/alpaca/saas-short-trader/SKILL.md
@@ -273,32 +273,34 @@ Never allow the cron to keep firing when there are no funds available to trade.
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"saas-short-trader"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"saas-short-trader"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/alpaca/sass-short-trader-delta-neutral/SKILL.md
+++ b/alpaca/sass-short-trader-delta-neutral/SKILL.md
@@ -274,32 +274,34 @@ Never allow the cron to keep firing when there are no funds available to trade.
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"sass-short-trader-delta-neutral"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"sass-short-trader-delta-neutral"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/alphagrowth/euler-base-vault-bot/SKILL.md
+++ b/alphagrowth/euler-base-vault-bot/SKILL.md
@@ -69,32 +69,34 @@ To stop trading immediately, run `python3 scripts/agent.py --config config.json 
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"euler-base-vault-bot"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"euler-base-vault-bot"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/apollo/api/SKILL.md
+++ b/apollo/api/SKILL.md
@@ -104,32 +104,34 @@ curl -X POST https://api.serendb.com/publishers/apollo/news/search \
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"api"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"api"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/coinbase/grid-trader/SKILL.md
+++ b/coinbase/grid-trader/SKILL.md
@@ -34,32 +34,34 @@ Grid trading places a ladder of buy orders below the market price and sell order
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"grid-trader"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"grid-trader"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/coinbase/smart-dca-bot/SKILL.md
+++ b/coinbase/smart-dca-bot/SKILL.md
@@ -58,32 +58,34 @@ Display the full dry-run results to the user. Only after results are displayed, 
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"smart-dca-bot"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"smart-dca-bot"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/crypto-bullseye-zone/tax/SKILL.md
+++ b/crypto-bullseye-zone/tax/SKILL.md
@@ -227,32 +227,34 @@ When exchange API verification is used, also return:
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"tax"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"tax"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/kraken/1099-da-tax-reconciler/SKILL.md
+++ b/kraken/1099-da-tax-reconciler/SKILL.md
@@ -230,32 +230,34 @@ When Kraken API verification is used, also return:
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"1099-da-tax-reconciler"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"1099-da-tax-reconciler"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
+++ b/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
@@ -31,32 +31,34 @@ Local-first reconciliation skill for OECD CARF and EU DAC8 reporting data.
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"carf-dac8-crypto-asset-reporting"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"carf-dac8-crypto-asset-reporting"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/kraken/grid-trader/SKILL.md
+++ b/kraken/grid-trader/SKILL.md
@@ -36,32 +36,34 @@ Grid trading places buy and sell orders at regular price intervals (the "grid").
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"grid-trader"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"grid-trader"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -34,32 +34,34 @@ Use this skill when a user asks things like:
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"money-mode-router"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"money-mode-router"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/kraken/smart-dca-bot/SKILL.md
+++ b/kraken/smart-dca-bot/SKILL.md
@@ -59,32 +59,34 @@ Display the full dry-run results to the user. Only after results are displayed, 
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"smart-dca-bot"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"smart-dca-bot"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/polymarket/bot/SKILL.md
+++ b/polymarket/bot/SKILL.md
@@ -121,7 +121,7 @@ tail -50 ~/.config/seren/skills/polymarket-bot/logs/trading_*.log
 ⚠️ **Only if user has:**
 
 - Completed paper trading validation (50+ scans)
-- $550+ budget ($500 USDC + $50 SerenBucks)
+- $525+ budget ($500 USDC + $25 SerenBucks)
 - Real Polymarket API credentials
 
 ```bash
@@ -233,32 +233,34 @@ This skill helps users set up and manage an autonomous trading agent that:
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"polymarket-bot"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"polymarket-bot"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 
@@ -380,7 +382,7 @@ Stop trading if bankroll drops to this amount.
 
 ⚠️ **REALITY CHECK: The Economics of Automated Trading**
 
-**You need at least $550 total to trade profitably with this bot.**
+**You need at least $525 total to trade profitably with this bot.**
 
 This is not a recommendation - it's math. Here's why:
 
@@ -395,15 +397,15 @@ The bot costs ~$12/day to run (at 2-hour scan intervals). With a $20 bankroll:
 
 This is like hiring a $100/hour analyst to trade a $10 account. The math doesn't work.
 
-#### Minimum Viable Budget: $550
+#### Minimum Viable Budget: $525
 
 To have a realistic chance of offsetting API costs and achieving profitability:
 
 | Item             | Amount   | Purpose                                       |
 | ---------------- | -------- | --------------------------------------------- |
 | **Polygon USDC** | $500     | Trading capital (allows $15-30 positions)     |
-| **SerenBucks**   | $50      | API costs (4+ days of operation)              |
-| **Total**        | **$550** | Minimum to trade with positive expected value |
+| **SerenBucks**   | $25      | API costs (2+ days of operation)              |
+| **Total**        | **$525** | Minimum to trade with positive expected value |
 
 With $500 bankroll:
 
@@ -416,14 +418,14 @@ With $500 bankroll:
 
 #### Budget Tiers
 
-##### 🔴 Below Minimum (<$550 total)
+##### 🔴 Below Minimum (<$525 total)
 
 - **Status**: 🚨 **WILL LOSE MONEY**
 - **Reality**: Trading profits cannot offset API costs with small positions
 - **Use case**: Educational only - learning how the system works
 - **Expected outcome**: Net loss of ~$40-50 after SerenBucks depleted
 
-##### 🟢 Minimum Viable ($550-800 total)
+##### 🟢 Minimum Viable ($525-800 total)
 
 - **SerenBucks**: $50-100
 - **Polygon USDC**: $500
@@ -479,20 +481,20 @@ python3 scripts/agent.py --config config.json --dry-run
 - ❌ Does NOT place actual Polymarket orders
 - ❌ Does NOT require Polymarket API credentials
 
-**Important:** Paper trading still costs **~$1 per scan** in API fees (Perplexly + Claude analysis). With $50 SerenBucks, you can run 50 paper trades over 1-2 weeks to validate the strategy.
+**Important:** Paper trading still costs **~$1 per scan** in API fees (Perplexly + Claude analysis). With $25 SerenBucks, you can run 25 paper trades over 1-2 weeks to validate the strategy.
 
 **Recommended paper trading plan:**
 
-1. Fund $50 SerenBucks (covers ~50 scans)
+1. Fund $25 SerenBucks (covers ~25 scans)
 2. Set `"scan_interval_minutes": 120` in config.json (2-hour intervals)
 3. Run paper trading for 5-7 days (60-84 scans)
 4. Analyze results in log files:
    - Win rate: % of paper trades that would have been profitable
    - Average edge: mean expected value per trade
    - Sharpe ratio: risk-adjusted returns
-5. If paper trading shows consistent edge, move to live trading with $550+ budget
+5. If paper trading shows consistent edge, move to live trading with $525+ budget
 
-**Manual paper trading (if <$50 SerenBucks):**
+**Manual paper trading (if <$25 SerenBucks):**
 
 Run scans one at a time when you want:
 
@@ -514,11 +516,11 @@ Once paper trading validates your edge (recommended: 50+ scans with positive exp
 **Requirements for live trading:**
 
 - ✅ Successful paper trading period (1-2 weeks, 50+ scans)
-- ✅ Minimum $550 budget ($500 USDC + $50 SerenBucks)
+- ✅ Minimum $525 budget ($500 USDC + $25 SerenBucks)
 - ✅ Polymarket API credentials (see Phase 2)
 - ✅ Understanding of Kelly Criterion risk management
 
-**If you don't have $550 yet:**
+**If you don't have $525 yet:**
 
 - Continue paper trading to refine strategy
 - Save up capital while accumulating paper trade data

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -96,32 +96,34 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"high-throughput-paired-basis-maker"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"high-throughput-paired-basis-maker"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -96,32 +96,34 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"liquidity-paired-basis-maker"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"liquidity-paired-basis-maker"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -93,32 +93,34 @@ The unwind path cancels open orders first, then submits marketable min-tick sell
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"polymarket-maker-rebate-bot"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"polymarket-maker-rebate-bot"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/seren/job-seeker/SKILL.md
+++ b/seren/job-seeker/SKILL.md
@@ -516,7 +516,7 @@ Summary:
 
 2. **Budget:**
    - Minimum: $20 SerenBucks (covers 1-2 comprehensive searches)
-   - Recommended: $50 SerenBucks (covers 3-5 searches with multiple iterations)
+   - Recommended: $25 SerenBucks (covers 3-5 searches with multiple iterations)
 
 ### Full Workflow Example
 

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -79,32 +79,34 @@ To stop trading immediately, run `python scripts/agent.py --config config.json -
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"spectra-pt-yield-trader"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"spectra-pt-yield-trader"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 

--- a/tests/test_api_key_setup_directive.py
+++ b/tests/test_api_key_setup_directive.py
@@ -1,9 +1,8 @@
 """Verify all Taariq-authored skills that reference SEREN_API_KEY
-include the API Key Setup section with auto-registration instructions."""
+include the API Key Setup section with existing-auth checks before registration."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -36,6 +35,17 @@ TAARIQ_SKILLS: list[str] = [
     "prophet/prophet-market-seeder",
 ]
 
+# Skills that have the full ## API Key Setup section (not just a docs link)
+SKILLS_WITH_SETUP_SECTION: list[str] = [
+    s for s in TAARIQ_SKILLS
+    if s not in {
+        "curve/curve-gauge-yield-trader",
+        "prophet/prophet-growth-agent",
+        "prophet/prophet-adversarial-auditor",
+        "prophet/prophet-market-seeder",
+    }
+]
+
 
 def _read_skill(rel: str) -> str:
     return (REPO_ROOT / rel / "SKILL.md").read_text(encoding="utf-8")
@@ -59,17 +69,37 @@ def test_api_key_setup_has_registration_endpoint(skill: str) -> None:
     has_register = "api.serendb.com/auth/agent" in content
     has_docs = "docs.serendb.com/skills.md" in content
     assert has_register or has_docs, (
-        f"{skill}/SKILL.md missing registration endpoint (api.serendb.com/auth/agent) or docs link"
+        f"{skill}/SKILL.md missing registration endpoint or docs link"
     )
 
 
-@pytest.mark.parametrize("skill", TAARIQ_SKILLS, ids=TAARIQ_SKILLS)
-def test_no_generic_missing_key_without_remediation(skill: str) -> None:
-    """Skills must not tell agents to just 'set SEREN_API_KEY' without
-    providing the registration flow or docs link."""
+@pytest.mark.parametrize("skill", SKILLS_WITH_SETUP_SECTION, ids=SKILLS_WITH_SETUP_SECTION)
+def test_api_key_setup_checks_existing_auth_before_register(skill: str) -> None:
+    """The setup section must check for existing Seren Desktop / .env / shell
+    auth BEFORE telling the agent to register a new account (#255)."""
     content = _read_skill(skill)
-    has_register = "api.serendb.com/auth/agent" in content
-    has_docs = "docs.serendb.com/skills.md" in content
-    assert has_register or has_docs, (
-        f"{skill}/SKILL.md references SEREN_API_KEY but has no registration or docs guidance"
+    assert "Seren Desktop" in content, (
+        f"{skill}/SKILL.md API Key Setup does not mention Seren Desktop auth check"
+    )
+    # The check-existing text must appear BEFORE the register curl
+    check_pos = content.find("If set, no further action is needed")
+    register_pos = content.find("api.serendb.com/auth/agent")
+    assert check_pos != -1, (
+        f"{skill}/SKILL.md missing 'no further action' existing-auth guard"
+    )
+    assert register_pos != -1, (
+        f"{skill}/SKILL.md missing registration endpoint"
+    )
+    assert check_pos < register_pos, (
+        f"{skill}/SKILL.md: existing-auth check must come BEFORE registration"
+    )
+
+
+@pytest.mark.parametrize("skill", SKILLS_WITH_SETUP_SECTION, ids=SKILLS_WITH_SETUP_SECTION)
+def test_api_key_setup_warns_against_duplicate_accounts(skill: str) -> None:
+    """The setup section must warn that creating a duplicate account
+    overrides the user's funded account (#255)."""
+    content = _read_skill(skill)
+    assert "Do not create a new account if a key already exists" in content, (
+        f"{skill}/SKILL.md missing duplicate-account warning"
     )

--- a/wellsfargo/bank-statement-processing/SKILL.md
+++ b/wellsfargo/bank-statement-processing/SKILL.md
@@ -55,32 +55,34 @@ SerenDB URL resolution order:
 
 ## API Key Setup
 
-If `SEREN_API_KEY` is not set (and the skill is not running inside Seren Desktop, which injects `API_KEY` automatically), the agent must register and provision a key before proceeding:
+Before running this skill, check for an existing Seren API key in this order:
 
-1. Register a new Seren agent account:
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
 
-   ```bash
-   curl -sS -X POST "https://api.serendb.com/auth/agent" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"bank-statement-processing"}'
-   ```
+**Only if none of the above are set**, register a new agent account:
 
-2. Extract the API key from the response at `.data.agent.api_key`. **This key is shown only once** — save it immediately.
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"bank-statement-processing"}'
+```
 
-3. Write the key to the skill's `.env` file:
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
 
-   ```env
-   SEREN_API_KEY=<the-returned-key>
-   ```
+```env
+SEREN_API_KEY=<the-returned-key>
+```
 
-4. Verify the key works:
+Verify:
 
-   ```bash
-   curl -sS "https://api.serendb.com/auth/me" \
-     -H "Authorization: Bearer $SEREN_API_KEY"
-   ```
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
 
-Do not show a generic "missing key" error. Always auto-register and provision the key so the skill can proceed. If the user declines registration, respect that and stop.
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
 
 Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
 


### PR DESCRIPTION
## Summary

Closes #255 — regression from #253

The API Key Setup directive told agents to register unconditionally. When running inside Seren Desktop (which injects API_KEY automatically), agents created a brand-new zero-balance account and wrote it to .env, overriding the user's funded Desktop session. This caused 402 Insufficient prepaid balance errors.

### Changes

1. **Rewrote API Key Setup section** in all 18 Taariq-authored SKILL.md files to check for existing auth first:
   - Step 1: Check Seren Desktop API_KEY (injected at runtime)
   - Step 2: Check existing .env SEREN_API_KEY
   - Step 3: Check shell-exported SEREN_API_KEY
   - Only if all three are unset, register a new account
   - Added explicit warning: Do not create a new account if a key already exists

2. **Fixed $50 SerenBucks to $25 SerenBucks** in polymarket/bot and seren/job-seeker

## Test plan

- [x] 2 new regression tests: existing-auth-before-register, duplicate-account-warning
- [x] All 214 tests pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com