### PR TITLE
fix(polymarket): add edge-to-spread ratio gate and depth-constrained sizing

### DIFF
--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -12,6 +12,8 @@
   "min_volume": 5000.0,
   "max_divergence": 0.50,
   "min_buy_price": 0.02,
+  "min_edge_to_spread_ratio": 3.0,
+  "max_depth_fraction": 0.25,
   "iteration": {
     "max_iterations": 2,
     "threshold_step": 0.01,

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -110,6 +110,10 @@ class TradingAgent:
         self.min_buy_price = float(self.config.get('min_buy_price', 0.02))
         self.min_volume = float(self.config.get('min_volume', 5000.0))
 
+        # Execution quality gates
+        self.min_edge_to_spread_ratio = float(self.config.get('min_edge_to_spread_ratio', 3.0))
+        self.max_depth_fraction = float(self.config.get('max_depth_fraction', 0.25))
+
         # Calibration-driven threshold override
         self._calibration = calibration.load_calibration()
         self.effective_mispricing_threshold, self._threshold_reason = (
@@ -560,16 +564,28 @@ class TradingAgent:
             print(f"    ✗ Annualized return {annualized_return * 100:.1f}% below {self.min_annualized_return * 100:.0f}% hurdle ({days_to_resolution}d to resolution)")
             return None
 
-        # Exit liquidity check: ensure we can sell what we buy
+        # --- Execution quality gates: spread, depth, and exit liquidity ---
+        book_metrics = None
         try:
-            token_to_check = market.get('no_token_id') or market.get('token_id')
+            token_to_check = market.get('token_id')
             if token_to_check:
-                bid_price = self.polymarket.get_price(token_to_check, 'SELL')
-                if bid_price <= 0:
+                book_metrics = self.polymarket.get_book_metrics(token_to_check)
+
+                # Exit liquidity: must have bids
+                if book_metrics['best_bid'] <= 0:
                     print(f"    ✗ No exit liquidity: zero bids on order book")
                     return None
+
+                # Edge-to-spread ratio gate: edge must exceed spread cost by min_edge_to_spread_ratio
+                spread = book_metrics['spread']
+                if spread > 0:
+                    edge_to_spread = edge / spread
+                    if edge_to_spread < self.min_edge_to_spread_ratio:
+                        print(f"    ✗ BLOCKED: edge/spread ratio {edge_to_spread:.1f}x below {self.min_edge_to_spread_ratio:.1f}x minimum")
+                        print(f"      Edge: {edge*100:.1f}%, spread: {spread*100:.1f}% — spread eats the edge")
+                        return None
         except Exception:
-            print(f"    ✗ Could not verify exit liquidity")
+            print(f"    ✗ Could not verify exit liquidity or book metrics")
             return None
 
         # Reject low confidence estimates
@@ -607,6 +623,19 @@ class TradingAgent:
         if position_size == 0:
             print(f"    ✗ Position size too small")
             return None
+
+        # Depth-constrained sizing: cap position at max_depth_fraction of visible book
+        if book_metrics:
+            relevant_depth = book_metrics['ask_depth_usd'] if side == 'BUY' else book_metrics['bid_depth_usd']
+            if relevant_depth > 0:
+                max_from_depth = relevant_depth * self.max_depth_fraction
+                if position_size > max_from_depth:
+                    print(f"    Depth cap: ${position_size:.2f} → ${max_from_depth:.2f} "
+                          f"({self.max_depth_fraction*100:.0f}% of ${relevant_depth:.0f} visible depth)")
+                    position_size = max_from_depth
+                    if position_size < 1.0:
+                        print(f"    ✗ Position too small after depth cap")
+                        return None
 
         # Calculate expected value
         ev = kelly.calculate_expected_value(fair_value, current_price, position_size, side)

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -287,6 +287,46 @@ class PolymarketClient:
         else:
             return best_bid
 
+    def get_book_metrics(self, token_id: str) -> Dict:
+        """Get spread and visible depth from the CLOB orderbook.
+
+        Returns:
+            Dict with keys: best_bid, best_ask, spread, mid, bid_depth_usd, ask_depth_usd
+        """
+        from polymarket_live import fetch_book
+        book = fetch_book(token_id)
+        bids = book.get('bids', [])
+        asks = book.get('asks', [])
+        if not bids or not asks:
+            raw = book.get('raw', {})
+            if isinstance(raw, dict):
+                bids = bids or raw.get('bids', [])
+                asks = asks or raw.get('asks', [])
+
+        best_bid = float(bids[0]['price']) if bids else 0.0
+        best_ask = float(asks[0]['price']) if asks else 0.0
+        mid = (best_bid + best_ask) / 2.0 if best_bid and best_ask else 0.0
+        spread = (best_ask - best_bid) if best_bid and best_ask else 0.0
+
+        # Visible depth in USD: sum(price * size) for each level
+        bid_depth = sum(
+            float(level.get('price', 0)) * float(level.get('size', 0))
+            for level in bids
+        )
+        ask_depth = sum(
+            float(level.get('price', 0)) * float(level.get('size', 0))
+            for level in asks
+        )
+
+        return {
+            'best_bid': best_bid,
+            'best_ask': best_ask,
+            'spread': spread,
+            'mid': mid,
+            'bid_depth_usd': bid_depth,
+            'ask_depth_usd': ask_depth,
+        }
+
     def get_midpoint(self, token_id: str, max_spread: float = 0.50) -> float:
         """Get midpoint price (average of best bid and ask).
 

--- a/tests/test_execution_quality_gates.py
+++ b/tests/test_execution_quality_gates.py
@@ -1,0 +1,106 @@
+"""Verify execution quality gates in polymarket/bot (issue #308).
+
+1. Edge-to-spread ratio gate — rejects trades where spread eats the edge
+2. Depth-constrained position sizing — caps positions at fraction of visible book
+3. get_book_metrics — returns spread and depth from CLOB
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOT_AGENT = REPO_ROOT / "polymarket" / "bot" / "scripts" / "agent.py"
+BOT_CLIENT = REPO_ROOT / "polymarket" / "bot" / "scripts" / "polymarket_client.py"
+BOT_CONFIG = REPO_ROOT / "polymarket" / "bot" / "config.example.json"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# --- Fix 1: Edge-to-spread ratio gate ---
+
+
+def test_edge_to_spread_gate_exists() -> None:
+    source = _read(BOT_AGENT)
+    assert "edge_to_spread" in source, "agent.py missing edge-to-spread ratio computation"
+    assert "min_edge_to_spread_ratio" in source, "agent.py missing min_edge_to_spread_ratio config"
+    assert "BLOCKED" in source and "spread eats" in source.lower(), (
+        "agent.py missing BLOCKED log for edge-to-spread gate"
+    )
+
+
+def test_edge_to_spread_default_is_3() -> None:
+    source = _read(BOT_AGENT)
+    match = re.search(r"['\"]min_edge_to_spread_ratio['\"],\s*([\d.]+)", source)
+    assert match, "Cannot find min_edge_to_spread_ratio default"
+    assert float(match.group(1)) == 3.0
+
+
+def test_edge_to_spread_in_config() -> None:
+    config = _read(BOT_CONFIG)
+    assert "min_edge_to_spread_ratio" in config
+
+
+def test_edge_to_spread_fires_before_kelly() -> None:
+    source = _read(BOT_AGENT)
+    gate_pos = source.find("edge_to_spread")
+    kelly_pos = source.find("calculate_position_size")
+    assert gate_pos > 0 and kelly_pos > 0
+    assert gate_pos < kelly_pos, "edge-to-spread gate must fire before Kelly sizing"
+
+
+# --- Fix 2: Depth-constrained position sizing ---
+
+
+def test_depth_constraint_exists() -> None:
+    source = _read(BOT_AGENT)
+    assert "max_depth_fraction" in source, "agent.py missing max_depth_fraction config"
+    assert "depth cap" in source.lower() or "depth_cap" in source.lower() or "max_from_depth" in source, (
+        "agent.py missing depth-constrained sizing logic"
+    )
+
+
+def test_depth_fraction_default_is_025() -> None:
+    source = _read(BOT_AGENT)
+    match = re.search(r"['\"]max_depth_fraction['\"],\s*([\d.]+)", source)
+    assert match, "Cannot find max_depth_fraction default"
+    assert float(match.group(1)) == 0.25
+
+
+def test_depth_constraint_in_config() -> None:
+    config = _read(BOT_CONFIG)
+    assert "max_depth_fraction" in config
+
+
+def test_depth_constraint_after_kelly_before_ev() -> None:
+    """Depth cap must apply after Kelly computes size but before EV calculation."""
+    source = _read(BOT_AGENT)
+    kelly_pos = source.find("calculate_position_size")
+    depth_pos = source.find("max_from_depth")
+    ev_pos = source.find("calculate_expected_value")
+    assert kelly_pos > 0 and depth_pos > 0 and ev_pos > 0
+    assert kelly_pos < depth_pos < ev_pos, (
+        "Depth cap must sit between Kelly sizing and EV calculation"
+    )
+
+
+# --- get_book_metrics ---
+
+
+def test_client_has_get_book_metrics() -> None:
+    source = _read(BOT_CLIENT)
+    assert "def get_book_metrics" in source
+    assert "spread" in source
+    assert "bid_depth_usd" in source
+    assert "ask_depth_usd" in source
+
+
+# --- Integration: agent calls get_book_metrics ---
+
+
+def test_agent_calls_book_metrics() -> None:
+    source = _read(BOT_AGENT)
+    assert "get_book_metrics" in source, "agent.py must call get_book_metrics for spread/depth"


### PR DESCRIPTION
## Summary

Two execution quality improvements inspired by [autopredict](https://github.com/howdymary/autopredict):

- **Edge-to-spread ratio gate** (`min_edge_to_spread_ratio`, default 3.0) — rejects trades where the CLOB spread consumes the theoretical edge. A 10% edge on a market with 8% spread = ratio 1.25x → BLOCKED. Edge must exceed spread by at least 3x to trade.

- **Depth-constrained position sizing** (`max_depth_fraction`, default 0.25) — after Kelly sizes the position, caps it at 25% of visible book depth. Prevents $6 orders on books with $8 depth (75% market impact).

New `get_book_metrics()` method on PolymarketClient returns spread, depth, and best prices in a single CLOB fetch.

## Gate ordering

```
buy floor → divergence → edge threshold → annualized return
→ spread ratio → exit liquidity → confidence → Kelly → depth cap → EV
```

## Test plan

- [x] `test_edge_to_spread_gate_exists` + `default_is_3` + `in_config` + `fires_before_kelly`
- [x] `test_depth_constraint_exists` + `default_is_025` + `in_config` + `after_kelly_before_ev`
- [x] `test_client_has_get_book_metrics`
- [x] `test_agent_calls_book_metrics` (10/10 pass)

Closes #308

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com