### PR TITLE
fix(polymarket): revert duplicate iteration loop from LPBM and MRB

### DIFF
--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -79,9 +79,5 @@
     "config_path": "config.json",
     "yes_live": false
   },
-  "iteration": {
-    "max_iterations": 15,
-    "annualized_return_hurdle": 0.25
-  },
   "markets": []
 }

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import copy
 import json
 import math
 import os
@@ -2427,90 +2426,11 @@ def main() -> int:
         print(json.dumps(result, sort_keys=True))
         return 0 if result.get("status") == "ok" else 1
 
-    # --- Iterative backtest scan -------------------------------------------
-    iter_cfg = config.get("iteration", {}) if isinstance(config.get("iteration"), dict) else {}
-    max_iterations = int(iter_cfg.get("max_iterations", 15))
-    annualized_return_hurdle = float(iter_cfg.get("annualized_return_hurdle", 0.25))
-
-    # Save original config values that may be mutated during iteration.
-    saved_backtest_cfg = copy.deepcopy(config.get("backtest", {}))
-    orig_min_events = int(saved_backtest_cfg.get("min_events", 120))
-    orig_days = int(saved_backtest_cfg.get("days", 90))
-    orig_participation_rate = float(saved_backtest_cfg.get("participation_rate", 0.9))
-
-    best_backtest: dict[str, Any] | None = None
-    best_return_pct: float = -math.inf
-
-    for iteration in range(max_iterations):
-        backtest = run_backtest(
-            config=config,
-            backtest_days=args.backtest_days,
-            backtest_file=args.backtest_file,
-        )
-
-        if backtest.get("status") != "ok":
-            print(
-                f"[iter {iteration}] backtest failed with status={backtest.get('status')!r}",
-                file=sys.stderr,
-            )
-            # Keep best so far if we have one; stop iterating on error.
-            if best_backtest is None:
-                best_backtest = backtest
-            break
-
-        return_pct = _safe_float(backtest.get("results", {}).get("return_pct"), 0.0)
-
-        # Track the best result across all iterations.
-        if return_pct > best_return_pct:
-            best_return_pct = return_pct
-            best_backtest = backtest
-
-        # Determine which params were changed for logging.
-        cur_min_events = config.get("backtest", {}).get("min_events", orig_min_events)
-        cur_days = config.get("backtest", {}).get("days", orig_days)
-        cur_pr = config.get("backtest", {}).get("participation_rate", orig_participation_rate)
-        print(
-            f"[iter {iteration}] return_pct={return_pct:.4f} "
-            f"min_events={cur_min_events} days={cur_days} "
-            f"participation_rate={cur_pr:.2f}",
-            file=sys.stderr,
-        )
-
-        # Stop if hurdle is met.
-        if return_pct >= annualized_return_hurdle:
-            print(
-                f"[iter {iteration}] hurdle {annualized_return_hurdle} met, stopping.",
-                file=sys.stderr,
-            )
-            break
-
-        # Last iteration -- no more relaxation needed.
-        if iteration == max_iterations - 1:
-            break
-
-        # --- Relaxation strategy ---------------------------------------------
-        bt = config.setdefault("backtest", {})
-        if iteration < 5:
-            # Iterations 0-4 (1-5): reduce min_events by 10% per iteration.
-            new_min_events = max(20, int(orig_min_events * (0.9 ** (iteration + 1))))
-            bt["min_events"] = new_min_events
-        elif iteration < 10:
-            # Iterations 5-9 (6-10): widen days by 30 per iteration step.
-            steps = iteration - 5 + 1  # 1..5
-            new_days = min(365, orig_days + 30 * steps)
-            bt["days"] = new_days
-        else:
-            # Iterations 10-14 (11-15): reduce participation_rate by 0.05 per step.
-            steps = iteration - 10 + 1  # 1..5
-            new_pr = max(0.5, orig_participation_rate - 0.05 * steps)
-            bt["participation_rate"] = new_pr
-
-    # Restore original config values after the loop.
-    config["backtest"] = copy.deepcopy(saved_backtest_cfg)
-
-    backtest = best_backtest  # type: ignore[assignment]
-    # --- End iterative backtest scan ----------------------------------------
-
+    backtest = run_backtest(
+        config=config,
+        backtest_days=args.backtest_days,
+        backtest_file=args.backtest_file,
+    )
     if backtest.get("status") != "ok":
         print(json.dumps(backtest, sort_keys=True))
         return 1

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -79,9 +79,5 @@
     "config_path": "config.json",
     "yes_live": false
   },
-  "iteration": {
-    "max_iterations": 15,
-    "annualized_return_hurdle": 0.25
-  },
   "markets": []
 }

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import copy
 import json
 import math
 import os
@@ -3032,94 +3031,11 @@ def main() -> int:
         return 0 if result.get("status") == "ok" else 1
 
     if args.run_type == "backtest":
-        # --- iterative scan loop -------------------------------------------
-        iter_cfg = config.get("iteration", {})
-        max_iterations = int(iter_cfg.get("max_iterations", 15))
-        annualized_return_hurdle = float(iter_cfg.get("annualized_return_hurdle", 0.25))
-
-        original_config = copy.deepcopy(config)
-        best_result = None
-        best_return_pct = -math.inf
-
-        for iteration in range(1, max_iterations + 1):
-            result = run_backtest(
-                config=config,
-                backtest_file=args.backtest_file,
-                backtest_days_override=args.backtest_days,
-            )
-
-            # Extract return_pct from the result
-            current_return_pct = -math.inf
-            if result.get("status") == "ok":
-                results_inner = result.get("results", {})
-                if isinstance(results_inner, dict):
-                    current_return_pct = float(results_inner.get("return_pct", -math.inf))
-
-            # Track best result
-            if current_return_pct > best_return_pct:
-                best_return_pct = current_return_pct
-                best_result = copy.deepcopy(result)
-
-            params_changed = []
-
-            # Stop conditions
-            if result.get("status") == "error":
-                print(
-                    f"[iter {iteration}/{max_iterations}] status=error, stopping",
-                    file=sys.stderr,
-                )
-                break
-            if current_return_pct >= annualized_return_hurdle * 100:
-                print(
-                    f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f} "
-                    f">= hurdle {annualized_return_hurdle * 100:.1f}, stopping",
-                    file=sys.stderr,
-                )
-                break
-            if iteration == max_iterations:
-                print(
-                    f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f}, "
-                    f"max iterations reached",
-                    file=sys.stderr,
-                )
-                break
-
-            # --- Relaxation strategy ----------------------------------------
-            bt = config.setdefault("backtest", {})
-            ms = config.setdefault("market_selection", {})
-
-            if iteration <= 5:
-                # Reduce min_history_points by 10% (floor 48)
-                cur = int(bt.get("min_history_points", 480))
-                new_val = max(48, int(cur * 0.9))
-                bt["min_history_points"] = new_val
-                params_changed.append(f"min_history_points={new_val}")
-            elif iteration <= 10:
-                # Widen backtest.days by 10 (cap 180)
-                cur = int(bt.get("days", 90))
-                new_val = min(180, cur + 10)
-                bt["days"] = new_val
-                params_changed.append(f"days={new_val}")
-            else:
-                # Widen market_selection.midpoint_band by 0.03 (min 0.15, max 0.45)
-                cur = float(ms.get("midpoint_band", 0.15))
-                new_val = min(0.45, max(0.15, cur + 0.03))
-                ms["midpoint_band"] = round(new_val, 2)
-                params_changed.append(f"midpoint_band={ms['midpoint_band']}")
-
-            print(
-                f"[iter {iteration}/{max_iterations}] return_pct={current_return_pct:.2f}, "
-                f"relaxing: {', '.join(params_changed)}",
-                file=sys.stderr,
-            )
-
-        # Use the best result for final output
-        result = best_result if best_result is not None else result
-
-        # Restore config to original before applying updates
-        config = copy.deepcopy(original_config)
-        # --- end iterative scan loop ---------------------------------------
-
+        result = run_backtest(
+            config=config,
+            backtest_file=args.backtest_file,
+            backtest_days_override=args.backtest_days,
+        )
         if result.get("status") == "ok" and isinstance(result.get("config_updates"), dict):
             _apply_config_updates_in_place(config, result["config_updates"])
             try:

--- a/polymarket/tests/test_iterative_scan.py
+++ b/polymarket/tests/test_iterative_scan.py
@@ -191,36 +191,34 @@ class TestBotIterativeLoop:
 
 
 # ---------------------------------------------------------------------------
-# liquidity-paired-basis-maker: iterative backtest loop
+# liquidity-paired-basis-maker: PR #150 optimization loop (pre-existing)
 # ---------------------------------------------------------------------------
 
-LPBM_SCRIPTS = str(Path(__file__).resolve().parent.parent / "liquidity-paired-basis-maker" / "scripts")
 
+class TestLPBMOptimizationExists:
+    """Verify PR #150 auto-tune optimization loop is present in LPBM."""
 
-class TestLPBMIterativeLoop:
-    """Test iteration loop in liquidity-paired-basis-maker main()."""
-
-    def test_config_example_has_iteration_block(self):
+    def test_config_example_has_optimization_block(self):
         config_path = Path(__file__).resolve().parent.parent / "liquidity-paired-basis-maker" / "config.example.json"
         config = json.loads(config_path.read_text())
-        assert "iteration" in config
-        assert config["iteration"]["max_iterations"] == 15
-        assert config["iteration"]["annualized_return_hurdle"] == 0.25
+        backtest = config.get("backtest", {})
+        optimization = backtest.get("optimization", {})
+        assert "optimization" in backtest, "PR #150 optimization block missing from config"
+        assert optimization.get("target_return_pct") == 25.0
 
 
 # ---------------------------------------------------------------------------
-# maker-rebate-bot: iterative backtest loop
+# maker-rebate-bot: PR #150 optimization loop (pre-existing)
 # ---------------------------------------------------------------------------
 
-MRB_SCRIPTS = str(Path(__file__).resolve().parent.parent / "maker-rebate-bot" / "scripts")
 
+class TestMRBOptimizationExists:
+    """Verify PR #150 auto-tune optimization loop is present in MRB."""
 
-class TestMRBIterativeLoop:
-    """Test iteration loop in maker-rebate-bot main()."""
-
-    def test_config_example_has_iteration_block(self):
+    def test_config_example_has_optimization_block(self):
         config_path = Path(__file__).resolve().parent.parent / "maker-rebate-bot" / "config.example.json"
         config = json.loads(config_path.read_text())
-        assert "iteration" in config
-        assert config["iteration"]["max_iterations"] == 15
-        assert config["iteration"]["annualized_return_hurdle"] == 0.25
+        backtest = config.get("backtest", {})
+        optimization = backtest.get("optimization", {})
+        assert "optimization" in backtest, "PR #150 optimization block missing from config"
+        assert optimization.get("target_return_pct") == 25.0


### PR DESCRIPTION
## Summary
- Reverts duplicate iteration loop added to LPBM and MRB by PR #269
- PR #150 already implemented the auto-tune optimization loop for those two skills
- PR #269 unknowingly added a second iteration layer on top, causing nested loops
- Keeps the polymarket-bot iteration loop (PR #150 did not cover that skill)

## What went wrong
PR #269 searched for prior iteration work but missed PR #150 / issue #149 (closed). The duplicate iteration logic was merged to main for LPBM and MRB.

## What this PR does
- Restores LPBM and MRB agent.py + config to their pre-#269 state (which includes PR #150 optimization)
- Updates test_iterative_scan.py to validate PR #150 optimization blocks instead of the reverted config
- Leaves polymarket-bot changes from #269 intact (that skill genuinely needed the iteration loop)

## Test plan
- [x] 7 tests pass (5 bot tests + 2 config validation tests for LPBM/MRB)
- [x] LPBM and MRB files restored to exact pre-#269 state
- [x] All files parse cleanly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
