### PR TITLE
fix(polymarket): drop broken Gamma sort, add min_volume floor and event-group dedup

### DIFF
--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -9,6 +9,7 @@
   "candidate_limit": 80,
   "analyze_limit": 30,
   "min_liquidity": 100.0,
+  "min_volume": 1000.0,
   "max_divergence": 0.50,
   "min_buy_price": 0.02,
   "iteration": {

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -17,6 +17,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import sys
 
 # --- Force unbuffered stdout so piped/background output is visible immediately ---
@@ -106,6 +107,7 @@ class TradingAgent:
         # Market selection sanity gates
         self.max_divergence = float(self.config.get('max_divergence', 0.50))
         self.min_buy_price = float(self.config.get('min_buy_price', 0.02))
+        self.min_volume = float(self.config.get('min_volume', 1000.0))
 
         print(f"✓ Agent initialized (Dry-run: {dry_run})")
         print(f"  Bankroll: ${self.bankroll:.2f}")
@@ -156,8 +158,11 @@ class TradingAgent:
 
     def scan_markets(self, limit: int = 100) -> List[Dict]:
         """
-        Scan Polymarket for active markets, sorted by volume with server-side
-        end_date filtering to avoid fetching markets that will be discarded.
+        Scan Polymarket for active markets with server-side end_date filtering.
+
+        Does NOT rely on Gamma's sort order (tested unreliable — returns
+        zero-volume seeded markets above actually-traded ones). Instead fetches
+        a large batch and lets rank_candidates do client-side scoring.
 
         Args:
             limit: Max markets to fetch
@@ -167,20 +172,16 @@ class TradingAgent:
         """
         try:
             # Server-side date filter: only fetch markets resolving within our window
-            end_date_min = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-            max_end = datetime.now(timezone.utc).replace(
-                day=1, hour=0, minute=0, second=0, microsecond=0
-            )
-            # Advance to first day of month + max_resolution_days
             from datetime import timedelta
+            end_date_min = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             max_end = datetime.now(timezone.utc) + timedelta(days=self.max_resolution_days)
             end_date_max = max_end.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-            print(f"  Fetching up to {limit} active markets (sorted by volume, resolving within {self.max_resolution_days}d)...")
+            print(f"  Fetching up to {limit} active markets (resolving within {self.max_resolution_days}d)...")
             markets = self.polymarket.get_markets(
                 limit=limit,
                 active=True,
-                sort_by="volume",
+                sort_by="",
                 end_date_min=end_date_min,
                 end_date_max=end_date_max,
             )
@@ -264,7 +265,14 @@ class TradingAgent:
         if stale_gamma_pre_filter:
             print(f"  Filtered {stale_gamma_pre_filter} stale 50/50 Gamma-seeded markets")
 
-        ranked = sorted(stale_gamma_filtered, key=score, reverse=True)
+        # Hard-filter zero/low-volume markets — seeded but never traded
+        min_vol = self.min_volume
+        volume_filtered = [m for m in stale_gamma_filtered if float(m.get('volume', 0)) >= min_vol]
+        low_vol_count = len(stale_gamma_filtered) - len(volume_filtered)
+        if low_vol_count:
+            print(f"  Filtered {low_vol_count} markets with volume < ${min_vol:,.0f}")
+
+        ranked = sorted(volume_filtered, key=score, reverse=True)
 
         # Filter out markets resolving too far in the future
         now = datetime.now(timezone.utc)
@@ -316,7 +324,52 @@ class TradingAgent:
         if slug_skips > 0:
             print(f"  Deduped {slug_skips} markets exceeding {MAX_PER_SLUG_GROUP}/slug-group cap")
 
-        pre_selected = deduped[:limit]
+        # --- Event-group deduplication: max 5 markets per sporting/political event ---
+        # Polymarket templates one market per team/candidate for multi-outcome events
+        # (e.g. 30 "Will X win the NBA Finals?" markets). The slug dedup catches some
+        # but misses variants with different slug prefixes. This extracts the event
+        # name and caps per event.
+        MAX_PER_EVENT_GROUP = 5
+        EVENT_PATTERNS = [
+            # "Will X win the 2026 NBA Finals?" → "2026 nba finals"
+            re.compile(r'win (?:the )?((?:\d{4}[\s\-])?(?:nba|nhl|mlb|nfl|fifa|uefa|f1|afl|mls|wnba|ncaa)[\w\s\-]+(?:finals?|cup|championship|trophy|series|prix|bowl|league|tournament|primary|election|season))', re.IGNORECASE),
+            # "X: Points O/U 12.5" → extract sport event from context
+            re.compile(r'((?:nba|nhl|mlb|nfl|fifa|uefa|f1|eurovision|oscar|emmy|grammy)[\w\s\-]*(?:finals?|cup|championship|trophy|series|prix|bowl|league|tournament|award|contest|song))', re.IGNORECASE),
+            # "Will X be the {party} nominee for {office}" → "{party} nominee {office}"
+            re.compile(r'((?:republican|democratic|democrat) nominee (?:for )?[\w\s]+(?:senate|governor|house|president))', re.IGNORECASE),
+        ]
+
+        def _extract_event(question: str) -> str:
+            """Extract event name from market question, or empty string."""
+            for pattern in EVENT_PATTERNS:
+                match = pattern.search(question)
+                if match:
+                    # Normalize: lowercase, collapse whitespace
+                    return re.sub(r'\s+', ' ', match.group(1).strip().lower())
+            return ''
+
+        event_group_counts: Dict[str, int] = {}
+        event_deduped = []
+        event_skips = 0
+        for m in deduped:
+            event = _extract_event(m.get('question', ''))
+            if not event:
+                event_deduped.append(m)
+                continue
+            count = event_group_counts.get(event, 0)
+            if count >= MAX_PER_EVENT_GROUP:
+                event_skips += 1
+                continue
+            event_group_counts[event] = count + 1
+            event_deduped.append(m)
+
+        if event_skips > 0:
+            top_events = sorted(event_group_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+            print(f"  Deduped {event_skips} template markets exceeding {MAX_PER_EVENT_GROUP}/event cap")
+            for ev, ct in top_events:
+                print(f"    {ev}: {ct} kept, rest deduped")
+
+        pre_selected = event_deduped[:limit]
 
         # Enrich with live CLOB midpoint prices. If CLOB is unavailable, keep only
         # markets that already have a non-fallback Gamma price.

--- a/tests/test_market_selection_gates.py
+++ b/tests/test_market_selection_gates.py
@@ -1,14 +1,16 @@
 """Verify market selection sanity gates in polymarket/bot.
 
-Tests the three fixes from issue #286:
-1. Gamma API query uses sort_by=volume and end_date filters
+Tests fixes from issue #286:
+1. Gamma API query params (end_date filters, sort_by passthrough)
 2. Extreme-divergence sanity gate blocks absurd AI-vs-market gaps
 3. Min buy price floor blocks penny-market BUY signals
+4. Min volume floor rejects zero-volume seeded markets
+5. Event-group dedup catches template-generated sibling markets
+6. Gamma sort not trusted — client-side ranking does the real work
 """
 
 from __future__ import annotations
 
-import ast
 import re
 from pathlib import Path
 
@@ -22,7 +24,7 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-# --- Fix 1: Smarter Gamma query ---
+# --- Fix 1: Gamma query params ---
 
 
 def test_get_markets_accepts_sort_and_date_params() -> None:
@@ -31,28 +33,23 @@ def test_get_markets_accepts_sort_and_date_params() -> None:
     assert "sort_by" in source, "get_markets missing sort_by parameter"
     assert "end_date_min" in source, "get_markets missing end_date_min parameter"
     assert "end_date_max" in source, "get_markets missing end_date_max parameter"
-    assert "order=" in source, "get_markets not passing order= to Gamma API"
 
 
-def test_scan_markets_uses_volume_sort() -> None:
-    """scan_markets must request volume-sorted results from Gamma."""
+def test_scan_markets_does_not_trust_gamma_sort() -> None:
+    """scan_markets must NOT rely on Gamma's sort order (tested unreliable).
+    It should pass sort_by='' or omit it, and let rank_candidates score."""
     source = _read(BOT_AGENT)
-    # Find the scan_markets method and verify it passes sort_by="volume"
-    assert re.search(r'sort_by\s*=\s*["\']volume["\']', source), (
-        "scan_markets does not pass sort_by='volume' to get_markets"
+    # Should NOT have sort_by="volume" — Gamma's sort is broken
+    assert not re.search(r'sort_by\s*=\s*["\']volume["\']', source), (
+        "scan_markets still trusts Gamma sort_by='volume' — this is unreliable"
     )
 
 
 def test_scan_markets_uses_server_side_date_filter() -> None:
-    """scan_markets must pass end_date_min/max to avoid fetching markets
-    that will be discarded client-side."""
+    """scan_markets must pass end_date_min/max to avoid fetching expired markets."""
     source = _read(BOT_AGENT)
-    assert "end_date_min=" in source or "end_date_min" in source, (
-        "scan_markets does not pass end_date_min to get_markets"
-    )
-    assert "end_date_max=" in source or "end_date_max" in source, (
-        "scan_markets does not pass end_date_max to get_markets"
-    )
+    assert "end_date_min" in source, "scan_markets does not pass end_date_min"
+    assert "end_date_max" in source, "scan_markets does not pass end_date_max"
 
 
 # --- Fix 2: Extreme-divergence sanity gate ---
@@ -73,63 +70,94 @@ def test_max_divergence_default_is_50pp() -> None:
     source = _read(BOT_AGENT)
     match = re.search(r"['\"]max_divergence['\"],\s*([\d.]+)", source)
     assert match, "Cannot find max_divergence default in agent.py"
-    assert float(match.group(1)) == 0.50, (
-        f"max_divergence default should be 0.50, got {match.group(1)}"
-    )
+    assert float(match.group(1)) == 0.50
 
 
 def test_max_divergence_in_config_example() -> None:
-    """config.example.json must include max_divergence."""
     config_text = _read(BOT_CONFIG)
-    assert "max_divergence" in config_text, (
-        "config.example.json missing max_divergence field"
-    )
+    assert "max_divergence" in config_text
 
 
 # --- Fix 3: Min buy price floor ---
 
 
 def test_min_buy_price_gate_exists() -> None:
-    """evaluate_opportunity must block BUY signals on markets priced below
-    min_buy_price (default 2%)."""
     source = _read(BOT_AGENT)
-    assert "min_buy_price" in source, "agent.py missing min_buy_price config"
+    assert "min_buy_price" in source
 
 
 def test_min_buy_price_default_is_2pct() -> None:
-    """min_buy_price default must be 0.02 (2%)."""
     source = _read(BOT_AGENT)
     match = re.search(r"['\"]min_buy_price['\"],\s*([\d.]+)", source)
     assert match, "Cannot find min_buy_price default in agent.py"
-    assert float(match.group(1)) == 0.02, (
-        f"min_buy_price default should be 0.02, got {match.group(1)}"
-    )
+    assert float(match.group(1)) == 0.02
 
 
 def test_min_buy_price_in_config_example() -> None:
-    """config.example.json must include min_buy_price."""
     config_text = _read(BOT_CONFIG)
-    assert "min_buy_price" in config_text, (
-        "config.example.json missing min_buy_price field"
-    )
+    assert "min_buy_price" in config_text
 
 
-# --- Gate ordering: both gates must fire before Kelly sizing ---
+# --- Fix 4: Min volume floor ---
+
+
+def test_min_volume_filter_exists() -> None:
+    """rank_candidates must reject markets below min_volume."""
+    source = _read(BOT_AGENT)
+    assert "min_volume" in source, "agent.py missing min_volume config"
+
+
+def test_min_volume_default_is_1000() -> None:
+    source = _read(BOT_AGENT)
+    match = re.search(r"['\"]min_volume['\"],\s*([\d.]+)", source)
+    assert match, "Cannot find min_volume default in agent.py"
+    assert float(match.group(1)) == 1000.0
+
+
+def test_min_volume_in_config_example() -> None:
+    config_text = _read(BOT_CONFIG)
+    assert "min_volume" in config_text
+
+
+# --- Fix 5: Event-group dedup ---
+
+
+def test_event_group_dedup_exists() -> None:
+    """rank_candidates must deduplicate template-generated markets per event
+    (e.g. 30 'Will X win the NBA Finals?' markets capped to 5)."""
+    source = _read(BOT_AGENT)
+    assert "MAX_PER_EVENT_GROUP" in source, "agent.py missing event-group dedup"
+    assert "event_skips" in source, "agent.py missing event_skips counter"
+
+
+def test_event_patterns_cover_major_sports() -> None:
+    """Event patterns must match NBA, NHL, FIFA, F1, and election markets."""
+    source = _read(BOT_AGENT)
+    for keyword in ("nba", "nhl", "fifa", "f1", "republican", "democratic"):
+        assert keyword in source.lower(), (
+            f"Event-group patterns missing coverage for '{keyword}' markets"
+        )
+
+
+# --- Gate ordering ---
 
 
 def test_gates_fire_before_kelly() -> None:
-    """The divergence and min-price gates must appear before Kelly position
-    sizing in evaluate_opportunity, so absurd values never reach the sizer."""
+    """The divergence and min-price gates must appear before Kelly sizing."""
     source = _read(BOT_AGENT)
     div_pos = source.find("max_divergence")
     price_pos = source.find("min_buy_price")
     kelly_pos = source.find("calculate_position_size")
-    assert div_pos > 0, "max_divergence not found in agent.py"
-    assert price_pos > 0, "min_buy_price not found in agent.py"
-    assert kelly_pos > 0, "calculate_position_size not found in agent.py"
-    assert price_pos < kelly_pos, (
-        "min_buy_price gate must appear before calculate_position_size"
-    )
-    assert div_pos < kelly_pos, (
-        "max_divergence gate must appear before calculate_position_size"
-    )
+    assert div_pos > 0 and price_pos > 0 and kelly_pos > 0
+    assert price_pos < kelly_pos, "min_buy_price gate must appear before Kelly"
+    assert div_pos < kelly_pos, "max_divergence gate must appear before Kelly"
+
+
+def test_volume_filter_before_slug_dedup() -> None:
+    """min_volume filter must run before slug-group dedup to reduce the
+    candidate set that dedup iterates over."""
+    source = _read(BOT_AGENT)
+    vol_pos = source.find("min_volume")
+    slug_pos = source.find("MAX_PER_SLUG_GROUP")
+    assert vol_pos > 0 and slug_pos > 0
+    assert vol_pos < slug_pos, "min_volume filter must run before slug dedup"


### PR DESCRIPTION
## Summary

Follow-up to PR #288 after live testing proved Gamma's sort order is unreliable.

- **Drop Gamma sort** — `order=volume` returns zero-volume seeded markets above actually-traded ones. Now fetches unsorted and lets the client-side ranker (`log1p(liq) + log1p(vol)*2`) do the real work
- **Add `min_volume` floor** (default $1,000) — rejects markets seeded by Gamma market makers but never traded ($9,999 liquidity, $0 volume)
- **Add event-group dedup** (max 5 per event) — catches Polymarket's template market generation where they create one market per team/candidate per event (30 NBA Finals, 32 FIFA World Cup, etc.). Regex patterns cover NBA, NHL, FIFA, F1, MLB, NFL, UEFA, elections. Runs as a second dedup layer after slug-group

## Live test evidence

Before this fix, fetching 50 markets sorted by volume returned:
- 8 penny-priced junk markets ($9.9M volume, 0.1-0.4% price) — blocked by buy floor
- 32 stale 50/50 Gamma-seeded markets — filtered
- 9 surviving markets all had <$1,000 volume (weather, micro sports)

## Test plan

- [x] 16 tests covering all 6 fixes — all PASSED
- [x] `test_scan_markets_does_not_trust_gamma_sort` verifies sort_by=volume is gone
- [x] `test_min_volume_default_is_1000` + config presence
- [x] `test_event_group_dedup_exists` + `test_event_patterns_cover_major_sports`
- [x] `test_volume_filter_before_slug_dedup` verifies ordering

Closes #286

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com