### PR TITLE
fix(polymarket): add structured trade summary block to scan output

### DIFF
--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -856,6 +856,9 @@ class TradingAgent:
         print(f"  Estimated API cost: ~${api_cost:.2f} SerenBucks")
         print("=" * 60)
 
+        # Structured trade summary for LLM agents (issue #296)
+        print_trade_summary(opportunities, capital_deployed=capital_deployed)
+
         # Non-blocking post-scan calibration
         try:
             cal = calibration.run_post_scan_calibration(
@@ -872,6 +875,43 @@ class TradingAgent:
         print()
 
         return len(opportunities)
+
+
+def print_trade_summary(opportunities, *, capital_deployed=0.0, file=None):
+    """Print a structured, grep-able trade summary block.
+
+    Emits a contiguous block delimited by marker lines so any LLM agent
+    can extract the complete trade table without partial-read errors.
+    """
+    if not opportunities:
+        return
+
+    import sys as _sys
+    out = file or _sys.stdout
+
+    total_ev = sum(o['expected_value'] for o in opportunities)
+
+    print("=== DRY-RUN TRADE SUMMARY ===", file=out)
+    print("| # | Market | Side | Price | FV | Edge | Size | EV |", file=out)
+    print("|---|--------|------|-------|----|------|------|----|", file=out)
+    for i, opp in enumerate(opportunities, 1):
+        m = opp['market']
+        print(
+            f"| {i} "
+            f"| {m['question']} "
+            f"| {opp['side']} "
+            f"| {m['price'] * 100:.1f}% "
+            f"| {opp['fair_value'] * 100:.1f}% "
+            f"| {opp['edge'] * 100:.1f}% "
+            f"| ${opp['position_size']:.2f} "
+            f"| {'+' if opp['expected_value'] >= 0 else '-'}${abs(opp['expected_value']):.2f} |",
+            file=out,
+        )
+    print(
+        f"TOTAL_DEPLOYED: ${capital_deployed:.2f} | TOTAL_EV: {'+' if total_ev >= 0 else '-'}${abs(total_ev):.2f}",
+        file=out,
+    )
+    print("=== END TRADE SUMMARY ===", file=out)
 
 
 def _bootstrap_config_path(config_path: str) -> Path:

--- a/polymarket/tests/test_trade_summary.py
+++ b/polymarket/tests/test_trade_summary.py
@@ -1,0 +1,102 @@
+"""Tests for structured trade summary block output (issue #296).
+
+Verifies that scan output includes a contiguous, grep-able summary block
+so any LLM agent can extract complete trade data without partial reads.
+"""
+
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+BOT_SCRIPTS = str(Path(__file__).resolve().parent.parent / "bot" / "scripts")
+
+
+@pytest.fixture(autouse=True)
+def _add_bot_scripts_to_path():
+    if BOT_SCRIPTS not in sys.path:
+        sys.path.insert(0, BOT_SCRIPTS)
+    yield
+
+
+def _make_opportunities(n=3):
+    """Build n fake opportunity dicts matching agent.py's evaluate_opportunity return."""
+    opps = []
+    for i in range(n):
+        opps.append({
+            'market': {
+                'question': f'Test Market {i + 1}?',
+                'market_id': f'0x{i:040x}',
+                'price': 0.50 + i * 0.10,
+            },
+            'fair_value': 0.30 + i * 0.05,
+            'confidence': 'medium',
+            'edge': 0.15 + i * 0.02,
+            'side': 'SELL' if i % 2 == 0 else 'BUY',
+            'position_size': 5.00 + i,
+            'expected_value': 2.50 + i * 0.5,
+        })
+    return opps
+
+
+def test_summary_block_has_start_and_end_markers():
+    from agent import print_trade_summary
+
+    buf = StringIO()
+    print_trade_summary(_make_opportunities(2), capital_deployed=11.0, file=buf)
+    output = buf.getvalue()
+
+    assert "=== DRY-RUN TRADE SUMMARY ===" in output
+    assert "=== END TRADE SUMMARY ===" in output
+
+
+def test_summary_block_contains_all_trades():
+    from agent import print_trade_summary
+
+    opps = _make_opportunities(4)
+    buf = StringIO()
+    print_trade_summary(opps, capital_deployed=26.0, file=buf)
+    output = buf.getvalue()
+
+    for opp in opps:
+        assert opp['market']['question'] in output
+
+
+def test_summary_block_contains_all_fields_per_trade():
+    from agent import print_trade_summary
+
+    opps = _make_opportunities(1)
+    buf = StringIO()
+    print_trade_summary(opps, capital_deployed=5.0, file=buf)
+    output = buf.getvalue()
+
+    # Every row must have side, price, FV, edge, size, EV
+    assert "SELL" in output
+    assert "$5.00" in output
+    assert "+$2.50" in output
+
+
+def test_summary_block_includes_totals():
+    from agent import print_trade_summary
+
+    opps = _make_opportunities(2)
+    total_ev = sum(o['expected_value'] for o in opps)
+    buf = StringIO()
+    print_trade_summary(opps, capital_deployed=11.0, file=buf)
+    output = buf.getvalue()
+
+    assert "TOTAL_DEPLOYED" in output
+    assert "TOTAL_EV" in output
+    expected_ev = f"{'+' if total_ev >= 0 else '-'}${abs(total_ev):.2f}"
+    assert expected_ev in output
+
+
+def test_no_output_when_zero_opportunities():
+    from agent import print_trade_summary
+
+    buf = StringIO()
+    print_trade_summary([], capital_deployed=0.0, file=buf)
+    output = buf.getvalue()
+
+    assert output == ""


### PR DESCRIPTION
## Summary
- Adds a `print_trade_summary()` function that emits a contiguous, grep-able summary block at the end of every dry-run scan
- Block contains start/end markers (`=== DRY-RUN TRADE SUMMARY ===` / `=== END TRADE SUMMARY ===`) with a markdown table of every trade: #, Market, Side, Price, FV, Edge, Size, EV, plus totals
- Any LLM agent can now extract the complete trade table without partial-read reconstruction errors
- No output emitted when zero opportunities found
- Existing output format unchanged (additive only)

## Test plan
- [x] 5 new tests in `test_trade_summary.py` covering markers, all-trades, all-fields, totals, and zero-opportunity cases
- [x] All 5 pass, zero regressions in existing test suite (9 pre-existing failures confirmed on main)

Fixes #296

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com