### PR TITLE
fix(kraken): replace P2P references with Ramp in skill text

### DIFF
--- a/kraken/ramp-leverage-bitcoin-polymarket-deposit/SKILL.md
+++ b/kraken/ramp-leverage-bitcoin-polymarket-deposit/SKILL.md
@@ -3,7 +3,7 @@ name: ramp-leverage-bitcoin-polymarket-deposit
 description: "Deposit up to 5x leveraged cash into Polymarket using Kraken margin trading. Fiat onramp via Kraken Ramp API. Uses Kraken REST API directly — user supplies their own API keys."
 ---
 
-# P2P Cash Leveraged Bitcoin Polymarket Deposits (Kraken)
+# Ramp Leveraged Bitcoin Polymarket Deposits (Kraken)
 
 ## For Claude: How to Use This Skill
 

--- a/kraken/ramp-leverage-bitcoin-polymarket-deposit/scripts/agent.py
+++ b/kraken/ramp-leverage-bitcoin-polymarket-deposit/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""P2P Cash Leveraged Bitcoin Polymarket Deposits (Kraken) — 5x margin via direct Kraken REST API.
+"""Ramp Leveraged Bitcoin Polymarket Deposits (Kraken) — 5x margin via direct Kraken REST API.
 
 Pipeline: Cash → Kraken Ramp (fiat → USDC) → margin buy BTC 5x →
           withdraw USDC → Polygon → Polymarket funded.
@@ -28,7 +28,7 @@ if not sys.stdout.isatty():
     sys.stdout.reconfigure(line_buffering=True)
     sys.stderr.reconfigure(line_buffering=True)
 
-LIVE_SAFETY_VERSION = "2026-03-28.kraken-p2p-leverage-live-safety-v1"
+LIVE_SAFETY_VERSION = "2026-03-28.kraken-ramp-leverage-live-safety-v1"
 DEFAULT_DRY_RUN = True
 DEFAULT_KRAKEN_BASE = "https://api.kraken.com"
 DEFAULT_LEVERAGE = 5
@@ -375,7 +375,7 @@ def run_status(cfg: dict) -> dict:
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="P2P Cash Leveraged Bitcoin Polymarket Deposits (Kraken)")
+        description="Ramp Leveraged Bitcoin Polymarket Deposits (Kraken)")
     p.add_argument("command", nargs="?", default="run",
                    choices=["run", "status", "stop"])
     p.add_argument("--config", default="config.json")

--- a/kraken/ramp-leverage-bitcoin-polymarket-deposit/skill.spec.yaml
+++ b/kraken/ramp-leverage-bitcoin-polymarket-deposit/skill.spec.yaml
@@ -17,7 +17,7 @@ inputs:
     min: 1
     max: 200
     default: 200
-    description: Amount of cash to deposit via P2P onramp (USD)
+    description: Amount of cash to deposit via Kraken Ramp (USD)
   leverage:
     type: integer
     min: 2


### PR DESCRIPTION
Replace all remaining P2P/Peer text with Ramp in SKILL.md, agent.py, and skill.spec.yaml.

Closes #320

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com