### PR TITLE
fix(polymarket): improve market selection and add extreme-divergence sanity gate

### DIFF
--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -9,6 +9,8 @@
   "candidate_limit": 80,
   "analyze_limit": 30,
   "min_liquidity": 100.0,
+  "max_divergence": 0.50,
+  "min_buy_price": 0.02,
   "iteration": {
     "max_iterations": 2,
     "threshold_step": 0.01,

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -103,6 +103,10 @@ class TradingAgent:
         self.min_liquidity = float(self.config.get('min_liquidity', 100.0))
         self.stale_price_demotion = float(self.config.get('stale_price_demotion', 0.1))
 
+        # Market selection sanity gates
+        self.max_divergence = float(self.config.get('max_divergence', 0.50))
+        self.min_buy_price = float(self.config.get('min_buy_price', 0.02))
+
         print(f"✓ Agent initialized (Dry-run: {dry_run})")
         print(f"  Bankroll: ${self.bankroll:.2f}")
         print(f"  Mispricing threshold: {self.mispricing_threshold * 100:.1f}%")
@@ -152,7 +156,8 @@ class TradingAgent:
 
     def scan_markets(self, limit: int = 100) -> List[Dict]:
         """
-        Scan Polymarket for active markets
+        Scan Polymarket for active markets, sorted by volume with server-side
+        end_date filtering to avoid fetching markets that will be discarded.
 
         Args:
             limit: Max markets to fetch
@@ -161,8 +166,24 @@ class TradingAgent:
             List of market dicts
         """
         try:
-            print(f"  Fetching up to {limit} active markets from Polymarket...")
-            markets = self.polymarket.get_markets(limit=limit, active=True)
+            # Server-side date filter: only fetch markets resolving within our window
+            end_date_min = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            max_end = datetime.now(timezone.utc).replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
+            # Advance to first day of month + max_resolution_days
+            from datetime import timedelta
+            max_end = datetime.now(timezone.utc) + timedelta(days=self.max_resolution_days)
+            end_date_max = max_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            print(f"  Fetching up to {limit} active markets (sorted by volume, resolving within {self.max_resolution_days}d)...")
+            markets = self.polymarket.get_markets(
+                limit=limit,
+                active=True,
+                sort_by="volume",
+                end_date_min=end_date_min,
+                end_date_max=end_date_max,
+            )
             print(f"  ✓ Retrieved {len(markets)} markets with sufficient liquidity")
             return markets
         except Exception as e:
@@ -438,6 +459,26 @@ class TradingAgent:
             Trade recommendation dict or None if no opportunity
         """
         current_price = market['price']
+
+        # --- Fix 3: Min buy price floor ---
+        # Markets priced below min_buy_price should not generate BUY signals.
+        # At these prices the CLOB book is typically one-sided or empty, slippage
+        # consumes most of the theoretical edge, and the market is likely resolved,
+        # abandoned, or data-broken.
+        if current_price < self.min_buy_price and fair_value > current_price:
+            print(f"    ✗ BLOCKED: market price {current_price*100:.1f}% below {self.min_buy_price*100:.0f}% buy floor")
+            return None
+
+        # --- Fix 2: Extreme-divergence sanity gate ---
+        # A >max_divergence gap between AI estimate and market price almost always
+        # means the AI misunderstood the question, the market data is stale/broken,
+        # or the market is too illiquid for the price to be meaningful.
+        divergence = abs(fair_value - current_price)
+        if divergence > self.max_divergence:
+            print(f"    ✗ BLOCKED: {divergence*100:.0f}pp divergence exceeds {self.max_divergence*100:.0f}pp sanity limit")
+            print(f"      AI fair value: {fair_value*100:.1f}% vs market: {current_price*100:.1f}%")
+            print(f"      This likely indicates a data issue or model misunderstanding, not real edge")
+            return None
 
         # Calculate edge
         edge = kelly.calculate_edge(fair_value, current_price)

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -55,18 +55,34 @@ class PolymarketClient:
 
     # -- Market discovery (polymarket-data publisher) -------------------------
 
-    def get_markets(self, limit: int = 500, active: bool = True) -> List[Dict]:
+    def get_markets(
+        self,
+        limit: int = 500,
+        active: bool = True,
+        sort_by: str = "volume",
+        end_date_min: str = "",
+        end_date_max: str = "",
+    ) -> List[Dict]:
         """
         Get list of prediction markets via polymarket-data publisher.
 
         Args:
             limit: Max markets to return
             active: Only active markets
+            sort_by: Sort field for Gamma API (volume, liquidity, or default)
+            end_date_min: ISO date string; exclude markets resolving before this
+            end_date_max: ISO date string; exclude markets resolving after this
 
         Returns:
             List of market dicts
         """
         params = f"?limit={limit}&active={'true' if active else 'false'}&closed=false"
+        if sort_by:
+            params += f"&order={sort_by}&ascending=false"
+        if end_date_min:
+            params += f"&end_date_min={end_date_min}"
+        if end_date_max:
+            params += f"&end_date_max={end_date_max}"
 
         response = self.seren.call_publisher(
             publisher='polymarket-data',

--- a/tests/test_market_selection_gates.py
+++ b/tests/test_market_selection_gates.py
@@ -1,0 +1,135 @@
+"""Verify market selection sanity gates in polymarket/bot.
+
+Tests the three fixes from issue #286:
+1. Gamma API query uses sort_by=volume and end_date filters
+2. Extreme-divergence sanity gate blocks absurd AI-vs-market gaps
+3. Min buy price floor blocks penny-market BUY signals
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOT_AGENT = REPO_ROOT / "polymarket" / "bot" / "scripts" / "agent.py"
+BOT_CLIENT = REPO_ROOT / "polymarket" / "bot" / "scripts" / "polymarket_client.py"
+BOT_CONFIG = REPO_ROOT / "polymarket" / "bot" / "config.example.json"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# --- Fix 1: Smarter Gamma query ---
+
+
+def test_get_markets_accepts_sort_and_date_params() -> None:
+    """get_markets must accept sort_by, end_date_min, and end_date_max params."""
+    source = _read(BOT_CLIENT)
+    assert "sort_by" in source, "get_markets missing sort_by parameter"
+    assert "end_date_min" in source, "get_markets missing end_date_min parameter"
+    assert "end_date_max" in source, "get_markets missing end_date_max parameter"
+    assert "order=" in source, "get_markets not passing order= to Gamma API"
+
+
+def test_scan_markets_uses_volume_sort() -> None:
+    """scan_markets must request volume-sorted results from Gamma."""
+    source = _read(BOT_AGENT)
+    # Find the scan_markets method and verify it passes sort_by="volume"
+    assert re.search(r'sort_by\s*=\s*["\']volume["\']', source), (
+        "scan_markets does not pass sort_by='volume' to get_markets"
+    )
+
+
+def test_scan_markets_uses_server_side_date_filter() -> None:
+    """scan_markets must pass end_date_min/max to avoid fetching markets
+    that will be discarded client-side."""
+    source = _read(BOT_AGENT)
+    assert "end_date_min=" in source or "end_date_min" in source, (
+        "scan_markets does not pass end_date_min to get_markets"
+    )
+    assert "end_date_max=" in source or "end_date_max" in source, (
+        "scan_markets does not pass end_date_max to get_markets"
+    )
+
+
+# --- Fix 2: Extreme-divergence sanity gate ---
+
+
+def test_extreme_divergence_gate_exists() -> None:
+    """evaluate_opportunity must block markets where AI-vs-market divergence
+    exceeds max_divergence (default 50pp)."""
+    source = _read(BOT_AGENT)
+    assert "max_divergence" in source, "agent.py missing max_divergence config"
+    assert "BLOCKED" in source and "divergence" in source.lower(), (
+        "agent.py missing divergence sanity gate with BLOCKED log"
+    )
+
+
+def test_max_divergence_default_is_50pp() -> None:
+    """max_divergence default must be 0.50 (50 percentage points)."""
+    source = _read(BOT_AGENT)
+    match = re.search(r"['\"]max_divergence['\"],\s*([\d.]+)", source)
+    assert match, "Cannot find max_divergence default in agent.py"
+    assert float(match.group(1)) == 0.50, (
+        f"max_divergence default should be 0.50, got {match.group(1)}"
+    )
+
+
+def test_max_divergence_in_config_example() -> None:
+    """config.example.json must include max_divergence."""
+    config_text = _read(BOT_CONFIG)
+    assert "max_divergence" in config_text, (
+        "config.example.json missing max_divergence field"
+    )
+
+
+# --- Fix 3: Min buy price floor ---
+
+
+def test_min_buy_price_gate_exists() -> None:
+    """evaluate_opportunity must block BUY signals on markets priced below
+    min_buy_price (default 2%)."""
+    source = _read(BOT_AGENT)
+    assert "min_buy_price" in source, "agent.py missing min_buy_price config"
+
+
+def test_min_buy_price_default_is_2pct() -> None:
+    """min_buy_price default must be 0.02 (2%)."""
+    source = _read(BOT_AGENT)
+    match = re.search(r"['\"]min_buy_price['\"],\s*([\d.]+)", source)
+    assert match, "Cannot find min_buy_price default in agent.py"
+    assert float(match.group(1)) == 0.02, (
+        f"min_buy_price default should be 0.02, got {match.group(1)}"
+    )
+
+
+def test_min_buy_price_in_config_example() -> None:
+    """config.example.json must include min_buy_price."""
+    config_text = _read(BOT_CONFIG)
+    assert "min_buy_price" in config_text, (
+        "config.example.json missing min_buy_price field"
+    )
+
+
+# --- Gate ordering: both gates must fire before Kelly sizing ---
+
+
+def test_gates_fire_before_kelly() -> None:
+    """The divergence and min-price gates must appear before Kelly position
+    sizing in evaluate_opportunity, so absurd values never reach the sizer."""
+    source = _read(BOT_AGENT)
+    div_pos = source.find("max_divergence")
+    price_pos = source.find("min_buy_price")
+    kelly_pos = source.find("calculate_position_size")
+    assert div_pos > 0, "max_divergence not found in agent.py"
+    assert price_pos > 0, "min_buy_price not found in agent.py"
+    assert kelly_pos > 0, "calculate_position_size not found in agent.py"
+    assert price_pos < kelly_pos, (
+        "min_buy_price gate must appear before calculate_position_size"
+    )
+    assert div_pos < kelly_pos, (
+        "max_divergence gate must appear before calculate_position_size"
+    )


### PR DESCRIPTION
## Summary

- **Fix 1: Smarter Gamma queries** — sort by volume, pass `end_date_min`/`end_date_max` server-side to avoid fetching ~45% of markets that are immediately discarded by client-side resolution-time filtering
- **Fix 2: Extreme-divergence sanity gate** — blocks markets where AI fair value diverges from market price by more than `max_divergence` (default 50pp). The Beth Van Duyne 0.1% → 92% case would now be blocked instead of generating a $6 BUY order
- **Fix 3: Min buy price floor** — blocks BUY signals on markets priced below `min_buy_price` (default 2%). Penny markets have one-sided books and meaningless prices
- Both gates fire before Kelly sizing so absurd values never reach the position sizer
- Both are configurable via `config.json` (`max_divergence`, `min_buy_price`)

## Test plan

- [x] `test_get_markets_accepts_sort_and_date_params` — PASSED
- [x] `test_scan_markets_uses_volume_sort` — PASSED
- [x] `test_scan_markets_uses_server_side_date_filter` — PASSED
- [x] `test_extreme_divergence_gate_exists` — PASSED
- [x] `test_max_divergence_default_is_50pp` — PASSED
- [x] `test_max_divergence_in_config_example` — PASSED
- [x] `test_min_buy_price_gate_exists` — PASSED
- [x] `test_min_buy_price_default_is_2pct` — PASSED
- [x] `test_min_buy_price_in_config_example` — PASSED
- [x] `test_gates_fire_before_kelly` — PASSED (10/10)

Closes #286

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com