### PR TITLE
fix: strengthen removed skill regression test and verify Desktop exposure

### DIFF
--- a/tests/test_removed_skill_references.py
+++ b/tests/test_removed_skill_references.py
@@ -1,17 +1,30 @@
+"""Verify removed skills stay removed — no directory, no references, no Desktop exposure."""
+
 from __future__ import annotations
 
 import ast
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REMOVED_SKILL = "polymarket/paired-market-basis-maker"
+REMOVED_SLUG = "paired-market-basis-maker"
 REGISTRY_TESTS = [
     "tests/test_optimizer_candidates.py",
     "tests/test_on_invoke_directive.py",
     "tests/test_config_bootstrap_runtime.py",
     "polymarket/tests/test_execution_safety.py",
 ]
+
+# File extensions that could contain skill references
+SCANNABLE_SUFFIXES = {".py", ".md", ".json", ".yaml", ".yml", ".toml"}
+
+# Files that legitimately mention the removed skill (this test file itself,
+# and strategy descriptions in sibling skills that reference the original approach)
+ALLOWLISTED_FILES = {
+    "tests/test_removed_skill_references.py",
+}
+
+SKIP_DIRS = {".git", ".worktrees", "__pycache__", ".venv", "node_modules", ".pytest_cache"}
 
 
 def _literal_collections(module_path: Path) -> list[list[str] | tuple[str, ...] | dict[str, str]]:
@@ -44,7 +57,16 @@ def _iter_string_values(value: object):
             yield from _iter_string_values(item)
 
 
+def test_removed_skill_directory_does_not_exist() -> None:
+    """The skill directory must not exist in the repo."""
+    skill_dir = REPO_ROOT / REMOVED_SKILL
+    assert not skill_dir.exists(), (
+        f"{REMOVED_SKILL}/ directory still exists — delete it to complete removal."
+    )
+
+
 def test_removed_skill_not_pinned_in_repo_side_skill_registries() -> None:
+    """Skill registries (test lists, workflow configs) must not reference the removed skill."""
     for relative_path in REGISTRY_TESTS:
         module_path = REPO_ROOT / relative_path
         string_values = [
@@ -56,3 +78,34 @@ def test_removed_skill_not_pinned_in_repo_side_skill_registries() -> None:
             f"{relative_path} still references removed skill {REMOVED_SKILL}"
         )
 
+
+def test_removed_skill_not_referenced_in_workflows_or_configs() -> None:
+    """No workflow, config, or documentation file should reference the removed skill
+    as an active/discoverable skill. This catches Desktop skill catalog entries,
+    CI workflow lists, and packaging manifests."""
+    violations: list[str] = []
+    for path in sorted(REPO_ROOT.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(skip in path.parts for skip in SKIP_DIRS):
+            continue
+        if path.suffix not in SCANNABLE_SUFFIXES:
+            continue
+        try:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            continue
+        if rel in ALLOWLISTED_FILES:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        # Check for the full skill path (org/skill-name)
+        if REMOVED_SKILL in content:
+            violations.append(f"{rel} references '{REMOVED_SKILL}'")
+    assert not violations, (
+        "Removed skill is still referenced in repo files "
+        "(these may expose it via Desktop skill sync):\n  "
+        + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary

- Expand `test_removed_skill_references.py` from 1 test to 3 tests
- Add directory-existence check to verify `polymarket/paired-market-basis-maker/` stays deleted
- Add full-repo scan across `.py`, `.md`, `.json`, `.yaml`, `.yml`, `.toml` files to catch any reference that could expose the removed skill via Desktop skill sync
- Allowlisted files (the test itself) are excluded from the scan

## Test plan

- [x] `test_removed_skill_directory_does_not_exist` — PASSED
- [x] `test_removed_skill_not_pinned_in_repo_side_skill_registries` — PASSED
- [x] `test_removed_skill_not_referenced_in_workflows_or_configs` — PASSED (full repo scan, 0 violations)

## Desktop cache invalidation

Desktop users should ask their agent to "update my Seren skills" or "refresh skills" to pull the latest catalog. The skill will no longer appear after refresh since the directory and all references are removed from this repo.

Closes #240

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com