### PR TITLE
fix(polymarket-bot): reject wide-spread CLOB midpoints (#265)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -20,7 +20,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 
 # Import our modules
@@ -218,7 +218,6 @@ class TradingAgent:
         ranked = sorted(stale_gamma_filtered, key=score, reverse=True)
 
         # Filter out markets resolving too far in the future
-        from datetime import datetime, timezone
         now = datetime.now(timezone.utc)
         time_filtered = []
         for m in ranked:
@@ -573,7 +572,7 @@ class TradingAgent:
     def run_scan_cycle(self):
         """Run a single scan cycle"""
         print("=" * 60)
-        print(f"🔍 Polymarket Scan Starting - {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
+        print(f"🔍 Polymarket Scan Starting - {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC")
         print("=" * 60)
         print()
 

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -271,9 +271,17 @@ class PolymarketClient:
         else:
             return best_bid
 
-    def get_midpoint(self, token_id: str) -> float:
-        """Get midpoint price (average of best bid and ask)."""
+    def get_midpoint(self, token_id: str, max_spread: float = 0.50) -> float:
+        """Get midpoint price (average of best bid and ask).
+
+        Returns 0.0 when the book spread exceeds *max_spread* — a wide
+        spread (e.g. bid=0.001, ask=0.999 → spread=0.998) produces a
+        meaningless ~0.50 midpoint and must not overwrite a valid Gamma
+        price.
+        """
         best_bid, best_ask = self._get_book_levels(token_id)
         if best_bid and best_ask:
+            if best_ask - best_bid > max_spread:
+                return 0.0
             return (best_bid + best_ask) / 2.0
         return best_bid or best_ask

--- a/tests/test_wide_spread_midpoint.py
+++ b/tests/test_wide_spread_midpoint.py
@@ -1,0 +1,63 @@
+"""Verify get_midpoint rejects wide-spread CLOB books that produce
+meaningless ~0.50 midpoints.
+
+Root cause of issue #265: books with bid=0.001, ask=0.999 yield
+midpoint=0.50, which overwrites correct Gamma prices for low-
+probability markets (e.g. ceasefire at 0.75% displayed as 50%).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLIENT_PATH = "polymarket/bot/scripts/polymarket_client.py"
+
+
+def _source(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_get_midpoint_has_max_spread_guard() -> None:
+    """get_midpoint must reject books where ask - bid > max_spread."""
+    source = _source(CLIENT_PATH)
+    assert "max_spread" in source, (
+        "get_midpoint must accept a max_spread parameter"
+    )
+    # The guard must return 0.0 (falsy) so callers skip the midpoint
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "get_midpoint":
+            body_source = ast.get_source_segment(source, node)
+            assert "best_ask - best_bid > max_spread" in body_source, (
+                "get_midpoint must check spread width before computing midpoint"
+            )
+            assert "return 0.0" in body_source, (
+                "get_midpoint must return 0.0 for wide-spread books"
+            )
+            break
+    else:
+        pytest.fail("get_midpoint function not found in polymarket_client.py")
+
+
+def test_agent_enrichment_skips_zero_midpoint() -> None:
+    """agent.py must skip CLOB midpoint when get_midpoint returns 0.0.
+
+    The existing guard `if live_mid and 0.01 < live_mid < 0.99` already
+    rejects 0.0 (falsy).  Verify it is still present.
+    """
+    agent_src = _source("polymarket/bot/scripts/agent.py")
+    assert "if live_mid and 0.01 < live_mid < 0.99" in agent_src, (
+        "agent.py must gate CLOB midpoint overwrite on a truthy range check"
+    )
+
+
+def test_datetime_utcnow_removed() -> None:
+    """agent.py must not use deprecated datetime.utcnow()."""
+    agent_src = _source("polymarket/bot/scripts/agent.py")
+    assert "utcnow()" not in agent_src, (
+        "agent.py must use datetime.now(timezone.utc) instead of utcnow()"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: `get_midpoint()` in `polymarket_client.py` computed `(bid + ask) / 2` without checking spread width. For low-probability markets (e.g. ceasefire at 0.75%, FIFA longshots at 0.15%), the CLOB book has resting orders at bid=$0.001 and ask=$0.999, yielding midpoint=0.50. `agent.py:284` then overwrote the correct Gamma price with this garbage midpoint, causing **all 27 scan "opportunities" to be false positives**.
- **Fix**: Add `max_spread` guard (default 50%) to `get_midpoint()`. Wide-spread books return 0.0 (falsy), so the enrichment loop keeps the valid Gamma price.
- **Also**: Fixes deprecated `datetime.utcnow()` → `datetime.now(timezone.utc)` and removes redundant local import.

## Test plan

- [x] `test_get_midpoint_has_max_spread_guard` — verifies spread check exists in `get_midpoint()`
- [x] `test_agent_enrichment_skips_zero_midpoint` — verifies agent.py gates on truthy range check
- [x] `test_datetime_utcnow_removed` — verifies deprecated API removed
- [x] Full suite: 242 passed, 0 failed

Closes #265

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com