### PR TITLE
feat: implement family-office knowledge workflow runtime

### DIFF
--- a/family-office/knowledge/config.example.json
+++ b/family-office/knowledge/config.example.json
@@ -5,8 +5,11 @@
     "sharepoint",
     "storage"
   ],
+  "current_date": "2026-03-27",
   "dry_run": true,
   "inputs": {
+    "access_scope": "team",
+    "agent_id": "user-123",
     "asana_sync_enabled": true,
     "command": "capture",
     "current_date_label": "March 27, 2026",
@@ -14,12 +17,24 @@
     "interview_mode": "freeform",
     "organization_name": "Rendero Trust",
     "query_text": "",
+    "requester_id": "user-123",
     "reward_base_usd": 100,
     "reward_per_retrieval_usd": 1,
     "role_template": "general",
     "sharepoint_sync_enabled": true,
     "top_k": 5
   },
+  "storage_records": {
+    "briefs": [],
+    "knowledge_entries": [],
+    "retrieval_events": [],
+    "reward_audits": [],
+    "transcripts": []
+  },
+  "sharepoint_context": [],
+  "asana_context": [],
+  "documents": [],
+  "interview_transcript": [],
   "skill": "knowledge",
   "affiliates_webhook_url": "",
   "affiliates_webhook_secret": "",

--- a/family-office/knowledge/scripts/agent.py
+++ b/family-office/knowledge/scripts/agent.py
@@ -1,20 +1,29 @@
 #!/usr/bin/env python3
-"""Family-office knowledge skill runtime with affiliate reward webhook."""
+"""Family-office knowledge skill runtime with deterministic workflow steps."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
+from copy import deepcopy
+from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Any
+from uuid import uuid4
 
 from affiliates_webhook import fire_reward_webhook
 
 DEFAULT_DRY_RUN = True
-AVAILABLE_CONNECTORS = ['asana', 'docreader', 'sharepoint', 'storage']
+AVAILABLE_CONNECTORS = ["asana", "docreader", "sharepoint", "storage"]
+CAPTURE_COMMANDS = {"capture", "start", "start_capture", "knowledge_capture"}
+RETRIEVE_COMMANDS = {"retrieve", "recall", "search", "what_did_i_say_about"}
+BRIEF_COMMANDS = {"brief", "show_brief", "show_the_current_working_brief"}
+DIFF_COMMANDS = {"diff", "compare", "what_changed_since_the_first_brief"}
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser = argparse.ArgumentParser(description="Run family-office knowledge skill runtime.")
     parser.add_argument(
         "--config",
         default="config.json",
@@ -23,27 +32,520 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def load_config(config_path: str) -> dict[str, Any]:
     path = Path(config_path)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def calculate_rewards(config: dict, event_type: str = "knowledge_capture") -> dict:
-    """Step 14: Calculate and fire affiliate reward webhook.
+def _parse_iso_date(value: Any) -> date | None:
+    if not value:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    text = str(value).strip()
+    if not text:
+        return None
+    for candidate in (text, text.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate).date()
+        except ValueError:
+            continue
+    for fmt in ("%Y-%m-%d", "%B %d, %Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
 
-    Fires an HMAC-signed webhook to seren-affiliates so the employee
-    earns SerenBucks for the knowledge event. Non-blocking — failures
-    are logged but do not crash the session.
 
-    Args:
-        config: Skill config dict
-        event_type: "knowledge_capture" or "knowledge_retrieval"
+def _current_run_date(config: dict[str, Any]) -> date:
+    inputs = config.get("inputs", {})
+    for candidate in (
+        config.get("current_date"),
+        inputs.get("current_date"),
+        inputs.get("current_date_label"),
+    ):
+        parsed = _parse_iso_date(candidate)
+        if parsed is not None:
+            return parsed
+    return datetime.now(timezone.utc).date()
 
-    Returns:
-        Reward result dict with status, transaction_id, and any errors
-    """
+
+def _slug(value: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return text or "item"
+
+
+def _text_blob(payload: Any) -> str:
+    if isinstance(payload, dict):
+        return " ".join(_text_blob(value) for value in payload.values())
+    if isinstance(payload, list):
+        return " ".join(_text_blob(item) for item in payload)
+    return str(payload)
+
+
+def _tokenize(text: str) -> list[str]:
+    return [part for part in re.split(r"[^a-z0-9]+", text.lower()) if part]
+
+
+def _topic_terms(topic: str) -> set[str]:
+    return set(_tokenize(topic))
+
+
+def _match_score(record: dict[str, Any], query_text: str) -> int:
+    query_terms = _topic_terms(query_text)
+    if not query_terms:
+        return 1
+    haystack = set(_tokenize(_text_blob(record)))
+    return len(query_terms & haystack)
+
+
+class StorageConnector:
+    """In-process storage adapter backed by config-provided collections."""
+
+    def __init__(self, records: dict[str, list[dict[str, Any]]] | None):
+        self.records = deepcopy(records or {})
+
+    def query(
+        self,
+        collection: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        query_text: str = "",
+        top_k: int | None = None,
+        descending: bool = True,
+        sort_field: str = "updated_at",
+    ) -> dict[str, Any]:
+        items = [deepcopy(item) for item in self.records.get(collection, [])]
+        filters = filters or {}
+        filtered = [item for item in items if all(item.get(key) == value for key, value in filters.items())]
+
+        if query_text:
+            scored: list[tuple[int, dict[str, Any]]] = []
+            for item in filtered:
+                score = _match_score(item, query_text)
+                if score > 0:
+                    candidate = deepcopy(item)
+                    candidate["match_score"] = score
+                    scored.append((score, candidate))
+            scored.sort(key=lambda pair: (pair[0], pair[1].get(sort_field, "")), reverse=True)
+            filtered = [item for _, item in scored]
+        else:
+            filtered.sort(key=lambda item: item.get(sort_field, ""), reverse=descending)
+
+        if top_k is not None:
+            filtered = filtered[:top_k]
+
+        return {
+            "status": "ok",
+            "connector": "storage",
+            "action": "query",
+            "collection": collection,
+            "records": filtered,
+        }
+
+    def upsert(self, collection: str, record: dict[str, Any]) -> dict[str, Any]:
+        items = self.records.setdefault(collection, [])
+        record_id = record.get("id")
+        updated = False
+        if record_id:
+            for index, existing in enumerate(items):
+                if existing.get("id") == record_id:
+                    items[index] = deepcopy(record)
+                    updated = True
+                    break
+        if not updated:
+            items.append(deepcopy(record))
+        return {
+            "status": "ok",
+            "connector": "storage",
+            "action": "upsert",
+            "collection": collection,
+            "record": deepcopy(record),
+            "updated": updated,
+        }
+
+    def snapshot(self) -> dict[str, list[dict[str, Any]]]:
+        return deepcopy(self.records)
+
+
+class SharePointConnector:
+    def __init__(self, items: list[dict[str, Any]] | None):
+        self.items = deepcopy(items or [])
+
+    def get(self, *, department: str, topic: str) -> dict[str, Any]:
+        scoped = [
+            item
+            for item in self.items
+            if (not department or item.get("department") in ("", department, None))
+            and (_match_score(item, topic) > 0 or not topic)
+        ]
+        return {"status": "ok", "connector": "sharepoint", "action": "get", "records": scoped}
+
+
+class AsanaConnector:
+    def __init__(self, items: list[dict[str, Any]] | None):
+        self.items = deepcopy(items or [])
+
+    def get(self, *, department: str, topic: str) -> dict[str, Any]:
+        scoped = [
+            item
+            for item in self.items
+            if (not department or item.get("department") in ("", department, None))
+            and (_match_score(item, topic) > 0 or not topic)
+        ]
+        return {"status": "ok", "connector": "asana", "action": "get", "records": scoped}
+
+
+class DocReaderConnector:
+    def __init__(self, documents: list[dict[str, Any]] | None):
+        self.documents = deepcopy(documents or [])
+
+    def post(self, *, topic: str) -> dict[str, Any]:
+        records = []
+        for item in self.documents:
+            if _match_score(item, topic) > 0 or not topic:
+                record = deepcopy(item)
+                record["extracted_text"] = item.get("text", "")
+                records.append(record)
+        return {"status": "ok", "connector": "docreader", "action": "post", "records": records}
+
+
+def normalize_request(config: dict[str, Any]) -> dict[str, Any]:
+    inputs = config.get("inputs", {})
+    raw_command = str(inputs.get("command", "capture")).strip().lower()
+    if raw_command in CAPTURE_COMMANDS:
+        mode = "capture"
+    elif raw_command in RETRIEVE_COMMANDS:
+        mode = "retrieve"
+    elif raw_command in BRIEF_COMMANDS:
+        mode = "brief"
+    elif raw_command in DIFF_COMMANDS:
+        mode = "diff"
+    else:
+        mode = raw_command or "capture"
+
+    query_text = str(inputs.get("query_text", "")).strip()
+    requester_id = str(inputs.get("requester_id", config.get("agent_id", "unknown-user"))).strip() or "unknown-user"
+    department = str(inputs.get("department", "")).strip()
+    organization = str(inputs.get("organization_name", "")).strip()
+    topic = query_text or str(inputs.get("topic", "")).strip() or department or organization or "general"
+    top_k = int(inputs.get("top_k", 5))
+    return {
+        "mode": mode,
+        "command": raw_command,
+        "organization_name": organization,
+        "department": department,
+        "topic": topic,
+        "query_text": query_text,
+        "requester_id": requester_id,
+        "access_scope": str(inputs.get("access_scope", "team")).strip() or "team",
+        "role_template": str(inputs.get("role_template", "general")).strip() or "general",
+        "interview_mode": str(inputs.get("interview_mode", "freeform")).strip() or "freeform",
+        "top_k": top_k,
+        "current_date": _current_run_date(config).isoformat(),
+    }
+
+
+def load_current_brief(storage: StorageConnector, request: dict[str, Any]) -> dict[str, Any]:
+    response = storage.query(
+        "briefs",
+        filters={
+            "organization_name": request["organization_name"],
+            "department": request["department"],
+        },
+        top_k=1,
+    )
+    records = response["records"]
+    return records[0] if records else {}
+
+
+def sync_sharepoint_context(
+    connector: SharePointConnector,
+    request: dict[str, Any],
+    enabled: bool,
+) -> dict[str, Any]:
+    if not enabled:
+        return {"status": "skipped", "connector": "sharepoint", "action": "get", "records": []}
+    return connector.get(department=request["department"], topic=request["topic"])
+
+
+def sync_asana_context(
+    connector: AsanaConnector,
+    request: dict[str, Any],
+    enabled: bool,
+) -> dict[str, Any]:
+    if not enabled:
+        return {"status": "skipped", "connector": "asana", "action": "get", "records": []}
+    return connector.get(department=request["department"], topic=request["topic"])
+
+
+def extract_document_text(connector: DocReaderConnector, request: dict[str, Any]) -> dict[str, Any]:
+    return connector.post(topic=request["topic"])
+
+
+def conduct_guided_interview(
+    config: dict[str, Any],
+    request: dict[str, Any],
+    extracted_documents: dict[str, Any],
+) -> dict[str, Any]:
+    if request["mode"] != "capture":
+        return {"status": "skipped", "mode": request["interview_mode"], "turns": [], "turn_count": 0}
+
+    raw_turns = config.get("interview_transcript") or []
+    turns: list[dict[str, str]] = []
+    for index, raw_turn in enumerate(raw_turns, start=1):
+        if isinstance(raw_turn, dict):
+            speaker = str(raw_turn.get("speaker", "user"))
+            text = str(raw_turn.get("text", "")).strip()
+        else:
+            speaker = "user" if index % 2 else "assistant"
+            text = str(raw_turn).strip()
+        if text:
+            turns.append({"speaker": speaker, "text": text})
+
+    if not turns and request["query_text"]:
+        turns.append({"speaker": "user", "text": request["query_text"]})
+
+    if not turns:
+        for document in extracted_documents.get("records", [])[:1]:
+            doc_text = str(document.get("extracted_text", "")).strip()
+            if doc_text:
+                turns.append({"speaker": "user", "text": doc_text})
+
+    summary = " ".join(turn["text"] for turn in turns[:3]).strip()
+    return {
+        "status": "ok",
+        "mode": request["interview_mode"],
+        "turns": turns,
+        "turn_count": len(turns),
+        "summary": summary,
+    }
+
+
+def distill_knowledge_entries(
+    config: dict[str, Any],
+    request: dict[str, Any],
+    transcript: dict[str, Any],
+    sharepoint_context: dict[str, Any],
+    asana_context: dict[str, Any],
+    extracted_documents: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if request["mode"] != "capture":
+        return []
+
+    current_date = request["current_date"]
+    base_entry = {
+        "organization_name": request["organization_name"],
+        "department": request["department"],
+        "topic": request["topic"],
+        "owner_id": request["requester_id"],
+        "access_scope": request["access_scope"],
+        "created_at": current_date,
+        "updated_at": current_date,
+        "stale_after_days": int(config.get("freshness_window_days", 30)),
+    }
+
+    entries: list[dict[str, Any]] = []
+    for index, turn in enumerate(transcript.get("turns", []), start=1):
+        if turn["speaker"] != "user":
+            continue
+        text = turn["text"].strip()
+        if not text:
+            continue
+        entries.append(
+            {
+                **base_entry,
+                "id": f"knowledge-{_slug(request['topic'])}-{index}",
+                "title": f"{request['topic']} note {index}",
+                "summary": text,
+                "content": text,
+                "source": "guided_interview",
+            }
+        )
+
+    for source_name, payload in (
+        ("sharepoint", sharepoint_context),
+        ("asana", asana_context),
+        ("docreader", extracted_documents),
+    ):
+        for offset, record in enumerate(payload.get("records", [])[:1], start=1):
+            text = str(record.get("summary") or record.get("text") or record.get("extracted_text") or "").strip()
+            if not text:
+                continue
+            entries.append(
+                {
+                    **base_entry,
+                    "id": f"{source_name}-{_slug(request['topic'])}-{offset}",
+                    "title": str(record.get("title") or f"{source_name} context"),
+                    "summary": text,
+                    "content": text,
+                    "source": source_name,
+                }
+            )
+
+    deduped: list[dict[str, Any]] = []
+    seen = set()
+    for entry in entries:
+        fingerprint = (entry["source"], entry["summary"])
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(entry)
+    return deduped
+
+
+def archive_transcript(
+    storage: StorageConnector,
+    request: dict[str, Any],
+    transcript: dict[str, Any],
+) -> dict[str, Any]:
+    if request["mode"] != "capture" or not transcript.get("turns"):
+        return {"status": "skipped", "connector": "storage", "action": "upsert", "collection": "transcripts"}
+    record = {
+        "id": f"transcript-{_slug(request['topic'])}-{request['current_date']}",
+        "organization_name": request["organization_name"],
+        "department": request["department"],
+        "topic": request["topic"],
+        "owner_id": request["requester_id"],
+        "created_at": request["current_date"],
+        "turns": transcript["turns"],
+        "summary": transcript.get("summary", ""),
+    }
+    return storage.upsert("transcripts", record)
+
+
+def persist_knowledge_entries(
+    storage: StorageConnector,
+    entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    writes = []
+    for entry in entries:
+        writes.append(storage.upsert("knowledge_entries", entry))
+    return writes
+
+
+def retrieve_candidate_entries(
+    storage: StorageConnector,
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    if request["mode"] not in {"retrieve", "brief", "diff"}:
+        return {"status": "skipped", "connector": "storage", "action": "query", "collection": "knowledge_entries", "records": []}
+    return storage.query(
+        "knowledge_entries",
+        filters={
+            "organization_name": request["organization_name"],
+            "department": request["department"],
+        },
+        query_text=request["topic"],
+        top_k=request["top_k"],
+    )
+
+
+def _access_allowed(request: dict[str, Any], entry: dict[str, Any]) -> bool:
+    scope = entry.get("access_scope", "team")
+    if scope == "public":
+        return True
+    if scope == "private":
+        return entry.get("owner_id") == request["requester_id"]
+    if scope == "team":
+        return entry.get("department") == request["department"]
+    return True
+
+
+def _freshness_status(request: dict[str, Any], entry: dict[str, Any]) -> tuple[str, int | None]:
+    current_date = _parse_iso_date(request["current_date"])
+    updated_at = _parse_iso_date(entry.get("updated_at") or entry.get("created_at"))
+    if current_date is None or updated_at is None:
+        return "unknown", None
+    age_days = (current_date - updated_at).days
+    stale_after_days = int(entry.get("stale_after_days", 30))
+    return ("stale" if age_days > stale_after_days else "fresh"), age_days
+
+
+def apply_access_and_freshness_rules(
+    request: dict[str, Any],
+    candidate_response: dict[str, Any],
+) -> dict[str, Any]:
+    allowed = []
+    for entry in candidate_response.get("records", []):
+        if not _access_allowed(request, entry):
+            continue
+        candidate = deepcopy(entry)
+        freshness, age_days = _freshness_status(request, candidate)
+        candidate["freshness"] = freshness
+        candidate["age_days"] = age_days
+        allowed.append(candidate)
+    return {
+        "status": "ok",
+        "records": allowed,
+        "filtered_out_count": max(0, len(candidate_response.get("records", [])) - len(allowed)),
+    }
+
+
+def compose_answer_or_followup(
+    request: dict[str, Any],
+    filtered_results: dict[str, Any],
+    transcript: dict[str, Any],
+) -> dict[str, Any]:
+    mode = request["mode"]
+    if mode == "capture":
+        entry_count = len(filtered_results.get("records", []))
+        transcript_count = transcript.get("turn_count", 0)
+        return {
+            "status": "ok",
+            "kind": "answer",
+            "message": f"Captured {transcript_count} interview turns and prepared {entry_count} knowledge entries for {request['topic']}.",
+        }
+
+    records = filtered_results.get("records", [])
+    if mode == "retrieve":
+        if not records:
+            return {
+                "status": "needs_input",
+                "kind": "followup",
+                "message": f"No knowledge entries matched '{request['topic']}'. Provide more detail or run a capture session.",
+            }
+        highlights = "; ".join(
+            f"{record.get('title', 'entry')}: {record.get('summary', '')} [{record.get('freshness', 'unknown')}]"
+            for record in records[:3]
+        )
+        return {"status": "ok", "kind": "answer", "message": highlights}
+
+    if mode == "brief":
+        return {"status": "ok", "kind": "answer", "message": "Rendered current working brief."}
+    if mode == "diff":
+        return {"status": "ok", "kind": "answer", "message": "Compared current brief against the first recorded brief."}
+    return {"status": "ok", "kind": "answer", "message": "Request processed."}
+
+
+def log_retrieval_events(
+    storage: StorageConnector,
+    request: dict[str, Any],
+    filtered_results: dict[str, Any],
+) -> dict[str, Any]:
+    if request["mode"] != "retrieve":
+        return {"status": "skipped", "connector": "storage", "action": "upsert", "collection": "retrieval_events"}
+    record = {
+        "id": f"retrieval-{_slug(request['topic'])}-{request['current_date']}",
+        "query_text": request["query_text"],
+        "topic": request["topic"],
+        "requester_id": request["requester_id"],
+        "organization_name": request["organization_name"],
+        "department": request["department"],
+        "created_at": request["current_date"],
+        "result_count": len(filtered_results.get("records", [])),
+        "result_ids": [entry.get("id") for entry in filtered_results.get("records", [])],
+    }
+    return storage.upsert("retrieval_events", record)
+
+
+def calculate_rewards(config: dict[str, Any], event_type: str = "knowledge_capture") -> dict[str, Any]:
+    """Step 14: Calculate and fire affiliate reward webhook."""
     inputs = config.get("inputs", {})
     agent_id = config.get("agent_id", inputs.get("agent_id", ""))
     referral_code = config.get("referral_code", inputs.get("referral_code", ""))
@@ -64,17 +566,20 @@ def calculate_rewards(config: dict, event_type: str = "knowledge_capture") -> di
             amount_cents=amount_cents,
             test_mode=test_mode,
         )
-    except Exception as e:
-        result = {"status": "error", "error": str(e)}
+    except Exception as exc:
+        result = {"status": "error", "error": str(exc)}
 
+    result["event_type"] = event_type
+    result["amount_cents"] = amount_cents
     return result
 
 
-def persist_rewards(reward_result: dict) -> dict:
-    """Step 15: Log the reward webhook response for audit.
-
-    Returns the reward result unchanged for downstream consumption.
-    """
+def persist_rewards(
+    storage: StorageConnector,
+    request: dict[str, Any],
+    reward_result: dict[str, Any],
+) -> dict[str, Any]:
+    """Step 15: Log the reward webhook response for audit."""
     status = reward_result.get("status", "unknown")
     tx_id = reward_result.get("transaction_id", "")
 
@@ -87,23 +592,175 @@ def persist_rewards(reward_result: dict) -> dict:
     elif status == "error":
         print(f"  Reward webhook error: {reward_result.get('error', '')}")
 
+    record = {
+        "id": tx_id or f"reward-{request['mode']}-{request['current_date']}",
+        "request_mode": request["mode"],
+        "topic": request["topic"],
+        "requester_id": request["requester_id"],
+        "created_at": request["current_date"],
+        **reward_result,
+    }
+    storage.upsert("reward_audits", record)
     return reward_result
 
 
-def run_once(config: dict, dry_run: bool) -> dict:
-    result = {
-        "status": "ok",
-        "dry_run": dry_run,
-        "connectors": AVAILABLE_CONNECTORS,
-        "input_keys": sorted(config.get("inputs", {}).keys()),
+def _brief_record_summary(brief: dict[str, Any]) -> str:
+    if not brief:
+        return "No brief available."
+    return str(brief.get("summary") or brief.get("headline") or "No brief summary recorded.")
+
+
+def render_working_brief(
+    storage: StorageConnector,
+    request: dict[str, Any],
+    current_brief: dict[str, Any],
+    sharepoint_context: dict[str, Any],
+    asana_context: dict[str, Any],
+    extracted_documents: dict[str, Any],
+    filtered_results: dict[str, Any],
+) -> dict[str, Any]:
+    brief = {
+        "mode": request["mode"],
+        "headline": current_brief.get("headline") or f"{request['organization_name']} {request['department']} working brief",
+        "summary": current_brief.get("summary") or _brief_record_summary(current_brief),
+        "priorities": list(current_brief.get("priorities", [])),
+        "risks": list(current_brief.get("risks", [])),
+        "source_counts": {
+            "sharepoint": len(sharepoint_context.get("records", [])),
+            "asana": len(asana_context.get("records", [])),
+            "documents": len(extracted_documents.get("records", [])),
+            "knowledge_entries": len(filtered_results.get("records", [])),
+        },
+        "notes": [],
     }
 
-    # Steps 14-15: Calculate and persist rewards (non-blocking)
-    reward = calculate_rewards(config, event_type="knowledge_capture")
-    audit = persist_rewards(reward)
-    result["reward"] = audit
+    for record in sharepoint_context.get("records", [])[:2]:
+        brief["notes"].append(f"SharePoint: {record.get('title', 'context')}")
+    for record in asana_context.get("records", [])[:2]:
+        brief["notes"].append(f"Asana: {record.get('title', 'task')}")
+    for record in extracted_documents.get("records", [])[:1]:
+        brief["notes"].append(f"Document: {record.get('title', 'document')}")
 
-    return result
+    if request["mode"] == "diff":
+        earliest = storage.query(
+            "briefs",
+            filters={
+                "organization_name": request["organization_name"],
+                "department": request["department"],
+            },
+            top_k=100,
+            descending=False,
+            sort_field="created_at",
+        )["records"]
+        first_brief = earliest[0] if earliest else {}
+        changes = []
+        if first_brief.get("summary") != current_brief.get("summary"):
+            changes.append(
+                {
+                    "field": "summary",
+                    "from": first_brief.get("summary", ""),
+                    "to": current_brief.get("summary", ""),
+                }
+            )
+        first_priorities = set(first_brief.get("priorities", []))
+        current_priorities = set(current_brief.get("priorities", []))
+        for added in sorted(current_priorities - first_priorities):
+            changes.append({"field": "priorities", "change": "added", "value": added})
+        for removed in sorted(first_priorities - current_priorities):
+            changes.append({"field": "priorities", "change": "removed", "value": removed})
+        brief["comparison"] = {
+            "first_brief_id": first_brief.get("id", ""),
+            "current_brief_id": current_brief.get("id", ""),
+            "changes": changes,
+        }
+
+    return brief
+
+
+def run_once(config: dict[str, Any], dry_run: bool) -> dict[str, Any]:
+    request = normalize_request(config)
+    storage = StorageConnector(config.get("storage_records"))
+    sharepoint = SharePointConnector(config.get("sharepoint_context"))
+    asana = AsanaConnector(config.get("asana_context"))
+    docreader = DocReaderConnector(config.get("documents"))
+
+    current_brief = load_current_brief(storage, request)
+    sharepoint_context = sync_sharepoint_context(
+        sharepoint,
+        request,
+        enabled=bool(config.get("inputs", {}).get("sharepoint_sync_enabled", True)),
+    )
+    asana_context = sync_asana_context(
+        asana,
+        request,
+        enabled=bool(config.get("inputs", {}).get("asana_sync_enabled", True)),
+    )
+    extracted_documents = extract_document_text(docreader, request)
+    transcript = conduct_guided_interview(config, request, extracted_documents)
+    knowledge_entries = distill_knowledge_entries(
+        config,
+        request,
+        transcript,
+        sharepoint_context,
+        asana_context,
+        extracted_documents,
+    )
+    transcript_write = archive_transcript(storage, request, transcript)
+    knowledge_writes = persist_knowledge_entries(storage, knowledge_entries)
+
+    candidate_entries = retrieve_candidate_entries(storage, request)
+    if request["mode"] == "capture":
+        candidate_entries = {
+            "status": "ok",
+            "records": knowledge_entries,
+            "collection": "knowledge_entries",
+            "connector": "storage",
+            "action": "query",
+        }
+    filtered_results = apply_access_and_freshness_rules(request, candidate_entries)
+    response = compose_answer_or_followup(request, filtered_results, transcript)
+    retrieval_log = log_retrieval_events(storage, request, filtered_results)
+
+    if request["mode"] == "capture":
+        reward = calculate_rewards(config, event_type="knowledge_capture")
+    elif request["mode"] == "retrieve":
+        reward = calculate_rewards(config, event_type="knowledge_retrieval")
+    else:
+        reward = {"status": "skipped", "reason": "reward_not_applicable", "event_type": request["mode"]}
+    reward_audit = persist_rewards(storage, request, reward)
+
+    working_brief = render_working_brief(
+        storage,
+        request,
+        current_brief,
+        sharepoint_context,
+        asana_context,
+        extracted_documents,
+        filtered_results,
+    )
+
+    return {
+        "status": "ok",
+        "skill": "knowledge",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "normalized_request": request,
+        "current_brief": current_brief,
+        "sharepoint_context": sharepoint_context,
+        "asana_context": asana_context,
+        "extracted_documents": extracted_documents,
+        "transcript": transcript,
+        "knowledge_entries": knowledge_entries,
+        "transcript_write": transcript_write,
+        "knowledge_writes": knowledge_writes,
+        "retrieval_candidates": candidate_entries,
+        "retrieval_results": filtered_results,
+        "response": response,
+        "retrieval_log": retrieval_log,
+        "reward": reward_audit,
+        "working_brief": working_brief,
+        "storage_state": storage.snapshot(),
+    }
 
 
 def main() -> int:

--- a/family-office/knowledge/tests/test_smoke.py
+++ b/family-office/knowledge/tests/test_smoke.py
@@ -1,34 +1,231 @@
 from __future__ import annotations
 
-import json
+import importlib.util
+import sys
 from pathlib import Path
 
-FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+SCRIPT_PATH = SCRIPT_DIR / "agent.py"
 
 
-def _read_fixture(name: str) -> dict:
-    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+def _load_agent_module():
+    spec = importlib.util.spec_from_file_location("knowledge_agent", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
 
 
-def test_happy_path_fixture_is_successful() -> None:
-    payload = _read_fixture("happy_path.json")
-    assert payload["status"] == "ok"
-    assert payload["skill"] == "knowledge"
+def _base_config(command: str) -> dict:
+    return {
+        "current_date": "2026-03-27",
+        "dry_run": True,
+        "inputs": {
+            "access_scope": "team",
+            "asana_sync_enabled": True,
+            "command": command,
+            "department": "investments",
+            "interview_mode": "freeform",
+            "organization_name": "Rendero Trust",
+            "query_text": "tax strategy",
+            "requester_id": "user-123",
+            "reward_base_usd": 100,
+            "reward_per_retrieval_usd": 1,
+            "sharepoint_sync_enabled": True,
+            "top_k": 5,
+        },
+        "storage_records": {
+            "briefs": [],
+            "knowledge_entries": [],
+            "retrieval_events": [],
+            "reward_audits": [],
+            "transcripts": [],
+        },
+        "sharepoint_context": [],
+        "asana_context": [],
+        "documents": [],
+        "interview_transcript": [],
+    }
 
 
-def test_connector_failure_fixture_has_error_code() -> None:
-    payload = _read_fixture("connector_failure.json")
-    assert payload["status"] == "error"
-    assert payload["error_code"] == "connector_failure"
+def test_capture_workflow_archives_transcript_and_persists_entries(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.setattr(
+        agent,
+        "fire_reward_webhook",
+        lambda **_: {"status": "sent", "transaction_id": "tx-capture"},
+    )
+
+    config = _base_config("capture")
+    config["sharepoint_context"] = [
+        {"title": "Tax memo", "summary": "Use QSBS where available.", "department": "investments"}
+    ]
+    config["documents"] = [
+        {"title": "2026 planning doc", "text": "Tax strategy should prioritize entity cleanup."}
+    ]
+    config["interview_transcript"] = [
+        {"speaker": "user", "text": "We should centralize tax planning before Q3."},
+        {"speaker": "assistant", "text": "Who owns the workstream?"},
+        {"speaker": "user", "text": "Finance ops owns it with legal support."},
+    ]
+
+    result = agent.run_once(config, dry_run=True)
+
+    assert result["status"] == "ok"
+    assert result["normalized_request"]["mode"] == "capture"
+    assert result["transcript"]["turn_count"] == 3
+    assert len(result["knowledge_entries"]) >= 2
+    assert len(result["storage_state"]["transcripts"]) == 1
+    assert len(result["storage_state"]["knowledge_entries"]) == len(result["knowledge_entries"])
+    assert result["reward"]["status"] == "sent"
+    assert result["storage_state"]["reward_audits"][0]["transaction_id"] == "tx-capture"
 
 
-def test_policy_violation_fixture_has_error_code() -> None:
-    payload = _read_fixture("policy_violation.json")
-    assert payload["status"] == "error"
-    assert payload["error_code"] == "policy_violation"
+def test_retrieve_workflow_applies_access_and_freshness_and_logs_event(monkeypatch) -> None:
+    agent = _load_agent_module()
+    monkeypatch.setattr(
+        agent,
+        "fire_reward_webhook",
+        lambda **_: {"status": "sent", "transaction_id": "tx-retrieve"},
+    )
+
+    config = _base_config("recall")
+    config["storage_records"]["knowledge_entries"] = [
+        {
+            "id": "entry-fresh",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "topic": "tax strategy",
+            "title": "QSBS planning",
+            "summary": "Evaluate QSBS eligibility before any restructure.",
+            "content": "Evaluate QSBS eligibility before any restructure.",
+            "owner_id": "user-999",
+            "access_scope": "public",
+            "created_at": "2026-03-20",
+            "updated_at": "2026-03-20",
+            "stale_after_days": 30,
+        },
+        {
+            "id": "entry-private",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "topic": "tax strategy",
+            "title": "Private note",
+            "summary": "This should not be visible.",
+            "content": "This should not be visible.",
+            "owner_id": "other-user",
+            "access_scope": "private",
+            "created_at": "2026-03-20",
+            "updated_at": "2026-03-20",
+            "stale_after_days": 30,
+        },
+        {
+            "id": "entry-stale",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "topic": "tax strategy",
+            "title": "Old planning note",
+            "summary": "Legacy tax strategy assumptions from last year.",
+            "content": "Legacy tax strategy assumptions from last year.",
+            "owner_id": "user-123",
+            "access_scope": "team",
+            "created_at": "2025-12-01",
+            "updated_at": "2025-12-01",
+            "stale_after_days": 30,
+        },
+    ]
+
+    result = agent.run_once(config, dry_run=True)
+    result_ids = [entry["id"] for entry in result["retrieval_results"]["records"]]
+    freshness = {entry["id"]: entry["freshness"] for entry in result["retrieval_results"]["records"]}
+
+    assert result["normalized_request"]["mode"] == "retrieve"
+    assert result_ids == ["entry-fresh", "entry-stale"]
+    assert freshness["entry-fresh"] == "fresh"
+    assert freshness["entry-stale"] == "stale"
+    assert len(result["storage_state"]["retrieval_events"]) == 1
+    assert result["storage_state"]["retrieval_events"][0]["result_ids"] == result_ids
+    assert result["reward"]["event_type"] == "knowledge_retrieval"
 
 
-def test_dry_run_fixture_blocks_live_execution() -> None:
-    payload = _read_fixture("dry_run_guard.json")
-    assert payload["dry_run"] is True
-    assert payload["blocked_action"] == "live_execution"
+def test_brief_workflow_renders_current_working_brief_with_synced_context() -> None:
+    agent = _load_agent_module()
+
+    config = _base_config("show_brief")
+    config["inputs"]["query_text"] = "investor pipeline"
+    config["storage_records"]["briefs"] = [
+        {
+            "id": "brief-current",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "headline": "Investor pipeline",
+            "summary": "Top priority is converting three warm LP conversations.",
+            "priorities": ["Close Fund IV anchor", "Refresh monthly update"],
+            "risks": ["Data room is stale"],
+            "created_at": "2026-03-15",
+            "updated_at": "2026-03-25",
+        }
+    ]
+    config["sharepoint_context"] = [
+        {"title": "Pipeline memo", "summary": "Warm LPs want fee clarity.", "department": "investments"}
+    ]
+    config["asana_context"] = [
+        {"title": "Prepare LP update", "summary": "Draft April investor letter.", "department": "investments"}
+    ]
+    config["documents"] = [
+        {"title": "Data room checklist", "text": "Refresh portfolio metrics before the next LP call."}
+    ]
+
+    result = agent.run_once(config, dry_run=True)
+
+    assert result["normalized_request"]["mode"] == "brief"
+    assert result["working_brief"]["headline"] == "Investor pipeline"
+    assert result["working_brief"]["source_counts"]["sharepoint"] == 1
+    assert result["working_brief"]["source_counts"]["asana"] == 1
+    assert "SharePoint: Pipeline memo" in result["working_brief"]["notes"]
+    assert result["reward"]["status"] == "skipped"
+
+
+def test_diff_workflow_compares_current_brief_against_first_brief() -> None:
+    agent = _load_agent_module()
+
+    config = _base_config("compare")
+    config["inputs"]["query_text"] = "investor pipeline"
+    config["storage_records"]["briefs"] = [
+        {
+            "id": "brief-first",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "headline": "Investor pipeline",
+            "summary": "Initial LP pipeline is exploratory.",
+            "priorities": ["Draft initial LP list"],
+            "risks": ["No anchor investor"],
+            "created_at": "2026-01-10",
+            "updated_at": "2026-01-10",
+        },
+        {
+            "id": "brief-current",
+            "organization_name": "Rendero Trust",
+            "department": "investments",
+            "headline": "Investor pipeline",
+            "summary": "Top priority is converting three warm LP conversations.",
+            "priorities": ["Draft initial LP list", "Close Fund IV anchor"],
+            "risks": ["Data room is stale"],
+            "created_at": "2026-03-15",
+            "updated_at": "2026-03-25",
+        },
+    ]
+
+    result = agent.run_once(config, dry_run=True)
+    changes = result["working_brief"]["comparison"]["changes"]
+
+    assert result["normalized_request"]["mode"] == "diff"
+    assert any(change["field"] == "summary" for change in changes)
+    assert {"field": "priorities", "change": "added", "value": "Close Fund IV anchor"} in changes


### PR DESCRIPTION
## Summary
- implement a deterministic end-to-end runtime for the family-office knowledge skill across capture, retrieval, brief, and diff modes
- add in-process storage/sharepoint/asana/docreader adapters so the documented workflow can run locally without live connectors
- replace fixture-only smoke tests with critical behavioral coverage for the four supported workflow modes

## Testing
- pytest family-office/knowledge/tests/test_smoke.py tests/test_knowledge_affiliates_webhook.py
- python3 family-office/knowledge/scripts/agent.py --config family-office/knowledge/config.example.json

Closes #304
