### PR TITLE
fix(polymarket): split multi-statement DDL to prevent Python 3.14 hang

### DIFF
--- a/polymarket/bot/scripts/serendb_storage.py
+++ b/polymarket/bot/scripts/serendb_storage.py
@@ -190,131 +190,101 @@ class SerenDBStorage:
                 )
             """)
 
-            self._execute_sql("""
-                CREATE SCHEMA IF NOT EXISTS trading;
-
-                CREATE TABLE IF NOT EXISTS trading.strategy_runs (
-                    run_id UUID PRIMARY KEY,
-                    skill_slug TEXT NOT NULL,
-                    venue TEXT NOT NULL,
-                    strategy_name TEXT NOT NULL,
-                    mode TEXT NOT NULL,
-                    status TEXT NOT NULL,
+            # Extended trading schema — each statement executed individually.
+            # On Python 3.14 + macOS, a multi-statement DDL that returns 400
+            # hangs the process indefinitely (serenorg/seren-skills#298).
+            # Isolating each statement prevents the hang and allows the bot
+            # to continue with basic tables if the extended schema fails.
+            _extended_ddl = [
+                "CREATE SCHEMA IF NOT EXISTS trading",
+                """CREATE TABLE IF NOT EXISTS trading.strategy_runs (
+                    run_id UUID PRIMARY KEY, skill_slug TEXT NOT NULL,
+                    venue TEXT NOT NULL, strategy_name TEXT NOT NULL,
+                    mode TEXT NOT NULL, status TEXT NOT NULL,
                     dry_run BOOLEAN NOT NULL DEFAULT TRUE,
                     started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     completed_at TIMESTAMPTZ,
                     config JSONB NOT NULL DEFAULT '{}'::jsonb,
                     summary JSONB NOT NULL DEFAULT '{}'::jsonb,
-                    error_code TEXT,
-                    error_message TEXT,
+                    error_code TEXT, error_message TEXT,
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_strategy_runs_skill_mode_started
-                    ON trading.strategy_runs (skill_slug, mode, started_at DESC);
-
-                CREATE TABLE IF NOT EXISTS trading.order_events (
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_strategy_runs_skill_mode_started
+                    ON trading.strategy_runs (skill_slug, mode, started_at DESC)""",
+                """CREATE TABLE IF NOT EXISTS trading.order_events (
                     id BIGSERIAL PRIMARY KEY,
                     run_id UUID NOT NULL REFERENCES trading.strategy_runs(run_id) ON DELETE CASCADE,
-                    order_id TEXT,
-                    instrument_id TEXT,
-                    symbol TEXT,
-                    side TEXT,
-                    order_type TEXT,
-                    event_type TEXT NOT NULL,
-                    status TEXT,
-                    price NUMERIC(24, 10),
-                    quantity NUMERIC(24, 10),
-                    notional_usd NUMERIC(24, 10),
+                    order_id TEXT, instrument_id TEXT, symbol TEXT, side TEXT,
+                    order_type TEXT, event_type TEXT NOT NULL, status TEXT,
+                    price NUMERIC(24,10), quantity NUMERIC(24,10), notional_usd NUMERIC(24,10),
                     event_time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_order_events_run_time
-                    ON trading.order_events (run_id, event_time DESC);
-
-                CREATE TABLE IF NOT EXISTS trading.fills (
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_order_events_run_time
+                    ON trading.order_events (run_id, event_time DESC)""",
+                """CREATE TABLE IF NOT EXISTS trading.fills (
                     id BIGSERIAL PRIMARY KEY,
                     run_id UUID NOT NULL REFERENCES trading.strategy_runs(run_id) ON DELETE CASCADE,
-                    order_id TEXT,
-                    venue_fill_id TEXT,
-                    instrument_id TEXT,
-                    symbol TEXT,
-                    side TEXT,
-                    fill_price NUMERIC(24, 10),
-                    fill_quantity NUMERIC(24, 10),
-                    fee_usd NUMERIC(24, 10),
-                    notional_usd NUMERIC(24, 10),
-                    realized_pnl_usd NUMERIC(24, 10),
+                    order_id TEXT, venue_fill_id TEXT, instrument_id TEXT, symbol TEXT, side TEXT,
+                    fill_price NUMERIC(24,10), fill_quantity NUMERIC(24,10),
+                    fee_usd NUMERIC(24,10), notional_usd NUMERIC(24,10),
+                    realized_pnl_usd NUMERIC(24,10),
                     fill_time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_fills_run_time
-                    ON trading.fills (run_id, fill_time DESC);
-
-                CREATE TABLE IF NOT EXISTS trading.positions (
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_fills_run_time
+                    ON trading.fills (run_id, fill_time DESC)""",
+                """CREATE TABLE IF NOT EXISTS trading.positions (
                     id BIGSERIAL PRIMARY KEY,
                     run_id UUID NOT NULL REFERENCES trading.strategy_runs(run_id) ON DELETE CASCADE,
-                    position_key TEXT NOT NULL,
-                    instrument_id TEXT,
-                    symbol TEXT,
-                    side TEXT,
-                    quantity NUMERIC(24, 10),
-                    entry_price NUMERIC(24, 10),
-                    cost_basis_usd NUMERIC(24, 10),
-                    market_price NUMERIC(24, 10),
-                    market_value_usd NUMERIC(24, 10),
-                    unrealized_pnl_usd NUMERIC(24, 10),
-                    realized_pnl_usd NUMERIC(24, 10),
-                    status TEXT,
-                    opened_at TIMESTAMPTZ,
-                    closed_at TIMESTAMPTZ,
+                    position_key TEXT NOT NULL, instrument_id TEXT, symbol TEXT, side TEXT,
+                    quantity NUMERIC(24,10), entry_price NUMERIC(24,10), cost_basis_usd NUMERIC(24,10),
+                    market_price NUMERIC(24,10), market_value_usd NUMERIC(24,10),
+                    unrealized_pnl_usd NUMERIC(24,10), realized_pnl_usd NUMERIC(24,10),
+                    status TEXT, opened_at TIMESTAMPTZ, closed_at TIMESTAMPTZ,
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
                     UNIQUE (run_id, position_key)
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_positions_run_status
-                    ON trading.positions (run_id, status);
-
-                CREATE TABLE IF NOT EXISTS trading.position_marks (
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_positions_run_status
+                    ON trading.positions (run_id, status)""",
+                """CREATE TABLE IF NOT EXISTS trading.position_marks (
                     id BIGSERIAL PRIMARY KEY,
                     run_id UUID NOT NULL REFERENCES trading.strategy_runs(run_id) ON DELETE CASCADE,
-                    position_key TEXT NOT NULL,
-                    instrument_id TEXT,
-                    symbol TEXT,
-                    side TEXT,
-                    quantity NUMERIC(24, 10),
-                    mark_price NUMERIC(24, 10),
-                    market_value_usd NUMERIC(24, 10),
-                    unrealized_pnl_usd NUMERIC(24, 10),
-                    realized_pnl_usd NUMERIC(24, 10),
+                    position_key TEXT NOT NULL, instrument_id TEXT, symbol TEXT, side TEXT,
+                    quantity NUMERIC(24,10), mark_price NUMERIC(24,10), market_value_usd NUMERIC(24,10),
+                    unrealized_pnl_usd NUMERIC(24,10), realized_pnl_usd NUMERIC(24,10),
                     mark_time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_position_marks_run_time
-                    ON trading.position_marks (run_id, mark_time DESC);
-
-                CREATE TABLE IF NOT EXISTS trading.pnl_periods (
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_position_marks_run_time
+                    ON trading.position_marks (run_id, mark_time DESC)""",
+                """CREATE TABLE IF NOT EXISTS trading.pnl_periods (
                     id BIGSERIAL PRIMARY KEY,
                     run_id UUID NOT NULL REFERENCES trading.strategy_runs(run_id) ON DELETE CASCADE,
-                    period_type TEXT NOT NULL,
-                    period_start TIMESTAMPTZ,
+                    period_type TEXT NOT NULL, period_start TIMESTAMPTZ,
                     period_end TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    realized_pnl_usd NUMERIC(24, 10),
-                    unrealized_pnl_usd NUMERIC(24, 10),
-                    fees_usd NUMERIC(24, 10),
-                    gross_pnl_usd NUMERIC(24, 10),
-                    net_pnl_usd NUMERIC(24, 10),
-                    equity_start_usd NUMERIC(24, 10),
-                    equity_end_usd NUMERIC(24, 10),
+                    realized_pnl_usd NUMERIC(24,10), unrealized_pnl_usd NUMERIC(24,10),
+                    fees_usd NUMERIC(24,10), gross_pnl_usd NUMERIC(24,10), net_pnl_usd NUMERIC(24,10),
+                    equity_start_usd NUMERIC(24,10), equity_end_usd NUMERIC(24,10),
                     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
-                );
+                )""",
+                """CREATE INDEX IF NOT EXISTS idx_pnl_periods_run_end
+                    ON trading.pnl_periods (run_id, period_end DESC)""",
+            ]
 
-                CREATE INDEX IF NOT EXISTS idx_pnl_periods_run_end
-                    ON trading.pnl_periods (run_id, period_end DESC);
-            """)
+            extended_ok = 0
+            extended_fail = 0
+            for ddl in _extended_ddl:
+                try:
+                    self._execute_sql(ddl)
+                    extended_ok += 1
+                except Exception:
+                    extended_fail += 1
+
+            if extended_fail:
+                print(f"  Extended schema: {extended_ok} OK, {extended_fail} failed (non-blocking)")
+            else:
+                print(f"  Extended schema: {extended_ok} statements OK")
 
             print(f"✅ SerenDB setup complete")
             return True

--- a/tests/test_setup_db_no_hang.py
+++ b/tests/test_setup_db_no_hang.py
@@ -1,0 +1,88 @@
+"""Verify setup_database uses individual DDL statements to prevent Python 3.14 hang.
+
+Issue #298: A multi-statement DDL that returns 400 hangs Python 3.14 on macOS
+indefinitely. The fix executes each DDL statement individually so a failure in
+one statement doesn't block the process or prevent basic tables from being created.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORAGE_PATH = REPO_ROOT / "polymarket" / "bot" / "scripts" / "serendb_storage.py"
+
+
+def _read() -> str:
+    return STORAGE_PATH.read_text(encoding="utf-8")
+
+
+def test_no_multi_statement_ddl_in_setup_database() -> None:
+    """setup_database must NOT send multiple DDL statements in a single
+    _execute_sql call. Each CREATE TABLE/INDEX/SCHEMA must be its own call."""
+    source = _read()
+
+    # Find the setup_database method body
+    match = re.search(r'def setup_database\(self\).*?(?=\n    def )', source, re.DOTALL)
+    assert match, "setup_database method not found"
+    setup_body = match.group(0)
+
+    # Count _execute_sql calls that contain multiple CREATE statements
+    # A single _execute_sql call with 2+ CREATE keywords is the bug pattern
+    execute_calls = re.findall(
+        r'self\._execute_sql\("""(.*?)"""\)', setup_body, re.DOTALL
+    )
+    for call_body in execute_calls:
+        create_count = len(re.findall(r'\bCREATE\b', call_body, re.IGNORECASE))
+        assert create_count <= 1, (
+            f"Found _execute_sql call with {create_count} CREATE statements. "
+            "Each DDL must be its own _execute_sql call to prevent Python 3.14 hang."
+        )
+
+
+def test_extended_ddl_uses_individual_try_except() -> None:
+    """Each extended DDL statement must be wrapped in its own try/except
+    so a failure in one doesn't block the others."""
+    source = _read()
+
+    # The pattern: iterate over a list of DDL statements with per-statement try/except
+    assert "_extended_ddl" in source, (
+        "setup_database should use a _extended_ddl list for individual execution"
+    )
+    assert "for ddl in _extended_ddl" in source, (
+        "setup_database should iterate _extended_ddl with per-statement execution"
+    )
+
+
+def test_extended_ddl_failure_is_non_blocking() -> None:
+    """Extended schema DDL failures must not prevent setup_database from
+    returning True (basic tables are sufficient for the bot to run)."""
+    source = _read()
+    match = re.search(r'def setup_database\(self\).*?(?=\n    def )', source, re.DOTALL)
+    setup_body = match.group(0)
+
+    # The extended_fail counter must exist and not cause return False
+    assert "extended_fail" in setup_body, "Missing extended_fail counter"
+    assert "non-blocking" in setup_body.lower(), (
+        "Extended DDL failures should be logged as non-blocking"
+    )
+
+
+def test_basic_tables_each_have_own_execute_call() -> None:
+    """Core tables (positions, trades, scan_logs, config, predictions,
+    performance_metrics, resolved_markets) must each be a single-statement
+    _execute_sql call."""
+    source = _read()
+    match = re.search(r'def setup_database\(self\).*?(?=\n    def )', source, re.DOTALL)
+    setup_body = match.group(0)
+
+    required_tables = [
+        "positions", "trades", "scan_logs", "config",
+        "predictions", "performance_metrics", "resolved_markets",
+    ]
+    for table in required_tables:
+        pattern = rf'CREATE TABLE IF NOT EXISTS {table}\b'
+        assert re.search(pattern, setup_body), (
+            f"Basic table '{table}' not found in setup_database"
+        )


### PR DESCRIPTION
## Summary

- Split the single multi-statement `_execute_sql` call in `setup_database()` (CREATE SCHEMA + 6 tables + 6 indexes = 1 giant SQL block) into 13 individual calls
- Each extended DDL statement gets its own `try/except` — failures are counted and logged as non-blocking
- Basic tables (positions, trades, scan_logs, etc.) are already individual calls and unaffected

## Root cause

On Python 3.14 + macOS (arm64), when the seren-db REST API returns 400 for multi-statement DDL, the `requests.HTTPError` exception is caught and the traceback prints correctly, but `return False` never completes — the process hangs indefinitely. This is likely a Python 3.14 regression in exception/GC interaction with unclosed HTTP response objects.

## Why only polymarket/bot

The other Polymarket skills (maker-rebate-bot, basis makers) use `psycopg` direct PostgreSQL connections where multi-statement DDL works fine. Only `polymarket/bot/scripts/serendb_storage.py` uses the REST API path.

## Test plan

- [x] `test_no_multi_statement_ddl_in_setup_database` — no `_execute_sql` call contains 2+ CREATE statements
- [x] `test_extended_ddl_uses_individual_try_except` — iterates `_extended_ddl` list
- [x] `test_extended_ddl_failure_is_non_blocking` — failures logged, don't prevent `return True`
- [x] `test_basic_tables_each_have_own_execute_call` — all 7 core tables present (4/4 pass)

Closes #298

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com