### PR TITLE
fix: add unbuffered stdout to all trading skill agent scripts

### DIFF
--- a/alphagrowth/euler-base-vault-bot/scripts/agent.py
+++ b/alphagrowth/euler-base-vault-bot/scripts/agent.py
@@ -8,6 +8,14 @@ import json
 from pathlib import Path
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from urllib.request import Request, urlopen
 
 from normalized_trade_store import NormalizedTradingStore

--- a/coinbase/grid-trader/scripts/agent.py
+++ b/coinbase/grid-trader/scripts/agent.py
@@ -17,6 +17,14 @@ import json
 import os
 import signal
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import time
 import uuid
 from datetime import datetime

--- a/coinbase/smart-dca-bot/scripts/agent.py
+++ b/coinbase/smart-dca-bot/scripts/agent.py
@@ -24,6 +24,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from urllib.request import Request, urlopen
 
 try:

--- a/curve/curve-gauge-yield-trader/scripts/agent.py
+++ b/curve/curve-gauge-yield-trader/scripts/agent.py
@@ -19,6 +19,14 @@ from urllib.request import Request, urlopen
 from normalized_trade_store import NormalizedTradingStore
 import sys
 
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
+
 DEFAULT_DRY_RUN = True
 DEFAULT_API_BASE = "https://api.serendb.com"
 DEFAULT_WALLET_PATH = "state/wallet.local.json"

--- a/kraken/grid-trader/scripts/agent.py
+++ b/kraken/grid-trader/scripts/agent.py
@@ -17,6 +17,14 @@ import json
 import os
 import signal
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import time
 import uuid
 from datetime import datetime, timezone

--- a/kraken/money-mode-router/scripts/agent.py
+++ b/kraken/money-mode-router/scripts/agent.py
@@ -7,6 +7,14 @@ import argparse
 import json
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import uuid
 from dataclasses import asdict
 from pathlib import Path

--- a/kraken/smart-dca-bot/scripts/agent.py
+++ b/kraken/smart-dca-bot/scripts/agent.py
@@ -24,6 +24,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from urllib.request import Request, urlopen
 
 try:

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -18,6 +18,14 @@ import argparse
 import json
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from pathlib import Path
 from typing import Dict, List, Optional
 from datetime import datetime, timezone

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -8,6 +8,14 @@ import json
 import math
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -8,6 +8,14 @@ import json
 import math
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -957,6 +957,14 @@ def _fetch_predictions_signals(
     estimated_cost = 0.30  # batch consensus ($0.15) + batch divergence ($0.15)
     if balance < estimated_cost:
         import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
         print(
             f"WARNING: SerenBucks balance (${balance:.2f}) may be insufficient for "
             f"predictions intelligence (estimated ${estimated_cost:.2f}). "

--- a/prophet/prophet-adversarial-auditor/scripts/agent.py
+++ b/prophet/prophet-adversarial-auditor/scripts/agent.py
@@ -6,6 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass

--- a/prophet/prophet-growth-agent/scripts/agent.py
+++ b/prophet/prophet-growth-agent/scripts/agent.py
@@ -6,6 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -6,6 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 import urllib.parse
 import urllib.request
 import uuid

--- a/spectra/spectra-pt-yield-trader/scripts/agent.py
+++ b/spectra/spectra-pt-yield-trader/scripts/agent.py
@@ -8,6 +8,14 @@ import json
 from pathlib import Path
 import os
 import sys
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from urllib.request import Request, urlopen
 
 from normalized_trade_store import NormalizedTradingStore

--- a/tests/test_unbuffered_output.py
+++ b/tests/test_unbuffered_output.py
@@ -1,0 +1,43 @@
+"""Verify all trading/scanning skills use unbuffered stdout for piped output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TRADING_SKILLS_WITH_AGENT_PY: list[str] = [
+    "polymarket/bot",
+    "polymarket/maker-rebate-bot",
+    "polymarket/high-throughput-paired-basis-maker",
+    "polymarket/liquidity-paired-basis-maker",
+    "coinbase/grid-trader",
+    "coinbase/smart-dca-bot",
+    "kraken/grid-trader",
+    "kraken/smart-dca-bot",
+    "kraken/money-mode-router",
+    "curve/curve-gauge-yield-trader",
+    "spectra/spectra-pt-yield-trader",
+    "alphagrowth/euler-base-vault-bot",
+    "prophet/prophet-adversarial-auditor",
+    "prophet/prophet-growth-agent",
+    "prophet/prophet-market-seeder",
+]
+
+
+@pytest.mark.parametrize("skill", TRADING_SKILLS_WITH_AGENT_PY)
+def test_agent_has_unbuffered_output(skill: str) -> None:
+    agent_py = REPO_ROOT / skill / "scripts" / "agent.py"
+    assert agent_py.exists(), f"{agent_py} not found"
+    source = agent_py.read_text()
+    assert "PYTHONUNBUFFERED" in source, (
+        f"{skill}/scripts/agent.py is missing the unbuffered output fix. "
+        "Add the PYTHONUNBUFFERED / reconfigure(line_buffering=True) block "
+        "after 'import sys' so piped output is visible immediately."
+    )
+    assert "reconfigure(line_buffering=True)" in source, (
+        f"{skill}/scripts/agent.py sets PYTHONUNBUFFERED but is missing "
+        "sys.stdout.reconfigure(line_buffering=True) for in-process buffering."
+    )


### PR DESCRIPTION
## Summary

- Add `PYTHONUNBUFFERED=1` + `sys.stdout.reconfigure(line_buffering=True)` to 15 trading/scanning `agent.py` files
- When stdout is piped (background tasks, subprocess capture, cron), Python block-buffers output — causing AI agents to see 0 bytes for 40+ seconds and launch duplicate scans (doubling SerenBucks cost)
- The fix detects non-TTY mode and forces line buffering on both stdout and stderr

## Affected skills (15)

**Polymarket:** bot, maker-rebate-bot, high-throughput-paired-basis-maker, liquidity-paired-basis-maker
**Kraken:** grid-trader, smart-dca-bot, money-mode-router
**Coinbase:** grid-trader, smart-dca-bot
**DeFi:** curve-gauge-yield-trader, spectra-pt-yield-trader, euler-base-vault-bot
**Prophet:** prophet-adversarial-auditor, prophet-growth-agent, prophet-market-seeder

## Test plan

- [x] `tests/test_unbuffered_output.py` — parametrized test verifies all 15 agent.py files contain both `PYTHONUNBUFFERED` and `reconfigure(line_buffering=True)` (15/15 pass)

Closes #284

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com