### PR TITLE
feat(polymarket): add calibration-driven edge threshold (replace hardcoded 8%)

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -39,6 +39,7 @@ from position_tracker import PositionTracker
 from logger import TradingLogger
 from serendb_storage import SerenDBStorage
 import kelly
+import calibration
 
 
 class TradingAgent:
@@ -109,9 +110,15 @@ class TradingAgent:
         self.min_buy_price = float(self.config.get('min_buy_price', 0.02))
         self.min_volume = float(self.config.get('min_volume', 1000.0))
 
+        # Calibration-driven threshold override
+        self._calibration = calibration.load_calibration()
+        self.effective_mispricing_threshold, self._threshold_reason = (
+            calibration.effective_threshold(self.mispricing_threshold, self._calibration)
+        )
+
         print(f"✓ Agent initialized (Dry-run: {dry_run})")
         print(f"  Bankroll: ${self.bankroll:.2f}")
-        print(f"  Mispricing threshold: {self.mispricing_threshold * 100:.1f}%")
+        print(f"  Mispricing threshold: {self.effective_mispricing_threshold * 100:.1f}% ({self._threshold_reason})")
         print(f"  Max Kelly fraction: {self.max_kelly_fraction * 100:.1f}%")
         print(f"  Max positions: {self.max_positions}")
         print(f"  Scan pipeline: fetch={self.scan_limit} → candidates={self.candidate_limit} → analyze={self.analyze_limit}")
@@ -536,9 +543,9 @@ class TradingAgent:
         # Calculate edge
         edge = kelly.calculate_edge(fair_value, current_price)
 
-        # Check if edge exceeds threshold
-        if edge < self.mispricing_threshold:
-            print(f"    ✗ Edge {edge * 100:.1f}% below threshold {self.mispricing_threshold * 100:.1f}%")
+        # Check if edge exceeds threshold (uses calibrated threshold if available)
+        if edge < self.effective_mispricing_threshold:
+            print(f"    ✗ Edge {edge * 100:.1f}% below threshold {self.effective_mispricing_threshold * 100:.1f}%")
             return None
 
         # Annualized return gate: edge must justify the lockup period
@@ -793,6 +800,21 @@ class TradingAgent:
             if not fair_value:
                 continue
 
+            # Save prediction for calibration tracking
+            if self.storage:
+                try:
+                    self.storage.save_prediction({
+                        'market_id': market['market_id'],
+                        'market_question': market['question'],
+                        'predicted_fair_value': fair_value,
+                        'market_price_at_prediction': market['price'],
+                        'edge_calculated': abs(fair_value - market['price']),
+                        'prediction_timestamp': datetime.now(timezone.utc).isoformat(),
+                        'confidence': confidence,
+                    })
+                except Exception:
+                    pass  # Non-blocking
+
             opp = self.evaluate_opportunity(market, research, fair_value, confidence)
             if opp:
                 opportunities.append(opp)
@@ -833,6 +855,20 @@ class TradingAgent:
         print(f"  Capital deployed: ${capital_deployed:.2f}")
         print(f"  Estimated API cost: ~${api_cost:.2f} SerenBucks")
         print("=" * 60)
+
+        # Non-blocking post-scan calibration
+        try:
+            cal = calibration.run_post_scan_calibration(
+                self.polymarket, self.storage, self.mispricing_threshold
+            )
+            if cal:
+                self._calibration = cal
+                self.effective_mispricing_threshold, self._threshold_reason = (
+                    calibration.effective_threshold(self.mispricing_threshold, cal)
+                )
+        except Exception as e:
+            print(f"  Calibration error (non-blocking): {e}")
+
         print()
 
         return len(opportunities)
@@ -912,7 +948,7 @@ def main():
 
         for iteration in range(1, max_iterations + 1):
             print(f"\n>>> Iteration {iteration}/{max_iterations}  "
-                  f"mispricing_threshold={agent.mispricing_threshold:.4f}  "
+                  f"effective_threshold={agent.effective_mispricing_threshold:.4f}  "
                   f"scan_limit={agent.scan_limit}  "
                   f"min_annualized_return={agent.min_annualized_return:.4f}")
 

--- a/polymarket/bot/scripts/calibration.py
+++ b/polymarket/bot/scripts/calibration.py
@@ -1,0 +1,321 @@
+"""LLM calibration module for Polymarket bot.
+
+Computes data-driven edge thresholds from historical prediction accuracy.
+Non-blocking — runs after the scan/trade pipeline completes.
+
+Components:
+1. resolution_sweep()  — match unresolved predictions against Gamma closed markets
+2. compute_calibration() — compute MAE from resolved predictions
+3. load_calibration() / save_calibration() — local state/calibration.json cache
+4. effective_threshold() — returns max(config_threshold, calibrated_threshold)
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Minimum resolved predictions before calibration takes effect
+MIN_RESOLVED_FOR_CALIBRATION = 50
+
+# Added to MAE to account for CLOB spread cost and safety margin
+SPREAD_COST = 0.03
+SAFETY_MARGIN = 0.02
+
+STATE_DIR = Path(__file__).resolve().parents[1] / "state"
+CALIBRATION_FILE = STATE_DIR / "calibration.json"
+
+
+def load_calibration() -> Optional[Dict[str, Any]]:
+    """Load calibration from local cache. Returns None if not available."""
+    try:
+        if CALIBRATION_FILE.exists():
+            return json.loads(CALIBRATION_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def save_calibration(cal: Dict[str, Any]) -> None:
+    """Write calibration to local cache."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    CALIBRATION_FILE.write_text(
+        json.dumps(cal, indent=2, default=str), encoding="utf-8"
+    )
+
+
+def effective_threshold(config_threshold: float, calibration: Optional[Dict[str, Any]] = None) -> tuple[float, str]:
+    """Return (effective_threshold, reason) based on config and calibration.
+
+    The calibration can only RAISE the threshold above config, never lower it.
+    """
+    if calibration is None:
+        calibration = load_calibration()
+
+    if not calibration:
+        return config_threshold, "config (no calibration data)"
+
+    resolved = calibration.get("resolved_count", 0)
+    if resolved < MIN_RESOLVED_FOR_CALIBRATION:
+        return config_threshold, f"config (calibration: {resolved}/{MIN_RESOLVED_FOR_CALIBRATION} markets resolved)"
+
+    cal_threshold = calibration.get("calibrated_threshold", 0.0)
+    if cal_threshold > config_threshold:
+        return cal_threshold, (
+            f"calibrated from {resolved} resolved markets "
+            f"(MAE {calibration.get('median_absolute_error', 0)*100:.1f}% "
+            f"+ {SPREAD_COST*100:.0f}% spread + {SAFETY_MARGIN*100:.0f}% safety)"
+        )
+
+    return config_threshold, f"config (calibrated {cal_threshold*100:.1f}% is lower)"
+
+
+def resolution_sweep(polymarket_client: Any, storage: Any) -> int:
+    """Sweep recently resolved markets and update prediction outcomes.
+
+    Queries Gamma for closed markets, matches against unresolved predictions
+    in SerenDB, and writes resolution outcomes.
+
+    Returns number of predictions resolved.
+    """
+    if storage is None:
+        return 0
+
+    try:
+        unresolved = storage.get_unresolved_predictions()
+    except Exception:
+        return 0
+
+    if not unresolved:
+        return 0
+
+    # Build lookup of unresolved market_ids
+    # Handle both dict rows and list rows
+    unresolved_by_id: Dict[str, Dict] = {}
+    for pred in unresolved:
+        if isinstance(pred, dict):
+            mid = pred.get("market_id", "")
+        elif isinstance(pred, (list, tuple)):
+            mid = pred[0] if pred else ""
+        else:
+            continue
+        if mid:
+            unresolved_by_id[mid] = pred
+
+    if not unresolved_by_id:
+        return 0
+
+    # Fetch recently closed markets from Gamma
+    try:
+        response = polymarket_client.seren.call_publisher(
+            publisher="polymarket-data",
+            method="GET",
+            path="/markets?limit=200&closed=true&active=false",
+        )
+        closed_markets = response.get("body", [])
+        if not closed_markets and "data" in response:
+            closed_markets = response.get("data", [])
+    except Exception:
+        return 0
+
+    resolved_count = 0
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    for market in closed_markets:
+        condition_id = market.get("conditionId") or market.get("id", "")
+        if condition_id not in unresolved_by_id:
+            continue
+
+        # Determine resolution outcome from outcomePrices
+        # Resolved markets have prices at 1.0/0.0 (or very close)
+        raw_prices = market.get("outcomePrices")
+        if not raw_prices:
+            continue
+
+        try:
+            if isinstance(raw_prices, str):
+                prices = json.loads(raw_prices)
+            else:
+                prices = raw_prices
+            yes_price = float(str(prices[0]).strip())
+        except (json.JSONDecodeError, IndexError, ValueError, TypeError):
+            continue
+
+        # Resolved YES = price ~1.0, resolved NO = price ~0.0
+        if yes_price > 0.95:
+            outcome = "YES"
+            actual_prob = 1.0
+        elif yes_price < 0.05:
+            outcome = "NO"
+            actual_prob = 0.0
+        else:
+            continue  # Not fully resolved yet
+
+        try:
+            storage.update_prediction_resolution(
+                market_id=condition_id,
+                resolution_outcome=outcome,
+                resolution_timestamp=now_iso,
+                actual_probability=actual_prob,
+            )
+            resolved_count += 1
+        except Exception:
+            continue
+
+    return resolved_count
+
+
+def compute_calibration(storage: Any) -> Optional[Dict[str, Any]]:
+    """Compute calibration metrics from resolved predictions.
+
+    Returns calibration dict if enough data, None otherwise.
+    """
+    if storage is None:
+        return None
+
+    try:
+        resolved = storage.get_resolved_predictions(limit=5000)
+    except Exception:
+        return None
+
+    if not resolved or len(resolved) < MIN_RESOLVED_FOR_CALIBRATION:
+        return None
+
+    # Compute MAE per confidence bucket
+    errors_all: List[float] = []
+    errors_by_confidence: Dict[str, List[float]] = {"low": [], "medium": [], "high": []}
+
+    for pred in resolved:
+        if isinstance(pred, dict):
+            fv = pred.get("predicted_fair_value")
+            actual = pred.get("actual_probability")
+            confidence = pred.get("confidence", "medium")
+        elif isinstance(pred, (list, tuple)):
+            # Fallback for list-style rows — positions depend on schema
+            continue
+        else:
+            continue
+
+        if fv is None or actual is None:
+            continue
+
+        try:
+            error = abs(float(fv) - float(actual))
+        except (ValueError, TypeError):
+            continue
+
+        errors_all.append(error)
+        bucket = str(confidence).lower() if confidence else "medium"
+        if bucket in errors_by_confidence:
+            errors_by_confidence[bucket].append(error)
+
+    if len(errors_all) < MIN_RESOLVED_FOR_CALIBRATION:
+        return None
+
+    mae = statistics.median(errors_all)
+    calibrated_threshold = mae + SPREAD_COST + SAFETY_MARGIN
+
+    cal = {
+        "resolved_count": len(errors_all),
+        "median_absolute_error": round(mae, 4),
+        "calibrated_threshold": round(calibrated_threshold, 4),
+        "computed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Per-confidence MAE (only if bucket has data)
+    for bucket, errors in errors_by_confidence.items():
+        if errors:
+            cal[f"{bucket}_confidence_mae"] = round(statistics.median(errors), 4)
+            cal[f"{bucket}_confidence_count"] = len(errors)
+
+    # Save to local cache
+    save_calibration(cal)
+
+    # Save to SerenDB
+    try:
+        storage.save_performance_metrics({
+            "calculated_at": cal["computed_at"],
+            "total_predictions": len(errors_all),
+            "resolved_predictions": len(errors_all),
+            "avg_brier_score": None,
+            "calibration_slope": None,
+            "calibration_intercept": None,
+            "edge_threshold": calibrated_threshold,
+        })
+    except Exception:
+        pass  # Local cache is sufficient
+
+    return cal
+
+
+def print_calibration_report(cal: Optional[Dict[str, Any]], config_threshold: float) -> None:
+    """Print calibration summary after scan."""
+    if not cal:
+        unresolved_count = cal.get("resolved_count", 0) if cal else 0
+        print(f"Calibration: {unresolved_count}/{MIN_RESOLVED_FOR_CALIBRATION} markets resolved "
+              f"(need {MIN_RESOLVED_FOR_CALIBRATION - unresolved_count} more for data-driven threshold)")
+        return
+
+    resolved = cal.get("resolved_count", 0)
+    if resolved < MIN_RESOLVED_FOR_CALIBRATION:
+        print(f"Calibration: {resolved}/{MIN_RESOLVED_FOR_CALIBRATION} markets resolved "
+              f"(need {MIN_RESOLVED_FOR_CALIBRATION - resolved} more for data-driven threshold)")
+        return
+
+    mae = cal.get("median_absolute_error", 0)
+    cal_thresh = cal.get("calibrated_threshold", 0)
+    eff, _ = effective_threshold(config_threshold, cal)
+
+    print(f"LLM Calibration (N={resolved} resolved):")
+    print(f"  Overall MAE: {mae*100:.1f}%")
+
+    for bucket in ("high", "medium", "low"):
+        bucket_mae = cal.get(f"{bucket}_confidence_mae")
+        bucket_n = cal.get(f"{bucket}_confidence_count", 0)
+        if bucket_mae is not None:
+            print(f"  {bucket.capitalize()}-confidence MAE: {bucket_mae*100:.1f}% (N={bucket_n})")
+
+    print(f"  Calibrated threshold: {cal_thresh*100:.1f}% "
+          f"(MAE {mae*100:.1f}% + {SPREAD_COST*100:.0f}% spread + {SAFETY_MARGIN*100:.0f}% safety)")
+    print(f"  Config threshold: {config_threshold*100:.1f}%")
+    print(f"  Effective threshold: {eff*100:.1f}% ({'calibrated' if eff > config_threshold else 'config'})")
+
+
+def run_post_scan_calibration(
+    polymarket_client: Any,
+    storage: Any,
+    config_threshold: float,
+) -> Optional[Dict[str, Any]]:
+    """Non-blocking post-scan calibration pipeline.
+
+    Runs resolution sweep + calibration computation + report.
+    Returns calibration dict if computed, None otherwise.
+    """
+    print()
+    print("--- Post-scan calibration ---")
+
+    # Step 1: Resolution sweep
+    try:
+        resolved_count = resolution_sweep(polymarket_client, storage)
+        if resolved_count > 0:
+            print(f"  Resolved {resolved_count} predictions from closed markets")
+    except Exception as e:
+        print(f"  Resolution sweep failed: {e}")
+
+    # Step 2: Compute calibration
+    cal = None
+    try:
+        cal = compute_calibration(storage)
+    except Exception as e:
+        print(f"  Calibration computation failed: {e}")
+
+    # Step 3: Print report
+    if cal is None:
+        cal = load_calibration()  # Try local cache
+    print_calibration_report(cal, config_threshold)
+
+    return cal

--- a/tests/test_calibration_threshold.py
+++ b/tests/test_calibration_threshold.py
@@ -1,0 +1,180 @@
+"""Verify calibration-driven edge threshold for polymarket/bot.
+
+Tests the four components from issue #291:
+1. effective_threshold — calibration only raises, never lowers
+2. compute_calibration — MAE + spread + safety = calibrated threshold
+3. load/save_calibration — local state file
+4. Agent integration — effective threshold used instead of config threshold
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CAL_PATH = REPO_ROOT / "polymarket" / "bot" / "scripts" / "calibration.py"
+AGENT_PATH = REPO_ROOT / "polymarket" / "bot" / "scripts" / "agent.py"
+
+
+def _load_calibration_module():
+    """Load calibration.py in isolation."""
+    spec = importlib.util.spec_from_file_location("calibration", CAL_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cal():
+    return _load_calibration_module()
+
+
+# --- effective_threshold: only raises, never lowers ---
+
+
+class TestEffectiveThreshold:
+
+    def test_no_calibration_uses_config(self, cal) -> None:
+        threshold, reason = cal.effective_threshold(0.08, None)
+        assert threshold == 0.08
+        assert "config" in reason
+
+    def test_insufficient_data_uses_config(self, cal) -> None:
+        threshold, reason = cal.effective_threshold(0.08, {"resolved_count": 30})
+        assert threshold == 0.08
+        assert "30/50" in reason
+
+    def test_calibration_raises_threshold(self, cal) -> None:
+        calibration_data = {
+            "resolved_count": 100,
+            "median_absolute_error": 0.14,
+            "calibrated_threshold": 0.19,
+        }
+        threshold, reason = cal.effective_threshold(0.08, calibration_data)
+        assert threshold == 0.19
+        assert "calibrated" in reason
+
+    def test_calibration_never_lowers_threshold(self, cal) -> None:
+        """Critical safety rule: calibration can only raise, never lower."""
+        calibration_data = {
+            "resolved_count": 100,
+            "median_absolute_error": 0.02,
+            "calibrated_threshold": 0.05,  # Lower than config 0.08
+        }
+        threshold, reason = cal.effective_threshold(0.08, calibration_data)
+        assert threshold == 0.08, "Calibration must never lower the threshold below config"
+        assert "config" in reason
+
+
+# --- compute_calibration ---
+
+
+class TestComputeCalibration:
+
+    def test_returns_none_below_minimum(self, cal) -> None:
+        storage = MagicMock()
+        storage.get_resolved_predictions.return_value = [
+            {"predicted_fair_value": 0.7, "actual_probability": 1.0, "confidence": "medium"}
+            for _ in range(30)
+        ]
+        result = cal.compute_calibration(storage)
+        assert result is None
+
+    def test_computes_mae_above_minimum(self, cal, tmp_path) -> None:
+        # Temporarily redirect calibration file
+        original = cal.CALIBRATION_FILE
+        cal.CALIBRATION_FILE = tmp_path / "calibration.json"
+        cal.STATE_DIR = tmp_path
+
+        try:
+            storage = MagicMock()
+            # 60 predictions: predicted 0.6, actual was 1.0 → error = 0.4 each
+            storage.get_resolved_predictions.return_value = [
+                {"predicted_fair_value": 0.6, "actual_probability": 1.0, "confidence": "high"}
+                for _ in range(60)
+            ]
+            result = cal.compute_calibration(storage)
+            assert result is not None
+            assert result["resolved_count"] == 60
+            assert result["median_absolute_error"] == 0.4
+            # calibrated = MAE(0.4) + spread(0.03) + safety(0.02) = 0.45
+            assert result["calibrated_threshold"] == 0.45
+            assert result["high_confidence_mae"] == 0.4
+        finally:
+            cal.CALIBRATION_FILE = original
+            cal.STATE_DIR = original.parent
+
+    def test_none_storage_returns_none(self, cal) -> None:
+        assert cal.compute_calibration(None) is None
+
+
+# --- load/save calibration ---
+
+
+class TestCalibrationPersistence:
+
+    def test_save_and_load(self, cal, tmp_path) -> None:
+        original_file = cal.CALIBRATION_FILE
+        original_dir = cal.STATE_DIR
+        cal.CALIBRATION_FILE = tmp_path / "calibration.json"
+        cal.STATE_DIR = tmp_path
+
+        try:
+            data = {
+                "resolved_count": 100,
+                "median_absolute_error": 0.14,
+                "calibrated_threshold": 0.19,
+            }
+            cal.save_calibration(data)
+            loaded = cal.load_calibration()
+            assert loaded["resolved_count"] == 100
+            assert loaded["calibrated_threshold"] == 0.19
+        finally:
+            cal.CALIBRATION_FILE = original_file
+            cal.STATE_DIR = original_dir
+
+    def test_load_missing_file_returns_none(self, cal, tmp_path) -> None:
+        original = cal.CALIBRATION_FILE
+        cal.CALIBRATION_FILE = tmp_path / "nonexistent.json"
+        try:
+            assert cal.load_calibration() is None
+        finally:
+            cal.CALIBRATION_FILE = original
+
+
+# --- Agent integration ---
+
+
+class TestAgentIntegration:
+
+    def test_agent_uses_effective_threshold(self) -> None:
+        """agent.py must use effective_mispricing_threshold, not mispricing_threshold,
+        for the edge comparison in evaluate_opportunity."""
+        source = AGENT_PATH.read_text(encoding="utf-8")
+        assert "effective_mispricing_threshold" in source
+        assert "import calibration" in source
+
+    def test_agent_saves_predictions(self) -> None:
+        """agent.py must call save_prediction in the LLM analysis loop."""
+        source = AGENT_PATH.read_text(encoding="utf-8")
+        assert "save_prediction" in source
+
+    def test_agent_runs_post_scan_calibration(self) -> None:
+        """agent.py must call run_post_scan_calibration after scan completes."""
+        source = AGENT_PATH.read_text(encoding="utf-8")
+        assert "run_post_scan_calibration" in source
+
+    def test_effective_threshold_before_kelly(self) -> None:
+        """Effective threshold check must appear before Kelly sizing."""
+        source = AGENT_PATH.read_text(encoding="utf-8")
+        eff_pos = source.find("effective_mispricing_threshold")
+        kelly_pos = source.find("calculate_position_size")
+        assert eff_pos > 0 and kelly_pos > 0
+        assert eff_pos < kelly_pos


### PR DESCRIPTION
## Summary

Replace the hardcoded 8% mispricing threshold with a data-driven one based on LLM prediction accuracy. Four non-blocking components:

- **Resolution sweep** — after each scan, matches unresolved predictions against Gamma closed markets and writes outcomes to SerenDB
- **Calibration computation** — when N >= 50 resolved, computes `calibrated_threshold = median_absolute_error + 3% spread + 2% safety`
- **Effective threshold** — `max(config, calibrated)`. Can only raise, never lower. Prevents early biased samples from making the bot more aggressive
- **Prediction saving** — every LLM fair value estimate persisted for later resolution matching

## How it works at runtime

Cold start (< 50 resolved):
```
Mispricing threshold: 8.0% (config, calibration: 12/50 markets resolved)
```

After calibration kicks in:
```
Mispricing threshold: 19.0% (calibrated from 127 resolved markets)
LLM Calibration (N=127 resolved):
  Overall MAE: 14.2%
  High-confidence MAE: 9.8% (N=41)
  Medium-confidence MAE: 16.1% (N=72)
  Calibrated threshold: 19.0% (MAE 14.2% + 3% spread + 2% safety)
  Config threshold: 8.0%
  Effective threshold: 19.0% (calibrated)
```

## Test plan

- [x] `test_no_calibration_uses_config` — no data falls back to config
- [x] `test_insufficient_data_uses_config` — <50 resolved uses config
- [x] `test_calibration_raises_threshold` — calibrated > config is used
- [x] `test_calibration_never_lowers_threshold` — critical safety rule
- [x] `test_computes_mae_above_minimum` — MAE + spread + safety math
- [x] `test_returns_none_below_minimum` — <50 returns None
- [x] `test_save_and_load` — state/calibration.json persistence
- [x] `test_load_missing_file_returns_none`
- [x] `test_agent_uses_effective_threshold` — source verification
- [x] `test_agent_saves_predictions` — predictions persisted
- [x] `test_agent_runs_post_scan_calibration` — post-scan hook
- [x] `test_effective_threshold_before_kelly` — gate ordering
- (13/13 PASSED)

Closes #291

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com