### PR TITLE
Diversify polymarket-bot candidate ranking

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -180,6 +180,19 @@ class TradingAgent:
 
         stale_demotion = self.stale_price_demotion
 
+        def _parse_best_price(m):
+            """Return YES-outcome price as float in [0,1], or None."""
+            op = m.get('outcomePrices', '')
+            if not op:
+                return None
+            try:
+                parts = [float(p.strip()) for p in op.split(',')]
+                if parts:
+                    return parts[0]
+            except (ValueError, TypeError):
+                pass
+            return None
+
         def _parse_price_asymmetry(m: Dict) -> float:
             """Return abs(p1 - p2) from outcomePrices string, or -1 if unparseable."""
             raw = m.get('outcomePrices', '')
@@ -207,6 +220,13 @@ class TradingAgent:
             # Demote markets whose outcomePrices are still at the Gamma 0.5/0.5 default
             if _is_stale_gamma(m):
                 return base * stale_demotion
+
+            price = _parse_best_price(m)
+            if price is not None:
+                if price < 0.05 or price > 0.95:
+                    base *= 0.3
+                elif 0.15 <= price <= 0.85:
+                    base *= 1.5
             return base
 
         # Hard-filter stale 50/50 Gamma markets before ranking — they waste LLM budget
@@ -244,7 +264,30 @@ class TradingAgent:
         if len(ranked) - len(time_filtered) > 0:
             print(f"  Filtered {len(ranked) - len(time_filtered)} markets resolving >{self.max_resolution_days} days out")
 
-        pre_selected = time_filtered[:limit]
+        # --- Slug-group deduplication: max 3 markets per slug prefix ---
+        MAX_PER_SLUG_GROUP = 3
+        slug_group_counts = {}
+        deduped = []
+        slug_skips = 0
+        for m in time_filtered:
+            slug = m.get('market_slug', m.get('question', ''))
+            parts = slug.lower().replace(' ', '-').split('-')
+            # Check both head-4 and tail-4 to catch prefix- and suffix-similar slugs
+            head_key = 'h:' + ('-'.join(parts[:4]) if len(parts) >= 4 else slug.lower())
+            tail_key = 't:' + ('-'.join(parts[-4:]) if len(parts) >= 4 else slug.lower())
+            head_count = slug_group_counts.get(head_key, 0)
+            tail_count = slug_group_counts.get(tail_key, 0)
+            if head_count >= MAX_PER_SLUG_GROUP or tail_count >= MAX_PER_SLUG_GROUP:
+                slug_skips += 1
+                continue
+            slug_group_counts[head_key] = head_count + 1
+            slug_group_counts[tail_key] = tail_count + 1
+            deduped.append(m)
+
+        if slug_skips > 0:
+            print(f"  Deduped {slug_skips} markets exceeding {MAX_PER_SLUG_GROUP}/slug-group cap")
+
+        pre_selected = deduped[:limit]
 
         # Enrich with live CLOB midpoint prices. If CLOB is unavailable, keep only
         # markets that already have a non-fallback Gamma price.
@@ -775,10 +818,6 @@ def main():
             total_opportunities += (opportunities_found or 0)
 
             print(f"<<< Iteration {iteration} result: {opportunities_found or 0} opportunities found")
-
-            if opportunities_found and opportunities_found > 0:
-                print(f"    Opportunities found — stopping iteration loop.")
-                break
 
             # Check SerenBucks balance from the last scan cycle
             serenbucks_balance = getattr(agent, '_last_serenbucks_balance', None)

--- a/polymarket/bot/tests/test_rank_candidates.py
+++ b/polymarket/bot/tests/test_rank_candidates.py
@@ -1,0 +1,72 @@
+"""Tests for rank_candidates price-diversity and slug-dedup logic."""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+def _make_market(slug, price_yes, liquidity=100000, volume=50000, end_days=30):
+    from datetime import datetime, timezone, timedelta
+    end = datetime.now(timezone.utc) + timedelta(days=end_days)
+    return {
+        'market_slug': slug,
+        'question': slug.replace('-', ' ').title(),
+        'outcomePrices': f"{price_yes},{round(1-price_yes,4)}",
+        'liquidity': str(liquidity),
+        'volume': str(volume),
+        'end_date': end.isoformat(),
+        'token_id': f'tok_{slug}',
+        'price': price_yes,
+        'price_source': 'gamma',
+    }
+
+
+class _FakePolymarket:
+    """Stub that returns a valid midpoint so enrichment succeeds."""
+    def get_midpoint(self, token_id):
+        return None  # force fallback to gamma price_source
+
+
+def _make_agent():
+    from agent import TradingAgent
+    a = TradingAgent.__new__(TradingAgent)
+    a.max_resolution_days = 365
+    a.candidate_limit = 80
+    a.analyze_limit = 80
+    a.min_liquidity = 0
+    a.stale_price_demotion = 0.1
+    a.polymarket = _FakePolymarket()
+    return a
+
+class TestPriceDiversityScoring:
+    def test_midrange_beats_extreme_at_equal_liquidity(self):
+        agent = _make_agent()
+        markets = [
+            _make_market('longshot-team-wins', 0.02, liquidity=500000, volume=500000),
+            _make_market('close-election-race', 0.40, liquidity=500000, volume=500000),
+        ]
+        ranked = agent.rank_candidates(markets, limit=10)
+        slugs = [m['market_slug'] for m in ranked]
+        assert slugs.index('close-election-race') < slugs.index('longshot-team-wins')
+
+    def test_extreme_high_price_penalized(self):
+        agent = _make_agent()
+        markets = [
+            _make_market('near-certain-outcome', 0.97, liquidity=500000, volume=500000),
+            _make_market('contested-question', 0.60, liquidity=500000, volume=500000),
+        ]
+        ranked = agent.rank_candidates(markets, limit=10)
+        slugs = [m['market_slug'] for m in ranked]
+        assert slugs.index('contested-question') < slugs.index('near-certain-outcome')
+
+class TestSlugGroupDedup:
+    def test_caps_at_three_per_group(self):
+        agent = _make_agent()
+        markets = [
+            _make_market(f'will-{c}-win-the-2026-fifa-world-cup', 0.02*(i+1),
+                         liquidity=1000000-i*10000, volume=500000)
+            for i, c in enumerate(['brazil','germany','france','argentina','spain',
+                                   'england','portugal','italy','netherlands','belgium'])
+        ]
+        markets.append(_make_market('will-btc-hit-100k', 0.45, liquidity=200000, volume=100000))
+        ranked = agent.rank_candidates(markets, limit=80)
+        fifa_count = sum(1 for m in ranked if 'fifa' in m['market_slug'])
+        assert fifa_count <= 3, f"Expected max 3 FIFA markets, got {fifa_count}"
+        assert any('btc' in m['market_slug'] for m in ranked)


### PR DESCRIPTION
## Summary
- Add price-diversity multipliers to `rank_candidates()` scoring: 0.3x penalty for extreme prices (<5%/>95%), 1.5x boost for midrange (15-85%)
- Add slug-prefix deduplication: max 3 markets per group to prevent FIFA/NBA monoculture
- Remove iteration early-exit so all configured iterations run and discover 10+ opportunities
- Add tests for price scoring and slug dedup

## Test plan
- [x] `test_midrange_beats_extreme_at_equal_liquidity` — midrange market outranks longshot
- [x] `test_extreme_high_price_penalized` — 97% market ranks below 60% market
- [x] `test_caps_at_three_per_group` — only 3 FIFA markets survive, non-FIFA preserved

Fixes #275

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com