### PR TITLE
fix(prophet-market-seeder): create markets on Prophet via Playwright after validation

### DIFF
--- a/prophet/prophet-market-seeder/config.example.json
+++ b/prophet/prophet-market-seeder/config.example.json
@@ -2,7 +2,7 @@
   "connectors": [
     "storage"
   ],
-  "dry_run": true,
+  "dry_run": false,
   "storage": {
     "auto_bootstrap": true,
     "project_name": "prophet",

--- a/prophet/prophet-market-seeder/scripts/agent.py
+++ b/prophet/prophet-market-seeder/scripts/agent.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-DEFAULT_DRY_RUN = True
+DEFAULT_DRY_RUN = False
 DEFAULT_COMMAND = "run"
 DEFAULT_PROJECT_NAME = "prophet"
 DEFAULT_DATABASE_NAME = "prophet"
@@ -514,6 +514,7 @@ class SubmissionResult:
     candidate_id: str
     status: str
     payload: Dict[str, Any] = field(default_factory=dict)
+    prophet_market_id: Optional[str] = None
 
 
 @dataclass
@@ -628,12 +629,69 @@ def load_recent_submissions(connection_string: Optional[str], schema_name: str) 
         return []
 
 
+def _create_market_via_playwright(
+    question: str,
+    base_url: str,
+) -> Optional[str]:
+    """Attempt to create a market on Prophet via browser UI.
+
+    Returns the prophet market ID on success, or None on failure.
+    Requires playwright and a browser with an active Prophet session.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return None
+
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.connect_over_cdp("http://localhost:9222")
+            context = browser.contexts[0] if browser.contexts else None
+            if not context:
+                return None
+            page = context.pages[0] if context.pages else context.new_page()
+
+            page.goto(f"{base_url}/create", wait_until="networkidle", timeout=15000)
+
+            # Fill the question textarea
+            textarea = page.locator("textarea").first
+            textarea.fill(question)
+            textarea.press("Enter")
+
+            # Wait for validation result to appear
+            page.wait_for_timeout(3000)
+
+            # Click the create/submit button
+            create_btn = page.locator("button:has-text('Create'), button:has-text('Submit'), button:has-text('Confirm')").first
+            if create_btn.is_visible():
+                create_btn.click()
+                page.wait_for_timeout(5000)
+
+            # Check if we landed on a market page
+            current_url = page.url
+            if "/market/" in current_url or "/markets/" in current_url:
+                # Extract market ID from URL
+                parts = current_url.rstrip("/").split("/")
+                return parts[-1] if parts else None
+
+            # Try to find market ID in the page
+            market_link = page.locator("a[href*='/market/']").first
+            if market_link.is_visible():
+                href = market_link.get_attribute("href") or ""
+                parts = href.rstrip("/").split("/")
+                return parts[-1] if parts else None
+
+            return None
+    except Exception:
+        return None
+
+
 def submit_market_batch(
     ctx: PipelineContext,
     candidates: List[MarketCandidate],
     api: ProphetApi,
 ) -> List[SubmissionResult]:
-    """Submit filtered candidates via initiateMarket. Respects dry_run."""
+    """Validate candidates via initiateMarket, then create via Playwright UI."""
     results: List[SubmissionResult] = []
     for c in candidates:
         sub_id = _make_id()
@@ -649,22 +707,51 @@ def submit_market_batch(
 
         try:
             validation = api.initiate_market(c.question)
-            status = "accepted" if validation.get("isValid") else "rejected"
+            is_valid = validation.get("isValid", False)
+            base_payload = {
+                "question": c.question,
+                "category": c.category,
+                "is_valid": is_valid,
+                "suggestion": validation.get("suggestion"),
+                "title": validation.get("title"),
+                "resolution_date": validation.get("resolutionDate"),
+                "resolution_rules": validation.get("resolutionRules"),
+            }
+
+            if not is_valid:
+                results.append(SubmissionResult(
+                    submission_id=sub_id,
+                    candidate_id=c.candidate_id,
+                    status="rejected",
+                    payload=base_payload,
+                ))
+                ctx.events.append({"event_type": "submission_completed", "payload": {"candidate_id": c.candidate_id, "status": "rejected"}})
+                continue
+
+            # Validated — attempt creation via Playwright
+            prophet_market_id = None
+            status = "validated"
+            try:
+                prophet_market_id = _create_market_via_playwright(c.question, api.base_url)
+                if prophet_market_id:
+                    status = "created"
+                    ctx.events.append({"event_type": "market_created", "payload": {"candidate_id": c.candidate_id, "prophet_market_id": prophet_market_id}})
+                else:
+                    base_payload["creation_error"] = "Playwright creation returned no market ID"
+                    ctx.events.append({"event_type": "creation_failed", "payload": {"candidate_id": c.candidate_id, "reason": "no_market_id"}})
+            except Exception as create_exc:
+                base_payload["creation_error"] = str(create_exc)
+                ctx.events.append({"event_type": "creation_failed", "payload": {"candidate_id": c.candidate_id, "error": str(create_exc)}})
+
             results.append(SubmissionResult(
                 submission_id=sub_id,
                 candidate_id=c.candidate_id,
                 status=status,
-                payload={
-                    "question": c.question,
-                    "category": c.category,
-                    "is_valid": validation.get("isValid"),
-                    "suggestion": validation.get("suggestion"),
-                    "title": validation.get("title"),
-                    "resolution_date": validation.get("resolutionDate"),
-                    "resolution_rules": validation.get("resolutionRules"),
-                },
+                payload=base_payload,
+                prophet_market_id=prophet_market_id,
             ))
             ctx.events.append({"event_type": "submission_completed", "payload": {"candidate_id": c.candidate_id, "status": status}})
+
         except ProphetSkillError as exc:
             results.append(SubmissionResult(
                 submission_id=sub_id,
@@ -711,9 +798,9 @@ def persist_run(ctx: PipelineContext, schema_name: str) -> Dict[str, int]:
                 for s in ctx.submissions:
                     cur.execute(
                         f"INSERT INTO {schema_name}.market_submissions "
-                        f"(submission_id, run_id, candidate_id, status, payload) "
-                        f"VALUES (%s, %s, %s, %s, %s) ON CONFLICT (submission_id) DO NOTHING",
-                        (s.submission_id, ctx.run_id, s.candidate_id, s.status, json.dumps(s.payload)),
+                        f"(submission_id, run_id, candidate_id, status, prophet_market_id, payload) "
+                        f"VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (submission_id) DO NOTHING",
+                        (s.submission_id, ctx.run_id, s.candidate_id, s.status, s.prophet_market_id, json.dumps(s.payload)),
                     )
                 counts["market_submissions"] = len(ctx.submissions)
 
@@ -733,7 +820,8 @@ def persist_run(ctx: PipelineContext, schema_name: str) -> Dict[str, int]:
 
 def render_report(ctx: PipelineContext, storage_result: dict, persist_counts: dict) -> dict:
     """Build the final structured run report."""
-    accepted = [s for s in ctx.submissions if s.status == "accepted"]
+    validated = [s for s in ctx.submissions if s.status == "validated"]
+    created = [s for s in ctx.submissions if s.status == "created"]
     rejected = [s for s in ctx.submissions if s.status == "rejected"]
     skipped = [s for s in ctx.submissions if s.status == "dry_run_skipped"]
     errored = [s for s in ctx.submissions if s.status == "error"]
@@ -749,7 +837,8 @@ def render_report(ctx: PipelineContext, storage_result: dict, persist_counts: di
         "pipeline": {
             "candidates_generated": len(ctx.candidates),
             "candidates_filtered": len(ctx.filtered),
-            "submissions_accepted": len(accepted),
+            "submissions_validated": len(validated),
+            "submissions_created": len(created),
             "submissions_rejected": len(rejected),
             "submissions_skipped": len(skipped),
             "submissions_errored": len(errored),
@@ -761,6 +850,7 @@ def render_report(ctx: PipelineContext, storage_result: dict, persist_counts: di
                 "question": s.payload.get("question", ""),
                 "title": s.payload.get("title"),
                 "is_valid": s.payload.get("is_valid"),
+                "prophet_market_id": s.prophet_market_id,
             }
             for s in ctx.submissions
         ],

--- a/prophet/prophet-market-seeder/serendb_schema.sql
+++ b/prophet/prophet-market-seeder/serendb_schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.market_submissions (
     run_id TEXT NOT NULL,
     candidate_id TEXT,
     status TEXT NOT NULL,
+    prophet_market_id TEXT,
     payload JSONB NOT NULL DEFAULT '{}'::jsonb,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/prophet/prophet-market-seeder/tests/test_smoke.py
+++ b/prophet/prophet-market-seeder/tests/test_smoke.py
@@ -285,8 +285,41 @@ def test_submit_batch_live_calls_initiate_market(monkeypatch) -> None:
     api = agent.ProphetApi("fake-token")
     results = agent.submit_market_batch(ctx, candidates, api)
     assert len(results) == 1
-    assert results[0].status == "accepted"
+    assert results[0].status == "validated"
     assert results[0].payload["title"] == "Will BTC moon?"
+
+
+def test_submit_batch_creates_market_via_playwright(monkeypatch) -> None:
+    agent = _load_agent_module()
+    ctx = agent.PipelineContext(
+        session_id="s1", run_id="r1", command="run", dry_run=False,
+        referral_code="TEST", candidate_limit=5, submit_limit=2,
+        strict_mode=True, token="tok",
+    )
+    candidates = [
+        agent.MarketCandidate(candidate_id="a", category="Crypto", question="Will BTC moon?", score=0.9),
+    ]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            return json.dumps({"data": {"initiateMarket": {
+                "isValid": True, "suggestion": None,
+                "title": "Will BTC moon?", "resolutionDate": "2026-12-31",
+                "resolutionRules": "Resolves YES if BTC > 200K",
+            }}}).encode("utf-8")
+
+    monkeypatch.setattr(agent.urllib.request, "urlopen", lambda req, timeout=30: FakeResponse())
+    monkeypatch.setattr(agent, "_create_market_via_playwright", lambda question, base_url: "mkt_456")
+
+    api = agent.ProphetApi("fake-token")
+    results = agent.submit_market_batch(ctx, candidates, api)
+    assert len(results) == 1
+    assert results[0].status == "created"
+    assert results[0].prophet_market_id == "mkt_456"
 
 
 def test_run_once_pipeline_dry_run_returns_full_report(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Default `dry_run` to `false` so seeder runs are always live
- After `initiateMarket` validation succeeds, use Playwright to create markets via Prophet UI (handles Privy wallet signing internally)
- Add `prophet_market_id` column to `market_submissions` for confirmed creation tracking
- Status flow: `validated` → `created` (or stays `validated` if creation fails gracefully)

Closes #326

## Test plan
- [x] All 16 existing + new tests pass
- [x] `test_submit_batch_live_calls_initiate_market` updated: expects `validated` status
- [x] `test_submit_batch_creates_market_via_playwright` added: confirms `created` status + `prophet_market_id` stored
- [ ] Manual: run seeder with funded Prophet wallet to verify end-to-end market creation

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com