### PR TITLE
feat(prophet): add testnet USDC faucet to all prophet skills

### DIFF
--- a/prophet/prophet-adversarial-auditor/.env.example
+++ b/prophet/prophet-adversarial-auditor/.env.example
@@ -1,4 +1,5 @@
 # Generated SkillForge environment template for prophet-adversarial-auditor
 SEREN_API_KEY=
 PROPHET_SESSION_TOKEN=
+PROPHET_TESTNET_MODE=
 

--- a/prophet/prophet-adversarial-auditor/SKILL.md
+++ b/prophet/prophet-adversarial-auditor/SKILL.md
@@ -61,6 +61,28 @@ The runtime now auto-bootstraps Prophet storage on first run:
 
 If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
 
+## Testnet Mode
+
+To run against Prophet Testnet instead of production, enable testnet in your config:
+
+```json
+{
+  "testnet": {
+    "enabled": true,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  }
+}
+```
+
+Or set the environment variable:
+
+```bash
+export PROPHET_TESTNET_MODE=true
+```
+
+The USDC faucet contract at `0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06` can be used to mint fake USDC for testnet wallets. When testnet mode is active, the run output includes a `testnet` block with the faucet address and testnet base URL.
+
 ## Minimal Run
 
 ```bash

--- a/prophet/prophet-adversarial-auditor/config.example.json
+++ b/prophet/prophet-adversarial-auditor/config.example.json
@@ -19,5 +19,10 @@
     "severity_threshold": "medium",
     "strict_mode": true
   },
+  "testnet": {
+    "enabled": false,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  },
   "skill": "prophet-adversarial-auditor"
 }

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -20,6 +20,8 @@ DEFAULT_DATABASE_NAME = "prophet"
 DEFAULT_SCHEMA_NAME = "prophet_adversarial_auditor"
 DEFAULT_REGION = "aws-us-east-2"
 DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+DEFAULT_PROPHET_TESTNET_BASE_URL = "https://testnet.prophetmarket.ai"
+PROPHET_TESTNET_USDC_FAUCET = "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
 SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
 AVAILABLE_CONNECTORS = ["storage"]
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
@@ -431,6 +433,18 @@ def validate_prophet_access(config: dict) -> dict:
     }
 
 
+def resolve_testnet_config(config: dict) -> Optional[dict]:
+    testnet_cfg = config.get("testnet") if isinstance(config.get("testnet"), dict) else {}
+    enabled = _bool(testnet_cfg.get("enabled") or os.getenv("PROPHET_TESTNET_MODE"), False)
+    if not enabled:
+        return None
+    return {
+        "enabled": True,
+        "base_url": str(testnet_cfg.get("base_url") or os.getenv("PROPHET_TESTNET_BASE_URL") or DEFAULT_PROPHET_TESTNET_BASE_URL),
+        "usdc_faucet": str(testnet_cfg.get("usdc_faucet") or PROPHET_TESTNET_USDC_FAUCET),
+    }
+
+
 def run_once(config: dict, dry_run: bool) -> dict:
     inputs = _config_inputs(config)
     command = _normalize_command(inputs.get("command"))
@@ -472,6 +486,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
             "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
         }
 
+    testnet = resolve_testnet_config(config)
+
     result = {
         "status": "ok",
         "skill": "prophet-adversarial-auditor",
@@ -485,6 +501,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "severity_threshold": severity_threshold,
         "include_loss_hypotheses": include_loss_hypotheses,
     }
+    if testnet:
+        result["testnet"] = testnet
     if command == "run":
         result["analysis_mode"] = "dry-run" if dry_run else "live"
     return result

--- a/prophet/prophet-adversarial-auditor/tests/test_smoke.py
+++ b/prophet/prophet-adversarial-auditor/tests/test_smoke.py
@@ -154,6 +154,20 @@ def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monke
     assert any("CREATE SCHEMA IF NOT EXISTS prophet_adversarial_auditor" in stmt for stmt in executed)
 
 
+def test_resolve_testnet_config_returns_faucet_when_enabled(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.delenv("PROPHET_TESTNET_MODE", raising=False)
+
+    assert agent.resolve_testnet_config({}) is None
+    assert agent.resolve_testnet_config({"testnet": {"enabled": False}}) is None
+
+    result = agent.resolve_testnet_config({"testnet": {"enabled": True}})
+    assert result is not None
+    assert result["enabled"] is True
+    assert result["usdc_faucet"] == "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+    assert result["base_url"] == "https://testnet.prophetmarket.ai"
+
+
 def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
     agent = _load_agent_module()
 

--- a/prophet/prophet-growth-agent/.env.example
+++ b/prophet/prophet-growth-agent/.env.example
@@ -1,4 +1,5 @@
 # Generated SkillForge environment template for prophet-growth-agent
 SEREN_API_KEY=
 PROPHET_SESSION_TOKEN=
+PROPHET_TESTNET_MODE=
 

--- a/prophet/prophet-growth-agent/SKILL.md
+++ b/prophet/prophet-growth-agent/SKILL.md
@@ -60,6 +60,28 @@ The runtime now auto-bootstraps Prophet storage on first run:
 
 If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
 
+## Testnet Mode
+
+To run against Prophet Testnet instead of production, enable testnet in your config:
+
+```json
+{
+  "testnet": {
+    "enabled": true,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  }
+}
+```
+
+Or set the environment variable:
+
+```bash
+export PROPHET_TESTNET_MODE=true
+```
+
+The USDC faucet contract at `0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06` can be used to mint fake USDC for testnet wallets. When testnet mode is active, the run output includes a `testnet` block with the faucet address and testnet base URL.
+
 ## Minimal Run
 
 ```bash

--- a/prophet/prophet-growth-agent/config.example.json
+++ b/prophet/prophet-growth-agent/config.example.json
@@ -19,5 +19,10 @@
     "strict_mode": true,
     "weekly_target_markets": 3
   },
+  "testnet": {
+    "enabled": false,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  },
   "skill": "prophet-growth-agent"
 }

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -20,6 +20,8 @@ DEFAULT_DATABASE_NAME = "prophet"
 DEFAULT_SCHEMA_NAME = "prophet_growth_agent"
 DEFAULT_REGION = "aws-us-east-2"
 DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+DEFAULT_PROPHET_TESTNET_BASE_URL = "https://testnet.prophetmarket.ai"
+PROPHET_TESTNET_USDC_FAUCET = "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
 SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
 AVAILABLE_CONNECTORS = ["storage"]
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
@@ -431,6 +433,18 @@ def validate_prophet_access(config: dict) -> dict:
     }
 
 
+def resolve_testnet_config(config: dict) -> Optional[dict]:
+    testnet_cfg = config.get("testnet") if isinstance(config.get("testnet"), dict) else {}
+    enabled = _bool(testnet_cfg.get("enabled") or os.getenv("PROPHET_TESTNET_MODE"), False)
+    if not enabled:
+        return None
+    return {
+        "enabled": True,
+        "base_url": str(testnet_cfg.get("base_url") or os.getenv("PROPHET_TESTNET_BASE_URL") or DEFAULT_PROPHET_TESTNET_BASE_URL),
+        "usdc_faucet": str(testnet_cfg.get("usdc_faucet") or PROPHET_TESTNET_USDC_FAUCET),
+    }
+
+
 def run_once(config: dict, dry_run: bool) -> dict:
     inputs = _config_inputs(config)
     command = _normalize_command(inputs.get("command"))
@@ -472,6 +486,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
             "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
         }
 
+    testnet = resolve_testnet_config(config)
+
     result = {
         "status": "ok",
         "skill": "prophet-growth-agent",
@@ -485,6 +501,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "weekly_target_markets": weekly_target_markets,
         "reminder_enabled": reminder_enabled,
     }
+    if testnet:
+        result["testnet"] = testnet
     if command == "run":
         result["follow_up_mode"] = "dry-run" if dry_run else "live"
     return result

--- a/prophet/prophet-growth-agent/tests/test_smoke.py
+++ b/prophet/prophet-growth-agent/tests/test_smoke.py
@@ -154,6 +154,20 @@ def test_ensure_storage_bootstraps_schema_when_seren_resources_are_missing(monke
     assert any("CREATE SCHEMA IF NOT EXISTS prophet_growth_agent" in stmt for stmt in executed)
 
 
+def test_resolve_testnet_config_returns_faucet_when_enabled(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.delenv("PROPHET_TESTNET_MODE", raising=False)
+
+    assert agent.resolve_testnet_config({}) is None
+    assert agent.resolve_testnet_config({"testnet": {"enabled": False}}) is None
+
+    result = agent.resolve_testnet_config({"testnet": {"enabled": True}})
+    assert result is not None
+    assert result["enabled"] is True
+    assert result["usdc_faucet"] == "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+    assert result["base_url"] == "https://testnet.prophetmarket.ai"
+
+
 def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
     agent = _load_agent_module()
 

--- a/prophet/prophet-market-seeder/.env.example
+++ b/prophet/prophet-market-seeder/.env.example
@@ -1,4 +1,5 @@
 # Generated SkillForge environment template for prophet-market-seeder
 SEREN_API_KEY=
 PROPHET_SESSION_TOKEN=
+PROPHET_TESTNET_MODE=
 

--- a/prophet/prophet-market-seeder/SKILL.md
+++ b/prophet/prophet-market-seeder/SKILL.md
@@ -62,6 +62,28 @@ The runtime now auto-bootstraps Prophet storage on first run:
 
 If `SEREN_API_KEY` is missing, the runtime does not pause for DB setup questions. It fails immediately with a setup message that points the user to `https://docs.serendb.com/skills.md`.
 
+## Testnet Mode
+
+To run against Prophet Testnet instead of production, enable testnet in your config:
+
+```json
+{
+  "testnet": {
+    "enabled": true,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  }
+}
+```
+
+Or set the environment variable:
+
+```bash
+export PROPHET_TESTNET_MODE=true
+```
+
+The USDC faucet contract at `0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06` can be used to mint fake USDC for testnet wallets. When testnet mode is active, the run output includes a `testnet` block with the faucet address and testnet base URL.
+
 ## Minimal Run
 
 ```bash

--- a/prophet/prophet-market-seeder/config.example.json
+++ b/prophet/prophet-market-seeder/config.example.json
@@ -19,5 +19,10 @@
     "strict_mode": true,
     "submit_limit": 3
   },
+  "testnet": {
+    "enabled": false,
+    "base_url": "https://testnet.prophetmarket.ai",
+    "usdc_faucet": "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+  },
   "skill": "prophet-market-seeder"
 }

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -20,6 +20,8 @@ DEFAULT_DATABASE_NAME = "prophet"
 DEFAULT_SCHEMA_NAME = "prophet_market_seeder"
 DEFAULT_REGION = "aws-us-east-2"
 DEFAULT_PROPHET_BASE_URL = "https://app.prophetmarket.ai"
+DEFAULT_PROPHET_TESTNET_BASE_URL = "https://testnet.prophetmarket.ai"
+PROPHET_TESTNET_USDC_FAUCET = "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
 SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
 AVAILABLE_CONNECTORS = ["storage"]
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
@@ -432,6 +434,18 @@ def validate_prophet_access(config: dict) -> dict:
     }
 
 
+def resolve_testnet_config(config: dict) -> Optional[dict]:
+    testnet_cfg = config.get("testnet") if isinstance(config.get("testnet"), dict) else {}
+    enabled = _bool(testnet_cfg.get("enabled") or os.getenv("PROPHET_TESTNET_MODE"), False)
+    if not enabled:
+        return None
+    return {
+        "enabled": True,
+        "base_url": str(testnet_cfg.get("base_url") or os.getenv("PROPHET_TESTNET_BASE_URL") or DEFAULT_PROPHET_TESTNET_BASE_URL),
+        "usdc_faucet": str(testnet_cfg.get("usdc_faucet") or PROPHET_TESTNET_USDC_FAUCET),
+    }
+
+
 def run_once(config: dict, dry_run: bool) -> dict:
     inputs = _config_inputs(config)
     command = _normalize_command(inputs.get("command"))
@@ -465,6 +479,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
             "token_source": "localStorage['privy:token'] from an authenticated Prophet browser session",
         }
 
+    testnet = resolve_testnet_config(config)
+
     run_summary = {
         "status": "ok",
         "skill": "prophet-market-seeder",
@@ -477,6 +493,8 @@ def run_once(config: dict, dry_run: bool) -> dict:
         "limits": {"candidate_limit": candidate_limit, "submit_limit": submit_limit},
         "referral_code": referral_code,
     }
+    if testnet:
+        run_summary["testnet"] = testnet
     if command == "run":
         run_summary["submission_mode"] = "dry-run" if dry_run else "live"
         run_summary["selected_candidates"] = min(candidate_limit, submit_limit)

--- a/prophet/prophet-market-seeder/tests/test_smoke.py
+++ b/prophet/prophet-market-seeder/tests/test_smoke.py
@@ -166,6 +166,20 @@ def test_storage_bootstrap_sql_reads_checked_in_schema_file() -> None:
     assert any("CREATE TABLE IF NOT EXISTS prophet_market_seeder.artifacts" in stmt for stmt in statements)
 
 
+def test_resolve_testnet_config_returns_faucet_when_enabled(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.delenv("PROPHET_TESTNET_MODE", raising=False)
+
+    assert agent.resolve_testnet_config({}) is None
+    assert agent.resolve_testnet_config({"testnet": {"enabled": False}}) is None
+
+    result = agent.resolve_testnet_config({"testnet": {"enabled": True}})
+    assert result is not None
+    assert result["enabled"] is True
+    assert result["usdc_faucet"] == "0xa0f2da5e260486895d73086dd98af09c25dc2883c6ac96025a688f855c180d06"
+    assert result["base_url"] == "https://testnet.prophetmarket.ai"
+
+
 def test_setup_without_seren_api_key_points_user_to_docs(monkeypatch) -> None:
     agent = _load_agent_module()
     monkeypatch.delenv("SEREN_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

Closes #271

- Add PROPHET_TESTNET_USDC_FAUCET constant and resolve_testnet_config() to all 3 prophet skills
- Add testnet config section to config.example.json with faucet address and testnet base URL
- Add PROPHET_TESTNET_MODE env var to .env.example
- Document faucet usage in each SKILL.md
- Add smoke test verifying testnet config resolution (enabled/disabled/faucet address)

## Test plan

- [x] test_resolve_testnet_config_returns_faucet_when_enabled passes for all 3 skills (25/25 tests green)
- [ ] Manual: enable testnet in config and verify run_once output includes testnet.usdc_faucet

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com