### PR TITLE
feat: add SkillForge skills for SharePoint, Asana, Google suite, Attio, and Linear

### DIFF
--- a/google/calendar/.env.example
+++ b/google/calendar/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-calendar
+SEREN_API_KEY=
+

--- a/google/calendar/SKILL.md
+++ b/google/calendar/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: google-calendar
+description: "Create, read, update, and delete Google Calendar events. Supports free/busy queries, recurring events, multi-calendar management, and meeting scheduling with OAuth authentication."
+---
+
+# Google Calendar
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create calendar event
+- list calendar events
+- check availability
+- schedule meeting
+- update calendar event
+
+## Workflow Summary
+
+1. `list_events` uses `connector.calendar.get`
+2. `create_event` uses `connector.calendar.post`
+3. `check_freebusy` uses `connector.calendar.post`

--- a/google/calendar/config.example.json
+++ b/google/calendar/config.example.json
@@ -1,0 +1,14 @@
+{
+  "connectors": [
+    "calendar"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "attendees": "",
+    "calendar_id": "primary",
+    "end": "",
+    "start": "",
+    "summary": ""
+  },
+  "skill": "google-calendar"
+}

--- a/google/calendar/requirements.txt
+++ b/google/calendar/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-calendar.

--- a/google/calendar/scripts/agent.py
+++ b/google/calendar/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-calendar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['calendar']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/calendar/tests/fixtures/connector_failure.json
+++ b/google/calendar/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "google-calendar",
+  "error_code": "connector_failure",
+  "connector": "calendar",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "calendar": {
+      "get": {
+        "status": "error",
+        "connector": "calendar",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "calendar",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/calendar/tests/fixtures/dry_run_guard.json
+++ b/google/calendar/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-calendar",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/calendar/tests/fixtures/happy_path.json
+++ b/google/calendar/tests/fixtures/happy_path.json
@@ -1,0 +1,27 @@
+{
+  "status": "ok",
+  "skill": "google-calendar",
+  "workflow_step_count": 3,
+  "dry_run": true,
+  "inputs": {
+    "attendees": "",
+    "calendar_id": "primary",
+    "end": "",
+    "start": "",
+    "summary": ""
+  },
+  "connectors": {
+    "calendar": {
+      "get": {
+        "status": "ok",
+        "connector": "calendar",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "calendar",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/google/calendar/tests/fixtures/policy_violation.json
+++ b/google/calendar/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-calendar",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/calendar/tests/test_smoke.py
+++ b/google/calendar/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-calendar"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/contacts/.env.example
+++ b/google/contacts/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-contacts
+SEREN_API_KEY=
+

--- a/google/contacts/SKILL.md
+++ b/google/contacts/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: google-contacts
+description: "Read and manage Google Contacts via the People API. Access contact information including names, emails, phone numbers, and organizations with OAuth authentication."
+---
+
+# Google Contacts
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- list google contacts
+- search google contacts
+- get contact details
+- find contact by name
+
+## Workflow Summary
+
+1. `list_contacts` uses `connector.contacts.get`
+2. `search_contacts` uses `connector.contacts.get`
+3. `get_contact` uses `connector.contacts.get`

--- a/google/contacts/config.example.json
+++ b/google/contacts/config.example.json
@@ -1,0 +1,12 @@
+{
+  "connectors": [
+    "contacts"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "page_size": 20,
+    "query": "",
+    "resource_name": ""
+  },
+  "skill": "google-contacts"
+}

--- a/google/contacts/requirements.txt
+++ b/google/contacts/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-contacts.

--- a/google/contacts/scripts/agent.py
+++ b/google/contacts/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-contacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['contacts']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/contacts/tests/fixtures/connector_failure.json
+++ b/google/contacts/tests/fixtures/connector_failure.json
@@ -1,0 +1,17 @@
+{
+  "status": "error",
+  "skill": "google-contacts",
+  "error_code": "connector_failure",
+  "connector": "contacts",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "contacts": {
+      "get": {
+        "status": "error",
+        "connector": "contacts",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/contacts/tests/fixtures/dry_run_guard.json
+++ b/google/contacts/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-contacts",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/contacts/tests/fixtures/happy_path.json
+++ b/google/contacts/tests/fixtures/happy_path.json
@@ -1,0 +1,20 @@
+{
+  "status": "ok",
+  "skill": "google-contacts",
+  "workflow_step_count": 3,
+  "dry_run": true,
+  "inputs": {
+    "page_size": 20,
+    "query": "",
+    "resource_name": ""
+  },
+  "connectors": {
+    "contacts": {
+      "get": {
+        "status": "ok",
+        "connector": "contacts",
+        "action": "get"
+      }
+    }
+  }
+}

--- a/google/contacts/tests/fixtures/policy_violation.json
+++ b/google/contacts/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-contacts",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/contacts/tests/test_smoke.py
+++ b/google/contacts/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-contacts"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/docs/.env.example
+++ b/google/docs/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-docs
+SEREN_API_KEY=
+

--- a/google/docs/SKILL.md
+++ b/google/docs/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: google-docs
+description: "Create, read, and update Google Docs documents. Supports document creation, content insertion, formatting, and batch updates with OAuth authentication."
+---
+
+# Google Docs
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create google doc
+- read google doc
+- update google doc
+- insert text into document
+- format google doc
+
+## Workflow Summary
+
+1. `get_document` uses `connector.docs.get`
+2. `create_document` uses `connector.docs.post`
+3. `batch_update` uses `connector.docs.post`

--- a/google/docs/config.example.json
+++ b/google/docs/config.example.json
@@ -1,0 +1,12 @@
+{
+  "connectors": [
+    "docs"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "content": "",
+    "document_id": "",
+    "title": ""
+  },
+  "skill": "google-docs"
+}

--- a/google/docs/requirements.txt
+++ b/google/docs/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-docs.

--- a/google/docs/scripts/agent.py
+++ b/google/docs/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-docs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['docs']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/docs/tests/fixtures/connector_failure.json
+++ b/google/docs/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "google-docs",
+  "error_code": "connector_failure",
+  "connector": "docs",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "docs": {
+      "get": {
+        "status": "error",
+        "connector": "docs",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "docs",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/docs/tests/fixtures/dry_run_guard.json
+++ b/google/docs/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-docs",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/docs/tests/fixtures/happy_path.json
+++ b/google/docs/tests/fixtures/happy_path.json
@@ -1,0 +1,25 @@
+{
+  "status": "ok",
+  "skill": "google-docs",
+  "workflow_step_count": 3,
+  "dry_run": true,
+  "inputs": {
+    "content": "",
+    "document_id": "",
+    "title": ""
+  },
+  "connectors": {
+    "docs": {
+      "get": {
+        "status": "ok",
+        "connector": "docs",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "docs",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/google/docs/tests/fixtures/policy_violation.json
+++ b/google/docs/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-docs",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/docs/tests/test_smoke.py
+++ b/google/docs/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-docs"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/drive/.env.example
+++ b/google/drive/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-drive
+SEREN_API_KEY=
+

--- a/google/drive/SKILL.md
+++ b/google/drive/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: google-drive
+description: "Create, read, update, and manage files and folders in Google Drive. Upload documents, organize folder structures, search files, and manage sharing permissions with OAuth authentication."
+---
+
+# Google Drive
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- upload file to google drive
+- list google drive files
+- search google drive
+- create google drive folder
+- share google drive file
+
+## Workflow Summary
+
+1. `list_files` uses `connector.drive.get`
+2. `search_files` uses `connector.drive.get`
+3. `create_folder` uses `connector.drive.post`
+4. `upload_file` uses `connector.drive.post`

--- a/google/drive/config.example.json
+++ b/google/drive/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "drive"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "file_id": "",
+    "folder_id": "",
+    "name": "",
+    "query": ""
+  },
+  "skill": "google-drive"
+}

--- a/google/drive/requirements.txt
+++ b/google/drive/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-drive.

--- a/google/drive/scripts/agent.py
+++ b/google/drive/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-drive."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['drive']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/drive/tests/fixtures/connector_failure.json
+++ b/google/drive/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "google-drive",
+  "error_code": "connector_failure",
+  "connector": "drive",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "drive": {
+      "get": {
+        "status": "error",
+        "connector": "drive",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "drive",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/drive/tests/fixtures/dry_run_guard.json
+++ b/google/drive/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-drive",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/drive/tests/fixtures/happy_path.json
+++ b/google/drive/tests/fixtures/happy_path.json
@@ -1,0 +1,26 @@
+{
+  "status": "ok",
+  "skill": "google-drive",
+  "workflow_step_count": 4,
+  "dry_run": true,
+  "inputs": {
+    "file_id": "",
+    "folder_id": "",
+    "name": "",
+    "query": ""
+  },
+  "connectors": {
+    "drive": {
+      "get": {
+        "status": "ok",
+        "connector": "drive",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "drive",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/google/drive/tests/fixtures/policy_violation.json
+++ b/google/drive/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-drive",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/drive/tests/test_smoke.py
+++ b/google/drive/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-drive"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/meet/.env.example
+++ b/google/meet/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-meet
+SEREN_API_KEY=
+

--- a/google/meet/SKILL.md
+++ b/google/meet/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: google-meet
+description: "Create and manage Google Meet meeting spaces. Generate meeting links, configure meeting settings, and manage active conferences with OAuth authentication."
+---
+
+# Google Meet
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create google meet
+- generate meeting link
+- manage meeting space
+
+## Workflow Summary
+
+1. `create_space` uses `connector.meet.post`
+2. `get_space` uses `connector.meet.get`

--- a/google/meet/config.example.json
+++ b/google/meet/config.example.json
@@ -1,0 +1,11 @@
+{
+  "connectors": [
+    "meet"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "meeting_type": "MEETING_TYPE_DEFAULT",
+    "space_name": ""
+  },
+  "skill": "google-meet"
+}

--- a/google/meet/requirements.txt
+++ b/google/meet/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-meet.

--- a/google/meet/scripts/agent.py
+++ b/google/meet/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-meet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['meet']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/meet/tests/fixtures/connector_failure.json
+++ b/google/meet/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "google-meet",
+  "error_code": "connector_failure",
+  "connector": "meet",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "meet": {
+      "get": {
+        "status": "error",
+        "connector": "meet",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "meet",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/meet/tests/fixtures/dry_run_guard.json
+++ b/google/meet/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-meet",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/meet/tests/fixtures/happy_path.json
+++ b/google/meet/tests/fixtures/happy_path.json
@@ -1,0 +1,24 @@
+{
+  "status": "ok",
+  "skill": "google-meet",
+  "workflow_step_count": 2,
+  "dry_run": true,
+  "inputs": {
+    "meeting_type": "MEETING_TYPE_DEFAULT",
+    "space_name": ""
+  },
+  "connectors": {
+    "meet": {
+      "get": {
+        "status": "ok",
+        "connector": "meet",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "meet",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/google/meet/tests/fixtures/policy_violation.json
+++ b/google/meet/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-meet",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/meet/tests/test_smoke.py
+++ b/google/meet/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-meet"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/sheets/.env.example
+++ b/google/sheets/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-sheets
+SEREN_API_KEY=
+

--- a/google/sheets/SKILL.md
+++ b/google/sheets/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: google-sheets
+description: "Read and write Google Sheets data, create spreadsheets, manage worksheets, and apply formatting. Supports batch reads, cell updates, and formula operations with OAuth authentication."
+---
+
+# Google Sheets
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- read google sheet
+- write to google sheet
+- create google spreadsheet
+- update sheet cells
+- get sheet data
+
+## Workflow Summary
+
+1. `read_range` uses `connector.sheets.get`
+2. `write_range` uses `connector.sheets.post`
+3. `create_spreadsheet` uses `connector.sheets.post`

--- a/google/sheets/config.example.json
+++ b/google/sheets/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "sheets"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "range": "",
+    "spreadsheet_id": "",
+    "title": "",
+    "values": ""
+  },
+  "skill": "google-sheets"
+}

--- a/google/sheets/requirements.txt
+++ b/google/sheets/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-sheets.

--- a/google/sheets/scripts/agent.py
+++ b/google/sheets/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-sheets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['sheets']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/sheets/tests/fixtures/connector_failure.json
+++ b/google/sheets/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "google-sheets",
+  "error_code": "connector_failure",
+  "connector": "sheets",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "sheets": {
+      "get": {
+        "status": "error",
+        "connector": "sheets",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "sheets",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/sheets/tests/fixtures/dry_run_guard.json
+++ b/google/sheets/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-sheets",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/sheets/tests/fixtures/happy_path.json
+++ b/google/sheets/tests/fixtures/happy_path.json
@@ -1,0 +1,26 @@
+{
+  "status": "ok",
+  "skill": "google-sheets",
+  "workflow_step_count": 3,
+  "dry_run": true,
+  "inputs": {
+    "range": "",
+    "spreadsheet_id": "",
+    "title": "",
+    "values": ""
+  },
+  "connectors": {
+    "sheets": {
+      "get": {
+        "status": "ok",
+        "connector": "sheets",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "sheets",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/google/sheets/tests/fixtures/policy_violation.json
+++ b/google/sheets/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-sheets",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/sheets/tests/test_smoke.py
+++ b/google/sheets/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-sheets"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/google/trends/.env.example
+++ b/google/trends/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for google-trends
+SEREN_API_KEY=
+

--- a/google/trends/SKILL.md
+++ b/google/trends/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: google-trends
+description: "Access real-time Google Trends data including interest over time, regional breakdowns, related topics and queries. Supports up to 5 keywords per search, geographic filtering, date ranges, and search property filters."
+---
+
+# Google Trends
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- search google trends
+- compare trend keywords
+- get trending topics
+- analyze search interest
+
+## Workflow Summary
+
+1. `interest_over_time` uses `connector.trends.get`
+2. `regional_interest` uses `connector.trends.get`
+3. `related_queries` uses `connector.trends.get`

--- a/google/trends/config.example.json
+++ b/google/trends/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "trends"
+  ],
+  "dry_run": false,
+  "inputs": {
+    "category": 0,
+    "geo": "",
+    "keywords": "",
+    "timeframe": "today 12-m"
+  },
+  "skill": "google-trends"
+}

--- a/google/trends/requirements.txt
+++ b/google/trends/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for google-trends.

--- a/google/trends/scripts/agent.py
+++ b/google/trends/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for google-trends."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = False
+AVAILABLE_CONNECTORS = ['trends']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google/trends/tests/fixtures/connector_failure.json
+++ b/google/trends/tests/fixtures/connector_failure.json
@@ -1,0 +1,17 @@
+{
+  "status": "error",
+  "skill": "google-trends",
+  "error_code": "connector_failure",
+  "connector": "trends",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "trends": {
+      "get": {
+        "status": "error",
+        "connector": "trends",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/google/trends/tests/fixtures/dry_run_guard.json
+++ b/google/trends/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "google-trends",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/google/trends/tests/fixtures/happy_path.json
+++ b/google/trends/tests/fixtures/happy_path.json
@@ -1,0 +1,21 @@
+{
+  "status": "ok",
+  "skill": "google-trends",
+  "workflow_step_count": 3,
+  "dry_run": false,
+  "inputs": {
+    "category": 0,
+    "geo": "",
+    "keywords": "",
+    "timeframe": "today 12-m"
+  },
+  "connectors": {
+    "trends": {
+      "get": {
+        "status": "ok",
+        "connector": "trends",
+        "action": "get"
+      }
+    }
+  }
+}

--- a/google/trends/tests/fixtures/policy_violation.json
+++ b/google/trends/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "google-trends",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/google/trends/tests/test_smoke.py
+++ b/google/trends/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "google-trends"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/microsoft/sharepoint/.env.example
+++ b/microsoft/sharepoint/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for microsoft-sharepoint
+SEREN_API_KEY=
+

--- a/microsoft/sharepoint/SKILL.md
+++ b/microsoft/sharepoint/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: microsoft-sharepoint
+description: "Manage SharePoint sites, document libraries, files, folders, and lists via Microsoft Graph API. Browse sites, upload and download files, create folders, copy files, and search across sites with OAuth2 authentication."
+---
+
+# Microsoft Sharepoint
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- upload file to sharepoint
+- list sharepoint sites
+- search sharepoint documents
+- create sharepoint folder
+- read sharepoint list
+
+## Workflow Summary
+
+1. `list_sites` uses `connector.sharepoint.get`
+2. `browse_drive` uses `connector.sharepoint.get`
+3. `upload_file` uses `connector.sharepoint.post`
+4. `search` uses `connector.sharepoint.get`

--- a/microsoft/sharepoint/config.example.json
+++ b/microsoft/sharepoint/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "sharepoint"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "drive_id": "",
+    "path": "",
+    "query": "",
+    "site_id": ""
+  },
+  "skill": "microsoft-sharepoint"
+}

--- a/microsoft/sharepoint/requirements.txt
+++ b/microsoft/sharepoint/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for microsoft-sharepoint.

--- a/microsoft/sharepoint/scripts/agent.py
+++ b/microsoft/sharepoint/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for microsoft-sharepoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['sharepoint']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/microsoft/sharepoint/tests/fixtures/connector_failure.json
+++ b/microsoft/sharepoint/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "microsoft-sharepoint",
+  "error_code": "connector_failure",
+  "connector": "sharepoint",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "sharepoint": {
+      "get": {
+        "status": "error",
+        "connector": "sharepoint",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "sharepoint",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/microsoft/sharepoint/tests/fixtures/dry_run_guard.json
+++ b/microsoft/sharepoint/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "microsoft-sharepoint",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/microsoft/sharepoint/tests/fixtures/happy_path.json
+++ b/microsoft/sharepoint/tests/fixtures/happy_path.json
@@ -1,0 +1,26 @@
+{
+  "status": "ok",
+  "skill": "microsoft-sharepoint",
+  "workflow_step_count": 4,
+  "dry_run": true,
+  "inputs": {
+    "drive_id": "",
+    "path": "",
+    "query": "",
+    "site_id": ""
+  },
+  "connectors": {
+    "sharepoint": {
+      "get": {
+        "status": "ok",
+        "connector": "sharepoint",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "sharepoint",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/microsoft/sharepoint/tests/fixtures/policy_violation.json
+++ b/microsoft/sharepoint/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "microsoft-sharepoint",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/microsoft/sharepoint/tests/test_smoke.py
+++ b/microsoft/sharepoint/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "microsoft-sharepoint"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/seren/asana/.env.example
+++ b/seren/asana/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for asana
+SEREN_API_KEY=
+

--- a/seren/asana/SKILL.md
+++ b/seren/asana/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: asana
+description: "Manage Asana tasks, projects, sections, goals, portfolios, tags, teams, and workspaces through AI agents. Create, update, and organize work items with OAuth token passthrough."
+---
+
+# Asana
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create asana task
+- list asana projects
+- update asana task status
+- search asana tasks
+- manage asana workspace
+
+## Workflow Summary
+
+1. `list_workspaces` uses `connector.asana.get`
+2. `list_projects` uses `connector.asana.get`
+3. `create_task` uses `connector.asana.post`
+4. `search_tasks` uses `connector.asana.get`

--- a/seren/asana/config.example.json
+++ b/seren/asana/config.example.json
@@ -1,0 +1,14 @@
+{
+  "connectors": [
+    "asana"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "assignee": "",
+    "due_date": "",
+    "project_gid": "",
+    "task_name": "",
+    "workspace_gid": ""
+  },
+  "skill": "asana"
+}

--- a/seren/asana/requirements.txt
+++ b/seren/asana/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for asana.

--- a/seren/asana/scripts/agent.py
+++ b/seren/asana/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for asana."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['asana']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seren/asana/tests/fixtures/connector_failure.json
+++ b/seren/asana/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "asana",
+  "error_code": "connector_failure",
+  "connector": "asana",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "asana": {
+      "get": {
+        "status": "error",
+        "connector": "asana",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "asana",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/seren/asana/tests/fixtures/dry_run_guard.json
+++ b/seren/asana/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "asana",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/seren/asana/tests/fixtures/happy_path.json
+++ b/seren/asana/tests/fixtures/happy_path.json
@@ -1,0 +1,27 @@
+{
+  "status": "ok",
+  "skill": "asana",
+  "workflow_step_count": 4,
+  "dry_run": true,
+  "inputs": {
+    "assignee": "",
+    "due_date": "",
+    "project_gid": "",
+    "task_name": "",
+    "workspace_gid": ""
+  },
+  "connectors": {
+    "asana": {
+      "get": {
+        "status": "ok",
+        "connector": "asana",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "asana",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/seren/asana/tests/fixtures/policy_violation.json
+++ b/seren/asana/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "asana",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/seren/asana/tests/test_smoke.py
+++ b/seren/asana/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "asana"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/seren/attio/.env.example
+++ b/seren/attio/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for attio
+SEREN_API_KEY=
+

--- a/seren/attio/SKILL.md
+++ b/seren/attio/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: attio
+description: "Connect to Attio CRM to manage contacts, companies, deals, lists, tasks, notes, meetings, and comments through AI agents. Search records, create entries, update pipelines, and manage your sales workflow."
+---
+
+# Attio
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- search attio contacts
+- create attio record
+- update attio deal
+- list attio companies
+- manage attio pipeline
+
+## Workflow Summary
+
+1. `list_objects` uses `connector.attio.get`
+2. `search_records` uses `connector.attio.post`
+3. `get_record` uses `connector.attio.get`
+4. `create_record` uses `connector.attio.post`
+5. `list_entries` uses `connector.attio.get`

--- a/seren/attio/config.example.json
+++ b/seren/attio/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "attio"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "list_id": "",
+    "object_type": "",
+    "query": "",
+    "record_id": ""
+  },
+  "skill": "attio"
+}

--- a/seren/attio/requirements.txt
+++ b/seren/attio/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for attio.

--- a/seren/attio/scripts/agent.py
+++ b/seren/attio/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for attio."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['attio']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seren/attio/tests/fixtures/connector_failure.json
+++ b/seren/attio/tests/fixtures/connector_failure.json
@@ -1,0 +1,23 @@
+{
+  "status": "error",
+  "skill": "attio",
+  "error_code": "connector_failure",
+  "connector": "attio",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "attio": {
+      "get": {
+        "status": "error",
+        "connector": "attio",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "attio",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/seren/attio/tests/fixtures/dry_run_guard.json
+++ b/seren/attio/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "attio",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/seren/attio/tests/fixtures/happy_path.json
+++ b/seren/attio/tests/fixtures/happy_path.json
@@ -1,0 +1,26 @@
+{
+  "status": "ok",
+  "skill": "attio",
+  "workflow_step_count": 5,
+  "dry_run": true,
+  "inputs": {
+    "list_id": "",
+    "object_type": "",
+    "query": "",
+    "record_id": ""
+  },
+  "connectors": {
+    "attio": {
+      "get": {
+        "status": "ok",
+        "connector": "attio",
+        "action": "get"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "attio",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/seren/attio/tests/fixtures/policy_violation.json
+++ b/seren/attio/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "attio",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/seren/attio/tests/test_smoke.py
+++ b/seren/attio/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "attio"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/seren/linear/.env.example
+++ b/seren/linear/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for linear
+SEREN_API_KEY=
+

--- a/seren/linear/SKILL.md
+++ b/seren/linear/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: linear
+description: "Connect to Linear to manage issues, projects, cycles, and team workflows through AI agents. Create and update issues, manage project roadmaps, track sprint cycles, and search across your workspace."
+---
+
+# Linear
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- create linear issue
+- list linear issues
+- update linear issue
+- search linear projects
+- manage linear cycle
+
+## Workflow Summary
+
+1. `list_teams` uses `connector.linear.get`
+2. `list_issues` uses `connector.linear.get`
+3. `create_issue` uses `connector.linear.post`
+4. `update_issue` uses `connector.linear.patch`
+5. `list_projects` uses `connector.linear.get`

--- a/seren/linear/config.example.json
+++ b/seren/linear/config.example.json
@@ -1,0 +1,17 @@
+{
+  "connectors": [
+    "linear"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "assignee_id": "",
+    "description": "",
+    "issue_id": "",
+    "priority": 0,
+    "project_id": "",
+    "status": "",
+    "team_id": "",
+    "title": ""
+  },
+  "skill": "linear"
+}

--- a/seren/linear/requirements.txt
+++ b/seren/linear/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for linear.

--- a/seren/linear/scripts/agent.py
+++ b/seren/linear/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for linear."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['linear']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seren/linear/tests/fixtures/connector_failure.json
+++ b/seren/linear/tests/fixtures/connector_failure.json
@@ -1,0 +1,29 @@
+{
+  "status": "error",
+  "skill": "linear",
+  "error_code": "connector_failure",
+  "connector": "linear",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "linear": {
+      "get": {
+        "status": "error",
+        "connector": "linear",
+        "action": "get",
+        "error_code": "connector_failure"
+      },
+      "patch": {
+        "status": "error",
+        "connector": "linear",
+        "action": "patch",
+        "error_code": "connector_failure"
+      },
+      "post": {
+        "status": "error",
+        "connector": "linear",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    }
+  }
+}

--- a/seren/linear/tests/fixtures/dry_run_guard.json
+++ b/seren/linear/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "linear",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/seren/linear/tests/fixtures/happy_path.json
+++ b/seren/linear/tests/fixtures/happy_path.json
@@ -1,0 +1,35 @@
+{
+  "status": "ok",
+  "skill": "linear",
+  "workflow_step_count": 5,
+  "dry_run": true,
+  "inputs": {
+    "assignee_id": "",
+    "description": "",
+    "issue_id": "",
+    "priority": 0,
+    "project_id": "",
+    "status": "",
+    "team_id": "",
+    "title": ""
+  },
+  "connectors": {
+    "linear": {
+      "get": {
+        "status": "ok",
+        "connector": "linear",
+        "action": "get"
+      },
+      "patch": {
+        "status": "ok",
+        "connector": "linear",
+        "action": "patch"
+      },
+      "post": {
+        "status": "ok",
+        "connector": "linear",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/seren/linear/tests/fixtures/policy_violation.json
+++ b/seren/linear/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "linear",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/seren/linear/tests/test_smoke.py
+++ b/seren/linear/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "linear"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"


### PR DESCRIPTION
## Summary

- Add 11 new publisher-wrapper skills generated via SkillForge for existing gateway publishers
- **microsoft/sharepoint** — Graph API: sites, document libraries, files, folders, lists, search
- **seren/asana** — Tasks, projects, sections, goals, portfolios, tags, teams, workspaces
- **google/drive** — Files, folders, sharing, search
- **google/calendar** — Events, free/busy, recurring events, multi-calendar
- **google/sheets** — Read/write ranges, create spreadsheets, formatting
- **google/docs** — Create, read, batch update documents
- **google/contacts** — People API: list, search, detail lookup
- **google/meet** — Create and manage meeting spaces
- **google/trends** — Interest over time, regional breakdowns, related queries
- **seren/attio** — CRM: contacts, companies, deals, lists, tasks, notes
- **seren/linear** — Issues, projects, cycles, team workflows

## Test plan

- [x] All 11 specs pass `skillforge validate`
- [x] All skills released via `skillforge release --target ../seren-skills`
- [x] Each skill includes SKILL.md, agent.py, config.example.json, .env.example, requirements.txt, and smoke tests

Closes #280

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com