### PR TITLE
fix(polymarket): guard fallback_mid in all skills (#265)

### DIFF
--- a/polymarket/bot/scripts/polymarket_live.py
+++ b/polymarket/bot/scripts/polymarket_live.py
@@ -2212,7 +2212,11 @@ def inject_held_position_markets(
             best_ask = safe_float(book.get("best_ask"), 0.0)
             if not (0.0 < best_bid <= 1.0 and 0.0 < best_ask <= 1.0):
                 continue
-            midpoint = fetch_midpoint(token_id, fallback_mid=(best_bid + best_ask) / 2.0, timeout_seconds=timeout_seconds)
+            # Reject wide-spread books (e.g. bid=0.001, ask=0.999 → midpoint=0.50)
+            # as the naive midpoint is meaningless for illiquid markets.
+            spread = best_ask - best_bid
+            fallback_mid = (best_bid + best_ask) / 2.0 if spread <= 0.50 else 0.0
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
             end_ts = safe_int(book.get("end_date_iso"), 0) or safe_int(book.get("end_ts"), 0)
             seconds_to_res = max(0, end_ts - now_ts) if end_ts else 999999
             injected.append(

--- a/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py
@@ -2212,7 +2212,11 @@ def inject_held_position_markets(
             best_ask = safe_float(book.get("best_ask"), 0.0)
             if not (0.0 < best_bid <= 1.0 and 0.0 < best_ask <= 1.0):
                 continue
-            midpoint = fetch_midpoint(token_id, fallback_mid=(best_bid + best_ask) / 2.0, timeout_seconds=timeout_seconds)
+            # Reject wide-spread books (e.g. bid=0.001, ask=0.999 → midpoint=0.50)
+            # as the naive midpoint is meaningless for illiquid markets.
+            spread = best_ask - best_bid
+            fallback_mid = (best_bid + best_ask) / 2.0 if spread <= 0.50 else 0.0
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
             end_ts = safe_int(book.get("end_date_iso"), 0) or safe_int(book.get("end_ts"), 0)
             seconds_to_res = max(0, end_ts - now_ts) if end_ts else 999999
             injected.append(

--- a/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py
@@ -2212,7 +2212,11 @@ def inject_held_position_markets(
             best_ask = safe_float(book.get("best_ask"), 0.0)
             if not (0.0 < best_bid <= 1.0 and 0.0 < best_ask <= 1.0):
                 continue
-            midpoint = fetch_midpoint(token_id, fallback_mid=(best_bid + best_ask) / 2.0, timeout_seconds=timeout_seconds)
+            # Reject wide-spread books (e.g. bid=0.001, ask=0.999 → midpoint=0.50)
+            # as the naive midpoint is meaningless for illiquid markets.
+            spread = best_ask - best_bid
+            fallback_mid = (best_bid + best_ask) / 2.0 if spread <= 0.50 else 0.0
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
             end_ts = safe_int(book.get("end_date_iso"), 0) or safe_int(book.get("end_ts"), 0)
             seconds_to_res = max(0, end_ts - now_ts) if end_ts else 999999
             injected.append(

--- a/polymarket/maker-rebate-bot/scripts/polymarket_live.py
+++ b/polymarket/maker-rebate-bot/scripts/polymarket_live.py
@@ -2225,7 +2225,11 @@ def inject_held_position_markets(
             best_ask = safe_float(book.get("best_ask"), 0.0)
             if not (0.0 < best_bid <= 1.0 and 0.0 < best_ask <= 1.0):
                 continue
-            midpoint = fetch_midpoint(token_id, fallback_mid=(best_bid + best_ask) / 2.0, timeout_seconds=timeout_seconds)
+            # Reject wide-spread books (e.g. bid=0.001, ask=0.999 → midpoint=0.50)
+            # as the naive midpoint is meaningless for illiquid markets.
+            spread = best_ask - best_bid
+            fallback_mid = (best_bid + best_ask) / 2.0 if spread <= 0.50 else 0.0
+            midpoint = fetch_midpoint(token_id, fallback_mid=fallback_mid, timeout_seconds=timeout_seconds)
             end_ts = safe_int(book.get("end_date_iso"), 0) or safe_int(book.get("end_ts"), 0)
             seconds_to_res = max(0, end_ts - now_ts) if end_ts else 999999
             injected.append(

--- a/tests/test_wide_spread_fallback_mid.py
+++ b/tests/test_wide_spread_fallback_mid.py
@@ -1,0 +1,34 @@
+"""Verify all polymarket skills guard against wide-spread fallback midpoints.
+
+The fetch_midpoint callsites in polymarket_live.py compute a fallback_mid
+from (best_bid + best_ask) / 2.  Without a spread guard, books with
+bid=0.001 and ask=0.999 produce fallback_mid=0.50, poisoning downstream
+price signals.  Each skill must cap the fallback at spread <= 0.50.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+AFFECTED_SKILLS = [
+    "polymarket/bot/scripts/polymarket_live.py",
+    "polymarket/maker-rebate-bot/scripts/polymarket_live.py",
+    "polymarket/liquidity-paired-basis-maker/scripts/polymarket_live.py",
+    "polymarket/high-throughput-paired-basis-maker/scripts/polymarket_live.py",
+]
+
+
+@pytest.mark.parametrize("rel_path", AFFECTED_SKILLS)
+def test_fallback_mid_has_spread_guard(rel_path: str) -> None:
+    """Each polymarket_live.py must guard fallback_mid with a spread check."""
+    source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    assert "spread <= 0.50" in source or "spread <= 0.5" in source, (
+        f"{rel_path} must guard fallback_mid with a spread <= 0.50 check"
+    )
+    assert "else 0.0" in source, (
+        f"{rel_path} must return 0.0 fallback when spread is too wide"
+    )


### PR DESCRIPTION
## Summary

- Applies the wide-spread midpoint guard from #266 to the `fetch_midpoint` fallback path in `polymarket_live.py` across **all 4 Polymarket skills**
- When `best_ask - best_bid > 0.50`, the fallback midpoint is set to `0.0` instead of the naive `(bid + ask) / 2` which produces meaningless ~0.50 for illiquid books (bid=0.001, ask=0.999)
- Affected skills: bot, maker-rebate-bot, liquidity-paired-basis-maker, high-throughput-paired-basis-maker

## Test plan

- [x] `test_fallback_mid_has_spread_guard` (parametrized x4 skills)
- [x] Full suite: 246 passed, 0 failed

Related to #265

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com