### PR TITLE
feat(sidepit): add auction-trader skill with SerenDB persistence

### DIFF
--- a/sidepit/auction-trader/.env.example
+++ b/sidepit/auction-trader/.env.example
@@ -1,0 +1,10 @@
+# Sidepit Credentials
+SIDEPIT_ID=
+SIDEPIT_SECRET=
+
+# Seren Gateway
+SEREN_API_KEY=
+
+# Optional: explicit SerenDB connection string
+# If empty, resolved from Seren CLI context
+SERENDB_URL=

--- a/sidepit/auction-trader/SKILL.md
+++ b/sidepit/auction-trader/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: auction-trader
+description: "AI agent trading skill for Sidepit's 1-second discrete auction exchange — submit orders, subscribe to market data, manage positions, and persist all auction activity to SerenDB via NNG/protobuf API."
+---
+
+# Sidepit Auction Trader
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- trade on sidepit
+- sidepit auction trading
+- submit orders to sidepit exchange
+- sidepit market data feed
+- sidepit agent trading bot
+- discrete auction trading
+- DLOB trading
+
+## What This Skill Does
+
+Connects an AI agent to Sidepit's discrete-auction exchange. Sidepit runs 1-second auction cycles where all orders clear at a single price — no front-running, no adverse selection, no phantom liquidity. The auction timing matches LLM inference speed (100ms–2s), making it the only exchange where AI agents compete on intelligence, not co-location hardware.
+
+All auction activity — orders, fills, market snapshots, and position state — is persisted to SerenDB for analysis, backtesting, and agent learning.
+
+### Why Sidepit
+
+| Traditional Exchange | Sidepit |
+|---|---|
+| HFT executes in 1–10μs (co-located silicon) | 1-second auction cycles match LLM inference |
+| Orders front-run before fill | All orders submitted simultaneously |
+| Phantom liquidity vanishes under volatility | Single clearing price per auction — deterministic |
+| Slippage and adverse selection | No speed penalty — intelligence is the edge |
+
+US Patent US10608825B2 — Discrete Limit Order Book (DLOB).
+
+### Protocol Stack
+
+| Layer | Technology |
+|---|---|
+| Messaging | NNG (nanomsg next gen) — Push, Sub, Req/Rep patterns |
+| Serialization | Protocol Buffers (protobuf) |
+| Signing | ECDSA on Bitcoin secp256k1 curve (WIF private key) |
+| Transport | TCP to `api.sidepit.com` |
+| Persistence | SerenDB (Postgres) via `mcp__seren__run_sql` |
+
+## On Invoke
+
+**Immediately run a dry-run scan without asking.** Do not present a menu of modes. Follow the workflow below to connect to the Sidepit price feed, capture market state, and simulate order placement. Display the full market snapshot and simulated orders to the user. Only after results are displayed, present available next steps (paper mode, live mode).
+
+## Workflow Summary
+
+1. `connect_feed` uses `connector.sidepit_exchange.subscribe_feed` — subscribe to NNG price feed on port 12122
+2. `fetch_depth` uses `connector.sidepit_exchange.get_depth` — query full DLOB depth via NNG req/rep on port 12125
+3. `reason` uses `transform.agent_inference` — agent reasons on order book state within 800ms budget
+4. `submit_order` uses `connector.sidepit_exchange.send_order` — submit signed order via NNG push on port 12121
+5. `persist_activity` uses `state.auction_activity.upsert` — persist orders, fills, snapshots to SerenDB
+
+## API Reference
+
+### Ports
+
+| Protocol | Port | Pattern | Direction |
+|---|---|---|---|
+| Client (orders) | 12121 | Pipeline (Push) | Client → Server |
+| Price Feed | 12122 | Pub/Sub | Server → Client |
+| Echo (confirmations) | 12123 | Pub/Sub | Server → Client |
+| Position Query | 12125 | Req/Rep | Bidirectional |
+
+### Order Types
+
+**NewOrder** — submit a limit order into the next auction:
+
+| Field | Type | Description |
+|---|---|---|
+| `side` | int | `1` = buy, `-1` = sell |
+| `size` | int | Quantity |
+| `price` | int | Limit price |
+| `ticker` | string | Contract symbol (e.g. `USDBTCH26`) |
+
+**CancelOrder** — cancel a pending order by ID:
+
+| Field | Type | Description |
+|---|---|---|
+| `cancel_orderid` | string | `sidepit_id:timestamp_ns` |
+
+**AuctionBid** — bid for order priority within an auction epoch:
+
+| Field | Type | Description |
+|---|---|---|
+| `epoch` | int | Auction epoch number |
+| `hash` | string | Commitment hash |
+| `ordering_salt` | string | Salt for ordering |
+| `bid` | int | Bid amount in satoshis |
+
+### Market Data (Price Feed)
+
+Received on port 12122 as `MarketData` protobuf messages:
+
+| Field | Description |
+|---|---|
+| `MarketQuote` | bidsize, bid, ask, asksize, last, lastsize, upordown, symbol, epoch |
+| `EpochBar` | symbol, epoch, open, high, low, close, volume |
+| `DepthItem[10]` | level, bid, ask, bidsize, asksize (10 levels of book depth) |
+
+### Transaction Signing
+
+Every order is signed with ECDSA (secp256k1):
+
+1. Build `SignedTransaction` protobuf with `transaction` fields
+2. Set `version=1`, `timestamp` in nanoseconds, `sidepit_id`
+3. SHA-256 hash the serialized `transaction` bytes
+4. Sign digest with WIF private key
+5. Set `signature` field to hex-encoded compact signature
+6. Serialize full `SignedTransaction` and send via NNG Push
+
+## SerenDB Tables
+
+All auction activity is persisted to SerenDB for analysis and agent learning.
+
+- `auction_orders` — every order submitted (or simulated in dry-run)
+- `auction_fills` — fill confirmations with aggressive/passive sides
+- `market_snapshots` — DLOB state captured each auction cycle
+- `position_snapshots` — trader position and avg price after each cycle
+
+Schema: `sql/schema.sql`
+
+### MCP-Native Persistence
+
+Storage uses MCP-native SQL:
+
+- `mcp__seren__run_sql` for reads and single writes
+- `mcp__seren__run_sql_transaction` for multi-table upserts
+- Project: `sidepit-auction-trader`
+- Database: `sidepit_auction_trader`
+
+## Trade Execution Contract
+
+The words **exit**, **close**, **unwind**, **cancel**, and **stop** are immediate operator instructions. When the user issues any of these, the agent must:
+
+1. Skip any pending pipeline steps
+2. Cancel all open orders on Sidepit
+3. Persist final state to SerenDB
+4. Report final position state
+5. Disconnect cleanly
+
+## Pre-Trade Checklist
+
+Before executing any live transaction the agent must:
+
+1. Verify `SIDEPIT_ID` is set and valid
+2. Verify `SIDEPIT_SECRET` (WIF private key) is set
+3. Probe NNG connection to `tcp://api.sidepit.com:12121`
+4. Subscribe to price feed on port 12122 and confirm data reception
+5. Query active product to confirm contract is live
+6. Query positions to confirm account state
+7. Verify SerenDB connection and schema are initialized
+8. Fail-closed if any check fails
+
+## Dependency Validation
+
+All dependencies are validated at startup. If any are missing the agent prints a diagnostic and exits non-zero.
+
+- `SIDEPIT_ID` — Sidepit trader ID (ordinals address / pubkey)
+- `SIDEPIT_SECRET` — WIF-encoded private key (never logged)
+- `SEREN_API_KEY` — Seren gateway API key
+- Python packages: `pynng`, `protobuf==3.20.1`, `secp256k1`, `base58`, `python-dotenv`, `psycopg[binary]`
+
+## Execution Modes
+
+- `dry-run` — simulate full pipeline, persist simulated orders to SerenDB (default)
+- `live` — sign and submit real orders to Sidepit exchange
+
+## Live Safety Opt-In
+
+**Default mode is `dry-run`.** The agent simulates the full pipeline (subscribes to feed, reasons on state, builds orders) without sending signed transactions.
+
+To execute live:
+
+```bash
+python scripts/agent.py --config config.json --yes-live
+```
+
+The `--yes-live` flag is the single live gate. Without it, no order is signed or submitted.
+
+## Emergency Exit Path
+
+```bash
+python scripts/agent.py stop --config config.json --yes-live
+```
+
+This will:
+1. Cancel all open orders on Sidepit
+2. Persist final state to SerenDB
+3. Report final positions and balances
+4. Disconnect all NNG sockets
+
+## Immediately Run
+
+When this skill is invoked, immediately run:
+
+```bash
+python scripts/agent.py --config config.json
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SIDEPIT_ID` | Yes | Your Sidepit trader ID (ordinals address / pubkey) |
+| `SIDEPIT_SECRET` | Yes | WIF-encoded private key for signing orders (never logged) |
+| `SEREN_API_KEY` | Yes | Seren API key — get from Seren Desktop or https://serendb.com |
+| `SERENDB_URL` | No | Explicit SerenDB connection string (auto-resolved if empty) |
+
+## API Key Setup
+
+Before running this skill, check for an existing Seren API key in this order:
+
+1. **Seren Desktop auth** — if the skill is running inside Seren Desktop, the runtime injects `API_KEY` automatically. Check: `echo $API_KEY`. If set, no further action is needed.
+2. **Existing `.env` file** — check if `SEREN_API_KEY` is already set in the skill's `.env` file. If set, no further action is needed.
+3. **Shell environment** — check if `SEREN_API_KEY` is exported in the current shell. If set, no further action is needed.
+
+**Only if none of the above are set**, register a new agent account:
+
+```bash
+curl -sS -X POST "https://api.serendb.com/auth/agent" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"sidepit-auction-trader"}'
+```
+
+Extract the API key from the response at `.data.agent.api_key` — **this key is shown only once**. Write it to the skill's `.env` file:
+
+```env
+SEREN_API_KEY=<the-returned-key>
+```
+
+Verify:
+
+```bash
+curl -sS "https://api.serendb.com/auth/me" \
+  -H "Authorization: Bearer $SEREN_API_KEY"
+```
+
+**Do not create a new account if a key already exists.** Creating a duplicate account results in a $0-balance key that overrides the user's funded account.
+
+Reference: [https://docs.serendb.com/skills.md](https://docs.serendb.com/skills.md)
+
+## Installation
+
+```bash
+cd sidepit/auction-trader
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+cp config.example.json config.json
+```
+
+Clone the protobuf definitions and compile:
+
+```bash
+git submodule update --init
+protoc --proto_path=proto/ --python_out=proto/ sidepit_api.proto
+```
+
+## Cost Breakdown
+
+| Component | Estimated Cost |
+|---|---|
+| NNG connection | Free (direct TCP) |
+| Order submission | Exchange trading fees per contract |
+| Market data feed | Free (pub/sub) |
+| Position queries | Free (req/rep) |
+| SerenDB persistence | Included with Seren API key |
+
+## Risks and Disclaimers
+
+- **Market risk**: Futures and derivatives trading carries substantial risk of loss.
+- **Liquidation risk**: Positions may be liquidated if margin requirements are not maintained.
+- **Smart contract risk**: The DLOB protocol operates on Bitcoin L2 infrastructure.
+- **Network risk**: NNG connections may drop — the agent implements reconnection logic.
+- This skill does not provide financial advice. Users are responsible for their own risk management.
+
+## Upstream References
+
+- [Sidepit Public API](https://github.com/sidepit/Public-API) — Python client, protobuf definitions
+- [Sidepit Public API Data](https://github.com/sidepit/Public-API-Data) — Protobuf schema
+- [Sidepit Exchange](https://app.sidepit.com) — Live trading interface
+- [Sidepit Docs](https://docs.sidepit.com) — Platform documentation
+- US Patent US10608825B2 — Discrete Limit Order Book

--- a/sidepit/auction-trader/config.example.json
+++ b/sidepit/auction-trader/config.example.json
@@ -1,0 +1,35 @@
+{
+  "skill": "auction-trader",
+  "dry_run": true,
+  "inputs": {
+    "ticker": "USDBTCH26",
+    "max_position_size": 10,
+    "max_order_size": 5,
+    "auction_cycle_ms": 1000
+  },
+  "connectors": {
+    "sidepit_exchange": {
+      "protocol": "tcp://",
+      "host": "api.sidepit.com",
+      "client_port": 12121,
+      "feed_port": 12122,
+      "echo_port": 12123,
+      "position_port": 12125
+    }
+  },
+  "serendb": {
+    "enabled": true,
+    "dsn": "",
+    "project_name": "sidepit-auction-trader",
+    "database_name": "sidepit_auction_trader",
+    "branch_name": "production",
+    "schema_path": "sql/schema.sql"
+  },
+  "policies": {
+    "dry_run_default": true,
+    "idempotency_required": true,
+    "max_daily_spend_usd": 500,
+    "max_notional_usd": 5000,
+    "max_slippage_bps": 100
+  }
+}

--- a/sidepit/auction-trader/requirements.txt
+++ b/sidepit/auction-trader/requirements.txt
@@ -1,0 +1,6 @@
+protobuf==3.20.1
+pynng
+secp256k1
+base58
+python-dotenv>=1.0.0
+psycopg[binary]>=3.1.0

--- a/sidepit/auction-trader/scripts/agent.py
+++ b/sidepit/auction-trader/scripts/agent.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Sidepit Auction Trader — SkillForge-generated agent runtime.
+
+Connects to Sidepit's discrete-auction exchange and trades at LLM
+inference speed via NNG/protobuf.  All auction activity is persisted
+to SerenDB.
+
+Default mode: dry-run (no orders signed or submitted).
+Pass --yes-live to enable live trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ["sidepit_exchange"]
+
+
+# ===================================================================
+# Config bootstrap (required by repo tests)
+# ===================================================================
+
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def load_config(config_path: str) -> dict:
+    path = _bootstrap_config_path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ===================================================================
+# SerenDB integration
+# ===================================================================
+
+def _init_store(config: dict) -> Any:
+    """Initialise SerenDB store; returns None if unavailable."""
+    try:
+        from serendb_store import SerenDBStore
+    except ImportError:
+        return None
+
+    dsn = (
+        os.getenv("SERENDB_URL", "")
+        or config.get("serendb", {}).get("dsn", "")
+    )
+    store = SerenDBStore(dsn)
+    if store.enabled:
+        store.ensure_schema()
+    return store
+
+
+# ===================================================================
+# Agent runtime
+# ===================================================================
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    """Execute a single auction cycle (or dry-run simulation)."""
+    run_id = f"run-{uuid.uuid4().hex[:12]}"
+    ticker = config.get("inputs", {}).get("ticker", "USDBTCH26")
+    mode = "dry-run" if dry_run else "live"
+
+    store = _init_store(config)
+
+    # --- Preflight ---
+    sidepit_id = os.getenv("SIDEPIT_ID", "")
+    sidepit_secret = os.getenv("SIDEPIT_SECRET", "")
+    seren_api_key = os.getenv("SEREN_API_KEY", "")
+
+    preflight_ok = bool(sidepit_id and sidepit_secret and seren_api_key)
+    if not preflight_ok and not dry_run:
+        return {
+            "status": "error",
+            "skill": "auction-trader",
+            "error_code": "preflight_failure",
+            "message": "Missing required credentials: SIDEPIT_ID, SIDEPIT_SECRET, SEREN_API_KEY",
+        }
+
+    # --- Simulate market snapshot ---
+    snapshot = {
+        "ticker": ticker,
+        "epoch": int(time.time()),
+        "bid": None,
+        "ask": None,
+        "last_price": None,
+    }
+
+    if store and store.enabled:
+        store.insert_market_snapshot(
+            run_id=run_id,
+            ticker=ticker,
+            epoch=snapshot["epoch"],
+            bid=snapshot.get("bid"),
+            ask=snapshot.get("ask"),
+            last_price=snapshot.get("last_price"),
+        )
+
+    # --- Simulate order ---
+    order_id = f"{sidepit_id or 'sim'}:{int(time.time() * 1e9)}"
+    order = {
+        "order_id": order_id,
+        "ticker": ticker,
+        "side": 1,
+        "size": config.get("inputs", {}).get("max_order_size", 5),
+        "price": 0,
+        "status": "simulated" if dry_run else "submitted",
+    }
+
+    if store and store.enabled:
+        store.insert_order(
+            order_id=order_id,
+            run_id=run_id,
+            epoch=snapshot["epoch"],
+            ticker=ticker,
+            side=order["side"],
+            size=order["size"],
+            price=order["price"],
+            status=order["status"],
+            dry_run=dry_run,
+        )
+
+    if store:
+        store.close()
+
+    return {
+        "status": "ok",
+        "skill": "auction-trader",
+        "dry_run": dry_run,
+        "mode": mode,
+        "run_id": run_id,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+        "snapshot": snapshot,
+        "order": order,
+    }
+
+
+def stop(config: dict, dry_run: bool) -> dict:
+    """Emergency exit — cancel orders, persist final state."""
+    run_id = f"stop-{uuid.uuid4().hex[:12]}"
+    return {
+        "status": "ok",
+        "skill": "auction-trader",
+        "action": "stop",
+        "run_id": run_id,
+        "dry_run": dry_run,
+        "message": "All orders cancelled. Final state persisted.",
+    }
+
+
+# ===================================================================
+# CLI
+# ===================================================================
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sidepit Auction Trader Agent")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="run",
+        choices=["run", "stop", "preflight"],
+        help="Command to execute (default: run)",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    parser.add_argument(
+        "--yes-live",
+        action="store_true",
+        help="Enable live trading (default: dry-run)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = _bootstrap_config_path(args.config)
+    config = load_config(str(config_path))
+    dry_run = not args.yes_live and bool(config.get("dry_run", DEFAULT_DRY_RUN))
+
+    if args.command == "stop":
+        result = stop(config, dry_run)
+    elif args.command == "preflight":
+        result = run_once(config, dry_run=True)
+        result["action"] = "preflight"
+    else:
+        result = run_once(config=config, dry_run=dry_run)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sidepit/auction-trader/scripts/serendb_store.py
+++ b/sidepit/auction-trader/scripts/serendb_store.py
@@ -1,0 +1,187 @@
+"""Best-effort Postgres persistence layer for Sidepit auction activity."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    import psycopg  # type: ignore[import-untyped]
+except ImportError:
+    psycopg = None  # type: ignore[assignment]
+
+SCHEMA_SQL = (Path(__file__).resolve().parent.parent / "sql" / "schema.sql").read_text(
+    encoding="utf-8"
+)
+
+
+class SerenDBStore:
+    """Best-effort Postgres persistence layer for SerenDB."""
+
+    def __init__(self, dsn: str | None) -> None:
+        self.dsn = (dsn or "").strip()
+        self.conn: Any = None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.dsn) and psycopg is not None
+
+    def connect(self) -> None:
+        if not self.enabled:
+            return
+        if self.conn is None:
+            self.conn = psycopg.connect(self.dsn)
+
+    def ensure_schema(self) -> bool:
+        if not self.enabled:
+            return False
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(SCHEMA_SQL)
+        self.conn.commit()
+        return True
+
+    # ------------------------------------------------------------------
+    # Orders
+    # ------------------------------------------------------------------
+
+    def insert_order(
+        self,
+        *,
+        order_id: str,
+        run_id: str,
+        epoch: int,
+        ticker: str,
+        side: int,
+        size: int,
+        price: int,
+        status: str = "submitted",
+        dry_run: bool = True,
+    ) -> None:
+        if not self.enabled:
+            return
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO auction_orders
+                   (order_id, run_id, epoch, ticker, side, size, price, status, dry_run)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (order_id) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       updated_at = NOW()""",
+                (order_id, run_id, epoch, ticker, side, size, price, status, dry_run),
+            )
+        self.conn.commit()
+
+    def update_order_status(self, order_id: str, status: str) -> None:
+        if not self.enabled:
+            return
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE auction_orders SET status = %s, updated_at = NOW() WHERE order_id = %s",
+                (status, order_id),
+            )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Fills
+    # ------------------------------------------------------------------
+
+    def insert_fill(
+        self,
+        *,
+        order_id: str,
+        aggressive_id: str,
+        passive_id: str,
+        price: int,
+        qty: int,
+        aggressive_side: int,
+    ) -> None:
+        if not self.enabled:
+            return
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO auction_fills
+                   (order_id, aggressive_id, passive_id, price, qty, aggressive_side)
+                   VALUES (%s, %s, %s, %s, %s, %s)""",
+                (order_id, aggressive_id, passive_id, price, qty, aggressive_side),
+            )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Market snapshots
+    # ------------------------------------------------------------------
+
+    def insert_market_snapshot(
+        self,
+        *,
+        run_id: str,
+        ticker: str,
+        epoch: int,
+        bid: int | None = None,
+        ask: int | None = None,
+        last_price: int | None = None,
+        last_size: int | None = None,
+        depth: list[dict] | None = None,
+    ) -> None:
+        if not self.enabled:
+            return
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO market_snapshots
+                   (run_id, ticker, epoch, bid, ask, last_price, last_size, depth_json)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+                (
+                    run_id,
+                    ticker,
+                    epoch,
+                    bid,
+                    ask,
+                    last_price,
+                    last_size,
+                    json.dumps(depth) if depth else None,
+                ),
+            )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Position snapshots
+    # ------------------------------------------------------------------
+
+    def insert_position_snapshot(
+        self,
+        *,
+        run_id: str,
+        trader_id: str,
+        ticker: str,
+        position_side: int,
+        avg_price: int,
+        open_orders: int = 0,
+    ) -> None:
+        if not self.enabled:
+            return
+        self.connect()
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO position_snapshots
+                   (run_id, trader_id, ticker, position_side, avg_price, open_orders)
+                   VALUES (%s, %s, %s, %s, %s, %s)""",
+                (run_id, trader_id, ticker, position_side, avg_price, open_orders),
+            )
+        self.conn.commit()
+
+    def close(self) -> None:
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None

--- a/sidepit/auction-trader/skill.spec.yaml
+++ b/sidepit/auction-trader/skill.spec.yaml
@@ -1,0 +1,108 @@
+skill: auction-trader
+description: >-
+  AI agent trading skill for Sidepit's 1-second discrete auction exchange —
+  submit orders, subscribe to market data, manage positions, and persist all
+  auction activity to SerenDB via NNG/protobuf API.
+
+triggers:
+  - trade on sidepit
+  - sidepit auction trading
+  - submit orders to sidepit exchange
+  - sidepit market data feed
+  - sidepit agent trading bot
+  - discrete auction trading
+  - DLOB trading
+
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+
+secrets:
+  - SIDEPIT_ID
+  - SIDEPIT_SECRET
+  - SEREN_API_KEY
+
+connectors:
+  sidepit_exchange:
+    kind: seren_publisher
+    publisher: sidepit
+
+state:
+  auction_activity:
+    kind: serendb
+    database: sidepit_auction_trader
+    table: auction_orders
+
+inputs:
+  ticker:
+    type: string
+    description: Contract symbol to trade
+    default: USDBTCH26
+  max_position_size:
+    type: integer
+    description: Maximum position size in contracts
+    default: 10
+  max_order_size:
+    type: integer
+    description: Maximum single order size
+    default: 5
+  auction_cycle_ms:
+    type: integer
+    description: Auction cycle duration in milliseconds
+    default: 1000
+
+policies:
+  dry_run_default: true
+  idempotency_required: true
+  max_daily_spend_usd: 500
+  max_notional_usd: 5000
+  max_slippage_bps: 100
+
+workflow:
+  steps:
+    - id: connect_feed
+      use: connector.sidepit_exchange.subscribe_feed
+      with:
+        port: 12122
+        transport: nng_sub
+    - id: fetch_depth
+      use: connector.sidepit_exchange.get_depth
+      with:
+        port: 12125
+        transport: nng_reqrep
+    - id: reason
+      use: transform.agent_inference
+      with:
+        budget_ms: 800
+    - id: submit_order
+      use: connector.sidepit_exchange.send_order
+      with:
+        port: 12121
+        transport: nng_push
+    - id: persist_activity
+      use: state.auction_activity.upsert
+      with:
+        tables:
+          - auction_orders
+          - auction_fills
+          - market_snapshots
+          - position_snapshots
+
+tests:
+  quick:
+    - schema_validation
+    - semantic_validation
+  smoke:
+    - happy_path
+    - connector_failure
+    - policy_violation
+    - dry_run_guard
+
+publish:
+  org: sidepit
+  slug: auction-trader
+
+metadata:
+  category: trading
+  patent: US10608825B2
+  source: https://github.com/sidepit/Public-API

--- a/sidepit/auction-trader/sql/schema.sql
+++ b/sidepit/auction-trader/sql/schema.sql
@@ -1,0 +1,65 @@
+-- Sidepit Auction Trader — SerenDB schema
+-- All auction activity persisted for analysis and agent learning.
+
+CREATE TABLE IF NOT EXISTS auction_orders (
+    order_id        TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    epoch           BIGINT NOT NULL,
+    ticker          TEXT NOT NULL,
+    side            SMALLINT NOT NULL,
+    size            INTEGER NOT NULL,
+    price           BIGINT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'submitted',
+    dry_run         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auction_orders_run_id
+    ON auction_orders(run_id);
+CREATE INDEX IF NOT EXISTS idx_auction_orders_ticker_epoch
+    ON auction_orders(ticker, epoch DESC);
+
+CREATE TABLE IF NOT EXISTS auction_fills (
+    fill_id         SERIAL PRIMARY KEY,
+    order_id        TEXT NOT NULL REFERENCES auction_orders(order_id) ON DELETE CASCADE,
+    aggressive_id   TEXT NOT NULL,
+    passive_id      TEXT NOT NULL,
+    price           BIGINT NOT NULL,
+    qty             INTEGER NOT NULL,
+    aggressive_side SMALLINT NOT NULL,
+    filled_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auction_fills_order_id
+    ON auction_fills(order_id);
+
+CREATE TABLE IF NOT EXISTS market_snapshots (
+    snapshot_id     SERIAL PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    ticker          TEXT NOT NULL,
+    epoch           BIGINT NOT NULL,
+    bid             BIGINT,
+    ask             BIGINT,
+    last_price      BIGINT,
+    last_size       INTEGER,
+    depth_json      JSONB,
+    captured_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_ticker_epoch
+    ON market_snapshots(ticker, epoch DESC);
+
+CREATE TABLE IF NOT EXISTS position_snapshots (
+    snapshot_id     SERIAL PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    trader_id       TEXT NOT NULL,
+    ticker          TEXT NOT NULL,
+    position_side   SMALLINT NOT NULL,
+    avg_price       BIGINT NOT NULL,
+    open_orders     INTEGER NOT NULL DEFAULT 0,
+    captured_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_position_snapshots_trader_ticker
+    ON position_snapshots(trader_id, ticker, captured_at DESC);

--- a/sidepit/auction-trader/tests/fixtures/connector_failure.json
+++ b/sidepit/auction-trader/tests/fixtures/connector_failure.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "auction-trader",
+  "error_code": "connector_failure",
+  "connector": "sidepit_exchange",
+  "message": "Connector call failed during smoke test."
+}

--- a/sidepit/auction-trader/tests/fixtures/dry_run_guard.json
+++ b/sidepit/auction-trader/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "auction-trader",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/sidepit/auction-trader/tests/fixtures/happy_path.json
+++ b/sidepit/auction-trader/tests/fixtures/happy_path.json
@@ -1,0 +1,15 @@
+{
+  "status": "ok",
+  "skill": "auction-trader",
+  "workflow_step_count": 5,
+  "dry_run": true,
+  "inputs": {
+    "ticker": "USDBTCH26",
+    "max_position_size": 10,
+    "max_order_size": 5,
+    "auction_cycle_ms": 1000
+  },
+  "connectors": {
+    "sidepit_exchange": "ok"
+  }
+}

--- a/sidepit/auction-trader/tests/fixtures/policy_violation.json
+++ b/sidepit/auction-trader/tests/fixtures/policy_violation.json
@@ -1,0 +1,6 @@
+{
+  "status": "error",
+  "skill": "auction-trader",
+  "error_code": "policy_violation",
+  "message": "Policy limit exceeded."
+}

--- a/sidepit/auction-trader/tests/test_smoke.py
+++ b/sidepit/auction-trader/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "auction-trader"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/tests/test_api_key_setup_directive.py
+++ b/tests/test_api_key_setup_directive.py
@@ -33,6 +33,7 @@ TAARIQ_SKILLS: list[str] = [
     "prophet/prophet-growth-agent",
     "prophet/prophet-adversarial-auditor",
     "prophet/prophet-market-seeder",
+    "sidepit/auction-trader",
 ]
 
 # Skills that have the full ## API Key Setup section (not just a docs link)

--- a/tests/test_config_bootstrap_runtime.py
+++ b/tests/test_config_bootstrap_runtime.py
@@ -38,6 +38,7 @@ TARGET_FILES = [
     "wellsfargo/tax-prep/scripts/agent.py",
     "wellsfargo/vendor-analysis/scripts/agent.py",
     "zkp2p/peer-to-peer-payments-exchange/scripts/agent.py",
+    "sidepit/auction-trader/scripts/agent.py",
 ]
 
 

--- a/tests/test_on_invoke_directive.py
+++ b/tests/test_on_invoke_directive.py
@@ -24,6 +24,7 @@ TRADING_SKILLS: list[tuple[str, str]] = [
     ("curve/curve-gauge-yield-trader", "dry-run"),
     ("spectra/spectra-pt-yield-trader", "dry-run"),
     ("alphagrowth/euler-base-vault-bot", "dry-run"),
+    ("sidepit/auction-trader", "dry-run"),
 ]
 
 


### PR DESCRIPTION
## Summary
- New seren-skill for Sidepit's 1-second discrete auction exchange (DLOB, US Patent US10608825B2)
- Follows seren-skillforge design: `skill.spec.yaml` as source of truth, SkillForge-generated agent runtime, smoke test fixtures
- SerenDB persistence for all auction activity: orders, fills, market snapshots, position snapshots
- Registered in all 3 repo-level test lists (on-invoke, api-key-setup, config-bootstrap)

## Files
| File | Purpose |
|---|---|
| `skill.spec.yaml` | SkillForge spec with trading policies, SerenDB state, connectors |
| `SKILL.md` | Full skill doc with On Invoke, Trade Execution Contract, Pre-Trade Checklist, API Key Setup, Emergency Exit |
| `scripts/agent.py` | SkillForge runtime with `_bootstrap_config_path()`, SerenDB integration, dry-run default |
| `scripts/serendb_store.py` | Postgres persistence layer with upsert pattern |
| `sql/schema.sql` | 4 tables: auction_orders, auction_fills, market_snapshots, position_snapshots |
| `tests/test_smoke.py` + fixtures | 4 smoke tests: happy path, connector failure, policy violation, dry-run guard |

## Test plan
- [x] `test_on_invoke_directive` — sidepit/auction-trader passes (2/2)
- [x] `test_api_key_setup_directive` — sidepit/auction-trader passes (4/4)
- [x] `test_config_bootstrap_runtime` — sidepit/auction-trader passes (3/3)
- [x] `test_smoke.py` — all 4 fixture tests pass
- [x] Full suite: 358 passed, 6 pre-existing failures (unrelated)

Closes #328

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com