### PR TITLE
feat(polymarket): add iterative scan loop with auto-parameter adjustment

### DIFF
--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -9,6 +9,14 @@
   "candidate_limit": 80,
   "analyze_limit": 30,
   "min_liquidity": 100.0,
+  "iteration": {
+    "max_iterations": 15,
+    "threshold_step": 0.01,
+    "min_threshold_floor": 0.02,
+    "annualized_return_step": 0.05,
+    "annualized_return_floor": 0.0,
+    "low_balance_threshold": 1.50
+  },
   "cron": {
     "runner_name": "",
     "machine_label": "",

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -578,6 +578,7 @@ class TradingAgent:
 
         # Check balances
         balances = self.check_balances()
+        self._last_serenbucks_balance = balances['serenbucks']
         print(f"Balances:")
         print(f"  SerenBucks: ${balances['serenbucks']:.2f}")
         print(f"  Polymarket: ${balances['polymarket']:.2f}")
@@ -619,7 +620,7 @@ class TradingAgent:
                 polymarket_balance=balances['polymarket'],
                 errors=['No markets returned from polymarket-data']
             )
-            return
+            return 0
 
         # Stage 2: Cheap heuristic ranking — no LLM
         print("Ranking candidates (no LLM)...")
@@ -689,6 +690,8 @@ class TradingAgent:
         print("=" * 60)
         print()
 
+        return len(opportunities)
+
 
 def _bootstrap_config_path(config_path: str) -> Path:
     path = Path(config_path)
@@ -745,9 +748,69 @@ def main():
         print(f"Error initializing agent: {e}")
         sys.exit(1)
 
-    # Run scan cycle
+    # Run iterative scan cycle
     try:
-        agent.run_scan_cycle()
+        iter_cfg = agent.config.get("iteration", {})
+        max_iterations = int(iter_cfg.get("max_iterations", 15))
+        threshold_step = float(iter_cfg.get("threshold_step", 0.01))
+        min_threshold_floor = float(iter_cfg.get("min_threshold_floor", 0.02))
+        annualized_return_step = float(iter_cfg.get("annualized_return_step", 0.05))
+        annualized_return_floor = float(iter_cfg.get("annualized_return_floor", 0.0))
+        low_balance_threshold = float(iter_cfg.get("low_balance_threshold", 1.50))
+
+        # Save original parameters so we can report cumulative deltas
+        original_mispricing_threshold = agent.mispricing_threshold
+        original_scan_limit = agent.scan_limit
+        original_min_annualized_return = agent.min_annualized_return
+
+        total_opportunities = 0
+
+        for iteration in range(1, max_iterations + 1):
+            print(f"\n>>> Iteration {iteration}/{max_iterations}  "
+                  f"mispricing_threshold={agent.mispricing_threshold:.4f}  "
+                  f"scan_limit={agent.scan_limit}  "
+                  f"min_annualized_return={agent.min_annualized_return:.4f}")
+
+            opportunities_found = agent.run_scan_cycle()
+            total_opportunities += (opportunities_found or 0)
+
+            print(f"<<< Iteration {iteration} result: {opportunities_found or 0} opportunities found")
+
+            if opportunities_found and opportunities_found > 0:
+                print(f"    Opportunities found — stopping iteration loop.")
+                break
+
+            # Check SerenBucks balance from the last scan cycle
+            serenbucks_balance = getattr(agent, '_last_serenbucks_balance', None)
+            if serenbucks_balance is not None and serenbucks_balance < low_balance_threshold:
+                print(f"    SerenBucks balance ${serenbucks_balance:.2f} < ${low_balance_threshold:.2f} — stopping iteration loop.")
+                break
+
+            # Progressively relax parameters based on iteration band
+            if iteration <= 5:
+                new_threshold = agent.mispricing_threshold - threshold_step
+                agent.mispricing_threshold = max(new_threshold, min_threshold_floor)
+                print(f"    Relaxed mispricing_threshold → {agent.mispricing_threshold:.4f}")
+            elif iteration <= 10:
+                agent.scan_limit += 100
+                print(f"    Expanded scan_limit → {agent.scan_limit}")
+            else:
+                new_annualized = agent.min_annualized_return - annualized_return_step
+                agent.min_annualized_return = max(new_annualized, annualized_return_floor)
+                print(f"    Relaxed min_annualized_return → {agent.min_annualized_return:.4f}")
+
+        # Cumulative summary
+        print()
+        print("=" * 60)
+        print("Iterative Scan Summary")
+        print("=" * 60)
+        print(f"  Iterations run:           {iteration}")
+        print(f"  Total opportunities:      {total_opportunities}")
+        print(f"  mispricing_threshold:     {original_mispricing_threshold:.4f} → {agent.mispricing_threshold:.4f}")
+        print(f"  scan_limit:               {original_scan_limit} → {agent.scan_limit}")
+        print(f"  min_annualized_return:    {original_min_annualized_return:.4f} → {agent.min_annualized_return:.4f}")
+        print("=" * 60)
+
     except KeyboardInterrupt:
         print("\n\nScan interrupted by user")
         sys.exit(0)

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -79,5 +79,9 @@
     "config_path": "config.json",
     "yes_live": false
   },
+  "iteration": {
+    "max_iterations": 15,
+    "annualized_return_hurdle": 0.25
+  },
   "markets": []
 }

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import os
@@ -2426,11 +2427,90 @@ def main() -> int:
         print(json.dumps(result, sort_keys=True))
         return 0 if result.get("status") == "ok" else 1
 
-    backtest = run_backtest(
-        config=config,
-        backtest_days=args.backtest_days,
-        backtest_file=args.backtest_file,
-    )
+    # --- Iterative backtest scan -------------------------------------------
+    iter_cfg = config.get("iteration", {}) if isinstance(config.get("iteration"), dict) else {}
+    max_iterations = int(iter_cfg.get("max_iterations", 15))
+    annualized_return_hurdle = float(iter_cfg.get("annualized_return_hurdle", 0.25))
+
+    # Save original config values that may be mutated during iteration.
+    saved_backtest_cfg = copy.deepcopy(config.get("backtest", {}))
+    orig_min_events = int(saved_backtest_cfg.get("min_events", 120))
+    orig_days = int(saved_backtest_cfg.get("days", 90))
+    orig_participation_rate = float(saved_backtest_cfg.get("participation_rate", 0.9))
+
+    best_backtest: dict[str, Any] | None = None
+    best_return_pct: float = -math.inf
+
+    for iteration in range(max_iterations):
+        backtest = run_backtest(
+            config=config,
+            backtest_days=args.backtest_days,
+            backtest_file=args.backtest_file,
+        )
+
+        if backtest.get("status") != "ok":
+            print(
+                f"[iter {iteration}] backtest failed with status={backtest.get('status')!r}",
+                file=sys.stderr,
+            )
+            # Keep best so far if we have one; stop iterating on error.
+            if best_backtest is None:
+                best_backtest = backtest
+            break
+
+        return_pct = _safe_float(backtest.get("results", {}).get("return_pct"), 0.0)
+
+        # Track the best result across all iterations.
+        if return_pct > best_return_pct:
+            best_return_pct = return_pct
+            best_backtest = backtest
+
+        # Determine which params were changed for logging.
+        cur_min_events = config.get("backtest", {}).get("min_events", orig_min_events)
+        cur_days = config.get("backtest", {}).get("days", orig_days)
+        cur_pr = config.get("backtest", {}).get("participation_rate", orig_participation_rate)
+        print(
+            f"[iter {iteration}] return_pct={return_pct:.4f} "
+            f"min_events={cur_min_events} days={cur_days} "
+            f"participation_rate={cur_pr:.2f}",
+            file=sys.stderr,
+        )
+
+        # Stop if hurdle is met.
+        if return_pct >= annualized_return_hurdle:
+            print(
+                f"[iter {iteration}] hurdle {annualized_return_hurdle} met, stopping.",
+                file=sys.stderr,
+            )
+            break
+
+        # Last iteration -- no more relaxation needed.
+        if iteration == max_iterations - 1:
+            break
+
+        # --- Relaxation strategy ---------------------------------------------
+        bt = config.setdefault("backtest", {})
+        if iteration < 5:
+            # Iterations 0-4 (1-5): reduce min_events by 10% per iteration.
+            new_min_events = max(20, int(orig_min_events * (0.9 ** (iteration + 1))))
+            bt["min_events"] = new_min_events
+        elif iteration < 10:
+            # Iterations 5-9 (6-10): widen days by 30 per iteration step.
+            steps = iteration - 5 + 1  # 1..5
+            new_days = min(365, orig_days + 30 * steps)
+            bt["days"] = new_days
+        else:
+            # Iterations 10-14 (11-15): reduce participation_rate by 0.05 per step.
+            steps = iteration - 10 + 1  # 1..5
+            new_pr = max(0.5, orig_participation_rate - 0.05 * steps)
+            bt["participation_rate"] = new_pr
+
+    # Restore original config values after the loop.
+    config["backtest"] = copy.deepcopy(saved_backtest_cfg)
+
+    backtest = best_backtest  # type: ignore[assignment]
+    # --- End iterative backtest scan ----------------------------------------
+
     if backtest.get("status") != "ok":
         print(json.dumps(backtest, sort_keys=True))
         return 1

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -79,5 +79,9 @@
     "config_path": "config.json",
     "yes_live": false
   },
+  "iteration": {
+    "max_iterations": 15,
+    "annualized_return_hurdle": 0.25
+  },
   "markets": []
 }

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import os
@@ -3031,11 +3032,94 @@ def main() -> int:
         return 0 if result.get("status") == "ok" else 1
 
     if args.run_type == "backtest":
-        result = run_backtest(
-            config=config,
-            backtest_file=args.backtest_file,
-            backtest_days_override=args.backtest_days,
-        )
+        # --- iterative scan loop -------------------------------------------
+        iter_cfg = config.get("iteration", {})
+        max_iterations = int(iter_cfg.get("max_iterations", 15))
+        annualized_return_hurdle = float(iter_cfg.get("annualized_return_hurdle", 0.25))
+
+        original_config = copy.deepcopy(config)
+        best_result = None
+        best_return_pct = -math.inf
+
+        for iteration in range(1, max_iterations + 1):
+            result = run_backtest(
+                config=config,
+                backtest_file=args.backtest_file,
+                backtest_days_override=args.backtest_days,
+            )
+
+            # Extract return_pct from the result
+            current_return_pct = -math.inf
+            if result.get("status") == "ok":
+                results_inner = result.get("results", {})
+                if isinstance(results_inner, dict):
+                    current_return_pct = float(results_inner.get("return_pct", -math.inf))
+
+            # Track best result
+            if current_return_pct > best_return_pct:
+                best_return_pct = current_return_pct
+                best_result = copy.deepcopy(result)
+
+            params_changed = []
+
+            # Stop conditions
+            if result.get("status") == "error":
+                print(
+                    f"[iter {iteration}/{max_iterations}] status=error, stopping",
+                    file=sys.stderr,
+                )
+                break
+            if current_return_pct >= annualized_return_hurdle * 100:
+                print(
+                    f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f} "
+                    f">= hurdle {annualized_return_hurdle * 100:.1f}, stopping",
+                    file=sys.stderr,
+                )
+                break
+            if iteration == max_iterations:
+                print(
+                    f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f}, "
+                    f"max iterations reached",
+                    file=sys.stderr,
+                )
+                break
+
+            # --- Relaxation strategy ----------------------------------------
+            bt = config.setdefault("backtest", {})
+            ms = config.setdefault("market_selection", {})
+
+            if iteration <= 5:
+                # Reduce min_history_points by 10% (floor 48)
+                cur = int(bt.get("min_history_points", 480))
+                new_val = max(48, int(cur * 0.9))
+                bt["min_history_points"] = new_val
+                params_changed.append(f"min_history_points={new_val}")
+            elif iteration <= 10:
+                # Widen backtest.days by 10 (cap 180)
+                cur = int(bt.get("days", 90))
+                new_val = min(180, cur + 10)
+                bt["days"] = new_val
+                params_changed.append(f"days={new_val}")
+            else:
+                # Widen market_selection.midpoint_band by 0.03 (min 0.15, max 0.45)
+                cur = float(ms.get("midpoint_band", 0.15))
+                new_val = min(0.45, max(0.15, cur + 0.03))
+                ms["midpoint_band"] = round(new_val, 2)
+                params_changed.append(f"midpoint_band={ms['midpoint_band']}")
+
+            print(
+                f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f}, "
+                f"relaxing: {', '.join(params_changed)}",
+                file=sys.stderr,
+            )
+
+        # Use the best result for final output
+        result = best_result if best_result is not None else result
+
+        # Restore config to original before applying updates
+        config = copy.deepcopy(original_config)
+        # --- end iterative scan loop ---------------------------------------
+
         if result.get("status") == "ok" and isinstance(result.get("config_updates"), dict):
             _apply_config_updates_in_place(config, result["config_updates"])
             try:

--- a/polymarket/tests/test_iterative_scan.py
+++ b/polymarket/tests/test_iterative_scan.py
@@ -1,0 +1,226 @@
+"""Tests for the iterative scan loop across all polymarket skills.
+
+Covers the core iteration contract:
+- Loop runs up to max_iterations when hurdle not met
+- Stops early on success (opportunities found / hurdle met)
+- Stops early on low SerenBucks balance
+- Progressively relaxes parameters per iteration band
+- Backward compatible: absent config defaults to 15 iterations
+"""
+
+import copy
+import json
+import sys
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# polymarket-bot: iterative scan loop
+# ---------------------------------------------------------------------------
+
+BOT_SCRIPTS = str(Path(__file__).resolve().parent.parent / "bot" / "scripts")
+
+
+@pytest.fixture(autouse=True)
+def _add_bot_scripts_to_path():
+    if BOT_SCRIPTS not in sys.path:
+        sys.path.insert(0, BOT_SCRIPTS)
+    yield
+    if BOT_SCRIPTS in sys.path:
+        sys.path.remove(BOT_SCRIPTS)
+
+
+def _make_bot_config(**overrides):
+    base = {
+        "bankroll": 100.0,
+        "mispricing_threshold": 0.08,
+        "max_kelly_fraction": 0.06,
+        "scan_interval_minutes": 10,
+        "max_positions": 10,
+        "stop_loss_bankroll": 0.0,
+        "scan_limit": 300,
+        "candidate_limit": 80,
+        "analyze_limit": 30,
+        "min_liquidity": 100.0,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBotIterativeLoop:
+    """Test the iterative scan loop in polymarket-bot main()."""
+
+    def test_stops_on_first_success(self, tmp_path):
+        """Loop breaks immediately when opportunities are found on iteration 1."""
+        config = _make_bot_config(iteration={"max_iterations": 15})
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with patch("agent.TradingAgent") as MockAgent, \
+             patch("sys.argv", ["agent.py", "--config", str(config_file), "--dry-run"]):
+            mock_instance = MagicMock()
+            mock_instance.config = config
+            mock_instance.mispricing_threshold = 0.08
+            mock_instance.scan_limit = 300
+            mock_instance.min_annualized_return = 0.25
+            mock_instance._last_serenbucks_balance = 20.0
+            mock_instance.run_scan_cycle.return_value = 3  # found opportunities
+            MockAgent.return_value = mock_instance
+
+            from agent import main
+            main()
+
+            assert mock_instance.run_scan_cycle.call_count == 1
+
+    def test_iterates_on_zero_opportunities(self, tmp_path):
+        """Loop continues when no opportunities found, up to max_iterations."""
+        config = _make_bot_config(iteration={"max_iterations": 3})
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with patch("agent.TradingAgent") as MockAgent, \
+             patch("sys.argv", ["agent.py", "--config", str(config_file), "--dry-run"]):
+            mock_instance = MagicMock()
+            mock_instance.config = config
+            mock_instance.mispricing_threshold = 0.08
+            mock_instance.scan_limit = 300
+            mock_instance.min_annualized_return = 0.25
+            mock_instance._last_serenbucks_balance = 20.0
+            mock_instance.run_scan_cycle.return_value = 0
+            MockAgent.return_value = mock_instance
+
+            from agent import main
+            main()
+
+            assert mock_instance.run_scan_cycle.call_count == 3
+
+    def test_stops_on_low_balance(self, tmp_path):
+        """Loop breaks when SerenBucks balance drops below threshold."""
+        config = _make_bot_config(iteration={"max_iterations": 15, "low_balance_threshold": 5.0})
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with patch("agent.TradingAgent") as MockAgent, \
+             patch("sys.argv", ["agent.py", "--config", str(config_file), "--dry-run"]):
+            mock_instance = MagicMock()
+            mock_instance.config = config
+            mock_instance.mispricing_threshold = 0.08
+            mock_instance.scan_limit = 300
+            mock_instance.min_annualized_return = 0.25
+            mock_instance._last_serenbucks_balance = 2.0  # below threshold
+            mock_instance.run_scan_cycle.return_value = 0
+            MockAgent.return_value = mock_instance
+
+            from agent import main
+            main()
+
+            # Should stop after first iteration due to low balance
+            assert mock_instance.run_scan_cycle.call_count == 1
+
+    def test_relaxes_mispricing_threshold_in_band_1(self, tmp_path):
+        """Iterations 1-5 lower mispricing_threshold."""
+        config = _make_bot_config(iteration={"max_iterations": 3, "threshold_step": 0.01})
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with patch("agent.TradingAgent") as MockAgent, \
+             patch("sys.argv", ["agent.py", "--config", str(config_file), "--dry-run"]):
+            mock_instance = MagicMock()
+            mock_instance.config = config
+            mock_instance.mispricing_threshold = 0.08
+            mock_instance.scan_limit = 300
+            mock_instance.min_annualized_return = 0.25
+            mock_instance._last_serenbucks_balance = 20.0
+            mock_instance.run_scan_cycle.return_value = 0
+            MockAgent.return_value = mock_instance
+
+            from agent import main
+            main()
+
+            # After 3 iterations (all in band 1-5), threshold relaxed after each:
+            # 0.08 - 3*0.01 = 0.05
+            assert mock_instance.mispricing_threshold == pytest.approx(0.05, abs=0.001)
+
+    def test_run_scan_cycle_returns_opportunity_count(self, tmp_path):
+        """run_scan_cycle() returns int count of opportunities."""
+        # This tests the return value contract, not the full scan
+        from agent import TradingAgent
+
+        config = _make_bot_config()
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with patch.object(TradingAgent, "__init__", lambda self, *a, **kw: None):
+            agent = TradingAgent.__new__(TradingAgent)
+            agent.dry_run = True
+            agent.config = config
+            agent.bankroll = 100.0
+            agent.mispricing_threshold = 0.08
+            agent.max_kelly_fraction = 0.06
+            agent.max_positions = 10
+            agent.stop_loss_bankroll = 0.0
+            agent.min_annualized_return = 0.25
+            agent.max_resolution_days = 180
+            agent.min_exit_bid_depth_ratio = 0.5
+            agent.scan_limit = 300
+            agent.candidate_limit = 80
+            agent.analyze_limit = 30
+            agent.min_liquidity = 100.0
+            agent.stale_price_demotion = 0.1
+
+            # Mock dependencies
+            agent.seren = MagicMock()
+            agent.polymarket = MagicMock()
+            agent.positions = MagicMock()
+            agent.positions.sync_with_polymarket.return_value = {"added": 0, "removed": 0, "updated": 0}
+            agent.positions.get_all_positions.return_value = []
+            agent.logger = MagicMock()
+            agent.storage = None
+
+            # Mock scan_markets to return empty
+            agent.scan_markets = MagicMock(return_value=[])
+
+            # Mock check_balances
+            agent.check_balances = MagicMock(return_value={"serenbucks": 20.0, "polymarket": 100.0})
+
+            result = agent.run_scan_cycle()
+            assert isinstance(result, int)
+            assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# liquidity-paired-basis-maker: iterative backtest loop
+# ---------------------------------------------------------------------------
+
+LPBM_SCRIPTS = str(Path(__file__).resolve().parent.parent / "liquidity-paired-basis-maker" / "scripts")
+
+
+class TestLPBMIterativeLoop:
+    """Test iteration loop in liquidity-paired-basis-maker main()."""
+
+    def test_config_example_has_iteration_block(self):
+        config_path = Path(__file__).resolve().parent.parent / "liquidity-paired-basis-maker" / "config.example.json"
+        config = json.loads(config_path.read_text())
+        assert "iteration" in config
+        assert config["iteration"]["max_iterations"] == 15
+        assert config["iteration"]["annualized_return_hurdle"] == 0.25
+
+
+# ---------------------------------------------------------------------------
+# maker-rebate-bot: iterative backtest loop
+# ---------------------------------------------------------------------------
+
+MRB_SCRIPTS = str(Path(__file__).resolve().parent.parent / "maker-rebate-bot" / "scripts")
+
+
+class TestMRBIterativeLoop:
+    """Test iteration loop in maker-rebate-bot main()."""
+
+    def test_config_example_has_iteration_block(self):
+        config_path = Path(__file__).resolve().parent.parent / "maker-rebate-bot" / "config.example.json"
+        config = json.loads(config_path.read_text())
+        assert "iteration" in config
+        assert config["iteration"]["max_iterations"] == 15
+        assert config["iteration"]["annualized_return_hurdle"] == 0.25


### PR DESCRIPTION
## Summary
- All three Polymarket skills now loop up to 15 iterations when the annualized return hurdle is not met
- Progressively relaxes scan parameters instead of asking the user to manually adjust config
- Stops early on success (opportunities found) or when SerenBucks are exhausted
- Backward compatible: absent iteration config defaults to 15 iterations

## Changes

**polymarket-bot:**
- `run_scan_cycle()` returns opportunity count (was `None`)
- `main()` wraps scan in iteration loop with 3 relaxation bands
- Band 1 (iter 1-5): lower `mispricing_threshold`
- Band 2 (iter 6-10): expand `scan_limit` (pagination)
- Band 3 (iter 11-15): lower `min_annualized_return`

**liquidity-paired-basis-maker:**
- `main()` wraps `run_backtest()` in iteration loop
- Relaxes `min_events`, backtest `days`, `participation_rate`
- Tracks best result across iterations

**maker-rebate-bot:**
- `main()` wraps `run_backtest()` in iteration loop
- Relaxes `min_history_points`, backtest `days`, `midpoint_band`
- Tracks best result across iterations

All three `config.example.json` files updated with `"iteration"` section.

## Test plan
- [x] 7 new tests in `polymarket/tests/test_iterative_scan.py` (all passing)
- [x] Stops on first success (1 iteration)
- [x] Iterates to max when no opportunities
- [x] Stops on low SerenBucks balance
- [x] Threshold relaxation verified
- [x] `run_scan_cycle()` return contract verified
- [x] Config example schema validated for LPBM and MRB
- [x] All pre-existing tests unaffected (36 pre-existing failures on main confirmed)

Closes #268

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
