### PR TITLE
fix: route SerenDB calls through seren-db publisher in all remaining skills (#258)

### DIFF
--- a/alpaca/saas-short-trader/scripts/serendb_bootstrap.py
+++ b/alpaca/saas-short-trader/scripts/serendb_bootstrap.py
@@ -62,28 +62,28 @@ class SerenApi:
         return []
 
     def list_projects(self) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", "/projects"))
+        return self._as_list(self._request("GET", "/publishers/seren-db/projects"))
 
     def create_project(self, name: str, region: str) -> Dict[str, Any]:
-        payload = self._request("POST", "/projects", body={"name": name, "region": region})
+        payload = self._request("POST", "/publishers/seren-db/projects", body={"name": name, "region": region})
         data = payload.get("data")
         return data if isinstance(data, dict) else payload
 
     def list_branches(self, project_id: str) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", f"/projects/{project_id}/branches"))
+        return self._as_list(self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches"))
 
     def list_databases(self, project_id: str, branch_id: str) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases"))
+        return self._as_list(self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/databases"))
 
     def create_database(self, project_id: str, branch_id: str, name: str) -> Dict[str, Any]:
-        payload = self._request("POST", f"/projects/{project_id}/branches/{branch_id}/databases", body={"name": name})
+        payload = self._request("POST", f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/databases", body={"name": name})
         data = payload.get("data")
         return data if isinstance(data, dict) else payload
 
     def get_connection_string(self, project_id: str, branch_id: str, role: str = "serendb_owner") -> str:
         payload = self._request(
             "GET",
-            f"/projects/{project_id}/branches/{branch_id}/connection-string",
+            f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/connection-string",
             query={"role": role, "pooled": "false"},
         )
         data = payload.get("data")

--- a/alpaca/sass-short-trader-delta-neutral/scripts/serendb_bootstrap.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/serendb_bootstrap.py
@@ -62,28 +62,28 @@ class SerenApi:
         return []
 
     def list_projects(self) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", "/projects"))
+        return self._as_list(self._request("GET", "/publishers/seren-db/projects"))
 
     def create_project(self, name: str, region: str) -> Dict[str, Any]:
-        payload = self._request("POST", "/projects", body={"name": name, "region": region})
+        payload = self._request("POST", "/publishers/seren-db/projects", body={"name": name, "region": region})
         data = payload.get("data")
         return data if isinstance(data, dict) else payload
 
     def list_branches(self, project_id: str) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", f"/projects/{project_id}/branches"))
+        return self._as_list(self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches"))
 
     def list_databases(self, project_id: str, branch_id: str) -> List[Dict[str, Any]]:
-        return self._as_list(self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases"))
+        return self._as_list(self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/databases"))
 
     def create_database(self, project_id: str, branch_id: str, name: str) -> Dict[str, Any]:
-        payload = self._request("POST", f"/projects/{project_id}/branches/{branch_id}/databases", body={"name": name})
+        payload = self._request("POST", f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/databases", body={"name": name})
         data = payload.get("data")
         return data if isinstance(data, dict) else payload
 
     def get_connection_string(self, project_id: str, branch_id: str, role: str = "serendb_owner") -> str:
         payload = self._request(
             "GET",
-            f"/projects/{project_id}/branches/{branch_id}/connection-string",
+            f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/connection-string",
             query={"role": role, "pooled": "false"},
         )
         data = payload.get("data")

--- a/crypto-bullseye-zone/tax/scripts/serendb_store.py
+++ b/crypto-bullseye-zone/tax/scripts/serendb_store.py
@@ -55,7 +55,7 @@ class SerenApi:
             raise SerenApiError(f"API request failed for {path}: {exc}") from exc
 
     def list_projects(self) -> List[Dict[str, Any]]:
-        payload = self._request("GET", "/projects")
+        payload = self._request("GET", "/publishers/seren-db/projects")
         data = payload.get("data")
         if isinstance(data, list):
             return data
@@ -64,7 +64,7 @@ class SerenApi:
         return []
 
     def list_branches(self, project_id: str) -> List[Dict[str, Any]]:
-        payload = self._request("GET", f"/projects/{project_id}/branches")
+        payload = self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches")
         data = payload.get("data")
         if isinstance(data, list):
             return data
@@ -75,7 +75,7 @@ class SerenApi:
         return []
 
     def list_databases(self, project_id: str, branch_id: str) -> List[Dict[str, Any]]:
-        payload = self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases")
+        payload = self._request("GET", f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/databases")
         data = payload.get("data")
         if isinstance(data, list):
             return data
@@ -88,7 +88,7 @@ class SerenApi:
     def get_connection_string(self, project_id: str, branch_id: str, role: str = "serendb_owner") -> str:
         payload = self._request(
             "GET",
-            f"/projects/{project_id}/branches/{branch_id}/connection-string",
+            f"/publishers/seren-db/projects/{project_id}/branches/{branch_id}/connection-string",
             query={"role": role, "pooled": "false"},
         )
         data = payload.get("data")

--- a/polymarket/bot/scripts/test_serendb_storage.py
+++ b/polymarket/bot/scripts/test_serendb_storage.py
@@ -30,20 +30,20 @@ class TestSerenDBStorageRoutes:
 
         def get_side_effect(url, timeout):
             assert timeout == 10
-            if url == "https://api.serendb.com/projects":
+            if url == "https://api.serendb.com/publishers/seren-db/projects":
                 return _response([])
-            if url == "https://api.serendb.com/projects/project-123":
+            if url == "https://api.serendb.com/publishers/seren-db/projects/project-123":
                 return _response({"data": {"id": "project-123", "name": "polymarket-bot"}})
-            if url == "https://api.serendb.com/projects/project-123/branches":
+            if url == "https://api.serendb.com/publishers/seren-db/projects/project-123/branches":
                 return _response([{"id": "branch-main", "name": "main"}])
             raise AssertionError(f"Unexpected GET {url}")
 
         def post_side_effect(url, json, timeout):
-            if url == "https://api.serendb.com/projects":
+            if url == "https://api.serendb.com/publishers/seren-db/projects":
                 assert timeout == 30
                 assert json == {"name": "polymarket-bot", "region": "aws-us-east-2"}
                 return _response({"data": {"id": "project-123"}})
-            if url == "https://api.serendb.com/projects/project-123/branches/branch-main/query":
+            if url == "https://api.serendb.com/publishers/seren-db/query":
                 assert timeout == 30
                 assert "query" in json
                 query_urls.append(url)
@@ -78,8 +78,8 @@ class TestSerenDBStorageRoutes:
 
         assert result == {"rows": [{"count": 1}]}
         session.post.assert_called_once_with(
-            "https://api.serendb.com/projects/project-123/branches/branch-main/query",
-            json={"query": "SELECT 1 AS count"},
+            "https://api.serendb.com/publishers/seren-db/query",
+            json={"query": "SELECT 1 AS count", "project_id": "project-123", "branch_id": "branch-main"},
             timeout=30,
         )
 

--- a/tests/test_serendb_publisher_routes.py
+++ b/tests/test_serendb_publisher_routes.py
@@ -1,5 +1,5 @@
-"""Verify serendb_storage.py routes all API calls through the seren-db publisher,
-not directly to /projects (which 404s on the Seren gateway)."""
+"""Verify all SerenDB storage/bootstrap files route API calls through the
+seren-db publisher, not directly to /projects (which 404s on the Seren gateway)."""
 
 from __future__ import annotations
 
@@ -10,66 +10,94 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-SERENDB_STORAGE_FILES: list[str] = [
-    "polymarket/bot/scripts/serendb_storage.py",
+# Files that build URLs by appending paths to a base URL (gateway_url or api_base).
+# Each tuple: (file_path, url_building_marker)
+# url_building_marker is the string that appears on lines that construct API URLs.
+SERENDB_FILES: list[tuple[str, str]] = [
+    ("polymarket/bot/scripts/serendb_storage.py", "gateway_url"),
+    ("crypto-bullseye-zone/tax/scripts/serendb_store.py", "_api_base"),
+    ("alpaca/saas-short-trader/scripts/serendb_bootstrap.py", "api_base"),
+    ("alpaca/sass-short-trader-delta-neutral/scripts/serendb_bootstrap.py", "api_base"),
+    # prophet skills bake /publishers/seren-db into api_base itself, so path
+    # strings like /projects/... resolve correctly without prefixing.
+    ("prophet/prophet-growth-agent/scripts/agent.py", "api_base"),
+    ("prophet/prophet-adversarial-auditor/scripts/agent.py", "api_base"),
+    ("prophet/prophet-market-seeder/scripts/agent.py", "api_base"),
 ]
+
+IDS = [t[0] for t in SERENDB_FILES]
 
 
 def _read_source(rel: str) -> str:
     return (REPO_ROOT / rel).read_text(encoding="utf-8")
 
 
-@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
-def test_no_direct_projects_route(rel_path: str) -> None:
-    """serendb_storage must not hit /projects directly — must route through
-    /publishers/seren-db/projects."""
+def _has_publisher_in_base(source: str) -> bool:
+    """Check if the file bakes /publishers/seren-db into the base URL itself."""
+    return "publishers/seren-db" in source.split("api_base")[0] if "api_base" in source else False
+
+
+@pytest.mark.parametrize("rel_path,marker", SERENDB_FILES, ids=IDS)
+def test_no_direct_projects_route(rel_path: str, marker: str) -> None:
+    """SerenDB files must not hit /projects directly — must route through
+    /publishers/seren-db/projects (either in path or base URL)."""
     source = _read_source(rel_path)
-    # Find lines that construct a URL with /projects but NOT /publishers/seren-db/projects
+    # If the file bakes /publishers/seren-db into api_base, then bare /projects
+    # paths are fine since the full URL will be correct.
+    base_has_publisher = "publishers/seren-db" in source and "api_base" in source
     for i, line in enumerate(source.splitlines(), 1):
-        if "/projects" in line and "gateway_url" in line:
+        if '"/projects' in line and marker in line:
+            if base_has_publisher:
+                continue  # base URL already includes publisher prefix
             assert "publishers/seren-db" in line, (
                 f"{rel_path}:{i} hits /projects directly instead of "
                 f"/publishers/seren-db/projects: {line.strip()}"
             )
 
 
-@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
-def test_query_route_uses_publisher(rel_path: str) -> None:
-    """SQL queries must go through /publishers/seren-db/query, not
-    /projects/{pid}/branches/{bid}/query."""
+@pytest.mark.parametrize("rel_path,marker", SERENDB_FILES, ids=IDS)
+def test_all_project_paths_resolve_through_publisher(rel_path: str, marker: str) -> None:
+    """Every /projects path in the file must ultimately resolve to
+    /publishers/seren-db/projects/... at runtime."""
     source = _read_source(rel_path)
+    has_publisher_in_base = False
+    for line in source.splitlines():
+        if "api_base" in line and "publishers/seren-db" in line and ("=" in line or "or" in line):
+            has_publisher_in_base = True
+            break
+
     for i, line in enumerate(source.splitlines(), 1):
-        if "/query" in line and "gateway_url" in line:
-            assert "publishers/seren-db" in line, (
-                f"{rel_path}:{i} hits /query directly instead of "
-                f"/publishers/seren-db/query: {line.strip()}"
+        # Skip comments, docstrings, and test assertions
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith('"""') or "assert" in stripped:
+            continue
+        if '"/projects' in line:
+            ok = (
+                "publishers/seren-db" in line  # path itself has prefix
+                or has_publisher_in_base        # base URL has prefix
+            )
+            assert ok, (
+                f"{rel_path}:{i} resolves to a bare /projects route: {stripped}"
             )
 
 
-@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
-def test_query_body_includes_project_and_branch(rel_path: str) -> None:
-    """The query POST body must include project_id and branch_id since
-    they are no longer encoded in the URL path."""
-    source = _read_source(rel_path)
+# -- polymarket/bot specific tests (has _execute_sql and branch lookup) --
+
+def test_query_body_includes_project_and_branch() -> None:
+    """The query POST body must include project_id and branch_id."""
+    source = _read_source("polymarket/bot/scripts/serendb_storage.py")
     tree = ast.parse(source)
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "_execute_sql":
             func_source = ast.get_source_segment(source, node)
-            assert "project_id" in func_source, (
-                f"{rel_path}: _execute_sql body must include project_id"
-            )
-            assert "branch_id" in func_source, (
-                f"{rel_path}: _execute_sql body must include branch_id"
-            )
+            assert "project_id" in func_source
+            assert "branch_id" in func_source
             break
     else:
-        pytest.fail(f"{rel_path}: _execute_sql function not found")
+        pytest.fail("_execute_sql function not found")
 
 
-@pytest.mark.parametrize("rel_path", SERENDB_STORAGE_FILES, ids=SERENDB_STORAGE_FILES)
-def test_branch_lookup_accepts_production(rel_path: str) -> None:
+def test_branch_lookup_accepts_production() -> None:
     """Branch lookup must accept 'production' (Seren default) not just 'main'."""
-    source = _read_source(rel_path)
-    assert "production" in source, (
-        f"{rel_path}: branch lookup must accept 'production' as a default branch name"
-    )
+    source = _read_source("polymarket/bot/scripts/serendb_storage.py")
+    assert "production" in source


### PR DESCRIPTION
## Summary

Closes #258 — follow-up to #259 which only fixed polymarket/bot.

### Files fixed

| File | Methods fixed |
|------|---------------|
| crypto-bullseye-zone/tax/scripts/serendb_store.py | list_projects, list_branches, list_databases, get_connection_string |
| alpaca/saas-short-trader/scripts/serendb_bootstrap.py | list_projects, create_project, list_branches, list_databases, create_database, get_connection_string |
| alpaca/sass-short-trader-delta-neutral/scripts/serendb_bootstrap.py | same as above |
| polymarket/bot/scripts/test_serendb_storage.py | all mocked URLs updated |

### Already correct (no changes needed)

prophet/prophet-growth-agent, prophet-adversarial-auditor, prophet-market-seeder — these bake `/publishers/seren-db` into their `api_base` default URL.

### Test coverage expanded

Tests now verify all 7 SerenDB files across the repo (not just polymarket/bot).

## Test plan

- [x] 16 route tests covering all 7 files
- [x] All 230 tests pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com