### PR TITLE
fix(polymarket-bot): route SerenDB storage through seren-db publisher (#258)

### DIFF
--- a/polymarket/bot/scripts/serendb_storage.py
+++ b/polymarket/bot/scripts/serendb_storage.py
@@ -62,12 +62,15 @@ class SerenDBStorage:
 
             self.project_id = project['id']
 
-            # Step 2: Get main branch
+            # Step 2: Get default branch (Seren names it 'production'; fall back to 'main')
             branches = self._list_branches(self.project_id)
-            main_branch = next((b for b in branches if b['name'] == 'main'), None)
+            main_branch = next(
+                (b for b in branches if b.get('default') or b['name'] in ('production', 'main')),
+                None,
+            )
 
             if not main_branch:
-                raise Exception("Main branch not found")
+                raise Exception("No default, production, or main branch found")
 
             self.branch_id = main_branch['id']
             print(f"  ✓ Using branch: {self.branch_id}")
@@ -1147,12 +1150,16 @@ class SerenDBStorage:
                 else:
                     query = query.replace('?', str(param), 1)
 
-        # Call Seren Gateway database API
-        url = f"{self.seren.gateway_url}/projects/{self.project_id}/branches/{self.branch_id}/query"
+        # Call Seren Gateway database API via seren-db publisher
+        url = f"{self.seren.gateway_url}/publishers/seren-db/query"
 
         response = self.seren.session.post(
             url,
-            json={'query': query},
+            json={
+                'project_id': self.project_id,
+                'branch_id': self.branch_id,
+                'query': query,
+            },
             timeout=30
         )
 
@@ -1160,15 +1167,15 @@ class SerenDBStorage:
         return self._unwrap_data(response.json())
 
     def _list_projects(self) -> List[Dict[str, Any]]:
-        """List all SerenDB projects"""
-        url = f"{self.seren.gateway_url}/projects"
+        """List all SerenDB projects via seren-db publisher"""
+        url = f"{self.seren.gateway_url}/publishers/seren-db/projects"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
         return self._unwrap_data(response.json(), default=[])
 
     def _create_project(self, name: str) -> Dict[str, Any]:
-        """Create a new SerenDB project"""
-        url = f"{self.seren.gateway_url}/projects"
+        """Create a new SerenDB project via seren-db publisher"""
+        url = f"{self.seren.gateway_url}/publishers/seren-db/projects"
         response = self.seren.session.post(
             url,
             json={'name': name, 'region': 'aws-us-east-2'},
@@ -1181,15 +1188,15 @@ class SerenDBStorage:
         return self._get_project(project_id)
 
     def _get_project(self, project_id: str) -> Dict[str, Any]:
-        """Get project details"""
-        url = f"{self.seren.gateway_url}/projects/{project_id}"
+        """Get project details via seren-db publisher"""
+        url = f"{self.seren.gateway_url}/publishers/seren-db/projects/{project_id}"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
         return self._unwrap_data(response.json(), default={})
 
     def _list_branches(self, project_id: str) -> List[Dict[str, Any]]:
-        """List branches for a project"""
-        url = f"{self.seren.gateway_url}/projects/{project_id}/branches"
+        """List branches for a project via seren-db publisher"""
+        url = f"{self.seren.gateway_url}/publishers/seren-db/projects/{project_id}/branches"
         response = self.seren.session.get(url, timeout=10)
         response.raise_for_status()
         return self._unwrap_data(response.json(), default=[])

--- a/tests/test_serendb_publisher_routes.py
+++ b/tests/test_serendb_publisher_routes.py
@@ -1,0 +1,75 @@
+"""Verify serendb_storage.py routes all API calls through the seren-db publisher,
+not directly to /projects (which 404s on the Seren gateway)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SERENDB_STORAGE_FILES: list[str] = [
+    "polymarket/bot/scripts/serendb_storage.py",
+]
+
+
+def _read_source(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
+def test_no_direct_projects_route(rel_path: str) -> None:
+    """serendb_storage must not hit /projects directly — must route through
+    /publishers/seren-db/projects."""
+    source = _read_source(rel_path)
+    # Find lines that construct a URL with /projects but NOT /publishers/seren-db/projects
+    for i, line in enumerate(source.splitlines(), 1):
+        if "/projects" in line and "gateway_url" in line:
+            assert "publishers/seren-db" in line, (
+                f"{rel_path}:{i} hits /projects directly instead of "
+                f"/publishers/seren-db/projects: {line.strip()}"
+            )
+
+
+@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
+def test_query_route_uses_publisher(rel_path: str) -> None:
+    """SQL queries must go through /publishers/seren-db/query, not
+    /projects/{pid}/branches/{bid}/query."""
+    source = _read_source(rel_path)
+    for i, line in enumerate(source.splitlines(), 1):
+        if "/query" in line and "gateway_url" in line:
+            assert "publishers/seren-db" in line, (
+                f"{rel_path}:{i} hits /query directly instead of "
+                f"/publishers/seren-db/query: {line.strip()}"
+            )
+
+
+@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
+def test_query_body_includes_project_and_branch(rel_path: str) -> None:
+    """The query POST body must include project_id and branch_id since
+    they are no longer encoded in the URL path."""
+    source = _read_source(rel_path)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_execute_sql":
+            func_source = ast.get_source_segment(source, node)
+            assert "project_id" in func_source, (
+                f"{rel_path}: _execute_sql body must include project_id"
+            )
+            assert "branch_id" in func_source, (
+                f"{rel_path}: _execute_sql body must include branch_id"
+            )
+            break
+    else:
+        pytest.fail(f"{rel_path}: _execute_sql function not found")
+
+
+@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
+def test_branch_lookup_accepts_production(rel_path: str) -> None:
+    """Branch lookup must accept 'production' (Seren default) not just 'main'."""
+    source = _read_source(rel_path)
+    assert "production" in source, (
+        f"{rel_path}: branch lookup must accept 'production' as a default branch name"
+    )


### PR DESCRIPTION
## Summary

Closes #258

The `serendb_storage.py` in polymarket/bot called gateway routes that do not exist:
- `GET /projects` -> 404
- `POST /projects/{pid}/branches/{bid}/query` -> 404

These routes must go through the `seren-db` publisher:
- `GET /publishers/seren-db/projects`
- `POST /publishers/seren-db/projects`
- `GET /publishers/seren-db/projects/{id}`
- `GET /publishers/seren-db/projects/{id}/branches`
- `POST /publishers/seren-db/query` (with project_id + branch_id in body)

Also fixed branch lookup: Seren names default branches `production`, not `main`.

Only polymarket/bot is affected — alpaca skills use psycopg with DSN strings.

## Verified routes

All routes tested against live API and confirmed working before implementation.

## Test plan

- [x] 4 new tests: no direct /projects routes, query uses publisher, body includes IDs, branch accepts production
- [x] All 218 tests pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com