### PR TITLE
feat(family-office): add knowledge skill

### DIFF
--- a/family-office/knowledge/.env.example
+++ b/family-office/knowledge/.env.example
@@ -1,0 +1,7 @@
+# Generated SkillForge environment template for knowledge
+SEREN_API_KEY=
+KNOWLEDGE_DB_URL=
+BEDROCK_REGION=
+BEDROCK_OPUS_MODEL_ID=
+BEDROCK_TITAN_MODEL_ID=
+

--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: knowledge
+description: "Captures, stores, and retrieves institutional knowledge for family offices through guided knowledge interviews, SharePoint and document ingestion, Asana-aware context seeding, same-user cross-thread recall, explicit freshness cues, and retrieval-linked SerenBucks incentives."
+---
+
+# Knowledge
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- capture knowledge for the office
+- start a knowledge session
+- knowledge office
+- what did i say about
+- show me the current working brief
+- what changed since the first brief
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `load_current_brief` uses `connector.storage.query`
+3. `sync_sharepoint_context` uses `connector.sharepoint.get`
+4. `sync_asana_context` uses `connector.asana.get`
+5. `extract_document_text` uses `connector.docreader.post`
+6. `conduct_guided_interview` uses `transform.run_guided_interview`
+7. `distill_knowledge_entries` uses `transform.distill_knowledge_entries`
+8. `archive_transcript` uses `connector.storage.upsert`
+9. `persist_knowledge_entries` uses `connector.storage.upsert`
+10. `retrieve_candidate_entries` uses `connector.storage.query`
+11. `apply_access_and_freshness_rules` uses `transform.apply_access_and_freshness_rules`
+12. `compose_answer_or_followup` uses `transform.compose_answer_or_followup`
+13. `log_retrieval_events` uses `connector.storage.upsert`
+14. `calculate_rewards` uses `transform.calculate_rewards`
+15. `persist_rewards` uses `connector.storage.upsert`
+16. `render_working_brief` uses `transform.render_working_brief`

--- a/family-office/knowledge/config.example.json
+++ b/family-office/knowledge/config.example.json
@@ -1,0 +1,24 @@
+{
+  "connectors": [
+    "asana",
+    "docreader",
+    "sharepoint",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "asana_sync_enabled": true,
+    "command": "capture",
+    "current_date_label": "March 27, 2026",
+    "department": "investments",
+    "interview_mode": "freeform",
+    "organization_name": "Rendero Trust",
+    "query_text": "",
+    "reward_base_usd": 100,
+    "reward_per_retrieval_usd": 1,
+    "role_template": "general",
+    "sharepoint_sync_enabled": true,
+    "top_k": 5
+  },
+  "skill": "knowledge"
+}

--- a/family-office/knowledge/requirements.txt
+++ b/family-office/knowledge/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for knowledge.

--- a/family-office/knowledge/scripts/agent.py
+++ b/family-office/knowledge/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for knowledge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['asana', 'docreader', 'sharepoint', 'storage']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/family-office/knowledge/tests/fixtures/connector_failure.json
+++ b/family-office/knowledge/tests/fixtures/connector_failure.json
@@ -1,0 +1,43 @@
+{
+  "status": "error",
+  "skill": "knowledge",
+  "error_code": "connector_failure",
+  "connector": "asana",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "asana": {
+      "get": {
+        "status": "error",
+        "connector": "asana",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "docreader": {
+      "post": {
+        "status": "ok",
+        "connector": "docreader",
+        "action": "post"
+      }
+    },
+    "sharepoint": {
+      "get": {
+        "status": "ok",
+        "connector": "sharepoint",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/family-office/knowledge/tests/fixtures/dry_run_guard.json
+++ b/family-office/knowledge/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "knowledge",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/family-office/knowledge/tests/fixtures/happy_path.json
+++ b/family-office/knowledge/tests/fixtures/happy_path.json
@@ -1,0 +1,55 @@
+{
+  "status": "ok",
+  "skill": "knowledge",
+  "workflow_step_count": 16,
+  "dry_run": true,
+  "inputs": {
+    "asana_sync_enabled": true,
+    "command": "capture",
+    "current_date_label": "March 27, 2026",
+    "department": "investments",
+    "interview_mode": "freeform",
+    "organization_name": "Rendero Trust",
+    "query_text": "",
+    "reward_base_usd": 100,
+    "reward_per_retrieval_usd": 1,
+    "role_template": "general",
+    "sharepoint_sync_enabled": true,
+    "top_k": 5
+  },
+  "connectors": {
+    "asana": {
+      "get": {
+        "status": "ok",
+        "connector": "asana",
+        "action": "get"
+      }
+    },
+    "docreader": {
+      "post": {
+        "status": "ok",
+        "connector": "docreader",
+        "action": "post"
+      }
+    },
+    "sharepoint": {
+      "get": {
+        "status": "ok",
+        "connector": "sharepoint",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/family-office/knowledge/tests/fixtures/policy_violation.json
+++ b/family-office/knowledge/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "knowledge",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/family-office/knowledge/tests/test_smoke.py
+++ b/family-office/knowledge/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "knowledge"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"


### PR DESCRIPTION
Summary:\n- add the new family-office/knowledge skill\n- include the generated runtime files and smoke tests\n- keep the change isolated from unrelated local files\n\nTesting:\n- pytest family-office/knowledge/tests/test_smoke.py -q\n- pytest tests/test_removed_skill_references.py -q\n\nCloses #300