### PR TITLE
fix(polymarket): add drawdown stop-loss, position aging, and cron auto-pause

### DIFF
--- a/polymarket/_shared/risk_guards.py
+++ b/polymarket/_shared/risk_guards.py
@@ -1,0 +1,141 @@
+"""Risk guards for Polymarket trading skills.
+
+Provides three protections:
+1. Drawdown stop-loss: auto-unwind when drawdown exceeds backtest max drawdown
+2. Position aging: force-close positions older than max age
+3. Cron auto-pause: pause seren-cron job when funds exhausted
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+def check_drawdown_stop_loss(
+    *,
+    live_risk: dict[str, Any],
+    max_drawdown_pct: float,
+    unwind_fn: Callable[[], dict[str, Any]],
+    log_fn: Callable[[str], None] = print,
+) -> dict[str, Any] | None:
+    """Trigger unwind if live drawdown exceeds the configured limit.
+
+    Returns unwind result dict if triggered, None otherwise.
+    """
+    if max_drawdown_pct <= 0:
+        return None
+
+    current_dd_pct = float(live_risk.get("drawdown_pct", 0.0))
+    if current_dd_pct < max_drawdown_pct:
+        return None
+
+    log_fn(
+        f"DRAWDOWN STOP-LOSS TRIGGERED: {current_dd_pct:.2f}% >= limit "
+        f"{max_drawdown_pct:.2f}%. Equity: "
+        f"${live_risk.get('current_equity_usd', 0):.2f}, "
+        f"Peak: ${live_risk.get('peak_equity_usd', 0):.2f}. "
+        f"Unwinding all positions."
+    )
+    return unwind_fn()
+
+
+def check_position_age(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    max_age_hours: float,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return token_ids whose positions exceed max_age_hours.
+
+    position_timestamps: {token_id: ISO-8601 string}
+    current_exposure:    {token_id: notional_usd}
+    """
+    if max_age_hours <= 0:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    aged: list[str] = []
+    for token_id, notional in current_exposure.items():
+        if notional <= 0:
+            continue
+        opened_str = position_timestamps.get(token_id)
+        if not opened_str:
+            continue
+        try:
+            opened = datetime.fromisoformat(opened_str.replace("Z", "+00:00"))
+            if (now - opened).total_seconds() / 3600.0 >= max_age_hours:
+                aged.append(token_id)
+        except (ValueError, TypeError):
+            continue
+    return aged
+
+
+def sync_position_timestamps(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Keep position_timestamps in sync with live exposure.
+
+    - New positions get the current timestamp.
+    - Closed positions are pruned.
+    - Existing positions keep their original timestamp.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    return {
+        token_id: position_timestamps.get(token_id, now_iso)
+        for token_id, notional in current_exposure.items()
+        if notional > 0
+    }
+
+
+def auto_pause_cron(
+    *,
+    serenbucks_balance: float | None,
+    trading_balance: float | None,
+    min_serenbucks: float = 1.0,
+    min_trading_balance: float = 0.0,
+    job_id: str | None = None,
+    pause_fn: Callable[[str], Any] | None = None,
+    log_fn: Callable[[str], None] = print,
+) -> bool:
+    """Pause the seren-cron job if balances are below thresholds.
+
+    Returns True if the job was paused.
+    """
+    if not job_id or not pause_fn:
+        return False
+
+    reason: str | None = None
+    if serenbucks_balance is not None and serenbucks_balance < min_serenbucks:
+        reason = (
+            f"SerenBucks ${serenbucks_balance:.2f} < min ${min_serenbucks:.2f}"
+        )
+    elif (
+        trading_balance is not None
+        and min_trading_balance > 0
+        and trading_balance < min_trading_balance
+    ):
+        reason = (
+            f"Trading balance ${trading_balance:.2f} < min "
+            f"${min_trading_balance:.2f}"
+        )
+
+    if reason is None:
+        return False
+
+    log_fn(f"AUTO-PAUSE: {reason}. Pausing cron job {job_id}.")
+    try:
+        pause_fn(job_id)
+        log_fn(f"Cron job {job_id} paused successfully.")
+        return True
+    except Exception as exc:
+        log_fn(f"Failed to pause cron job {job_id}: {exc}")
+        return False

--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -22,6 +22,12 @@
     "annualized_return_floor": 0.0,
     "low_balance_threshold": 1.50
   },
+  "execution": {
+    "max_drawdown_pct": 15.0,
+    "max_position_age_hours": 72,
+    "min_serenbucks_balance": 1.0,
+    "auto_pause_on_exhaustion": true
+  },
   "cron": {
     "runner_name": "",
     "machine_label": "",

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -40,6 +40,12 @@ from logger import TradingLogger
 from serendb_storage import SerenDBStorage
 import kelly
 import calibration
+from risk_guards import (
+    auto_pause_cron,
+    check_drawdown_stop_loss,
+    check_position_age,
+    sync_position_timestamps,
+)
 
 
 class TradingAgent:
@@ -92,6 +98,10 @@ class TradingAgent:
         self.max_kelly_fraction = float(self.config['max_kelly_fraction'])
         self.max_positions = int(self.config['max_positions'])
         self.stop_loss_bankroll = float(self.config.get('stop_loss_bankroll', 0.0))
+        self.max_drawdown_pct = float(self.config.get("execution", {}).get("max_drawdown_pct", self.config.get("max_drawdown_pct", 15.0)))
+        self.max_position_age_hours = float(self.config.get("execution", {}).get("max_position_age_hours", 72.0))
+        self.min_serenbucks_balance = float(self.config.get("execution", {}).get("min_serenbucks_balance", 1.0))
+        self.cron_job_id = self.config.get("cron", {}).get("job_id", os.environ.get("SEREN_CRON_JOB_ID", ""))
 
         # Safety guards (configurable, with backward-compatible defaults)
         self.min_annualized_return = float(self.config.get('min_annualized_return', 0.25))
@@ -777,6 +787,49 @@ class TradingAgent:
             print(f"  ⚠️  Sync failed: {e}")
         print()
 
+        # ── risk guards ──────────────────────────────────────────
+        current_bankroll = self.positions.get_current_bankroll(self.bankroll)
+        peak = getattr(self, "_peak_equity", self.bankroll)
+        if current_bankroll > peak:
+            peak = current_bankroll
+        self._peak_equity = peak
+        dd_pct = ((peak - current_bankroll) / peak * 100.0) if peak > 0 else 0.0
+
+        live_risk = {"drawdown_pct": dd_pct, "current_equity_usd": current_bankroll, "peak_equity_usd": peak}
+        unwind_result = check_drawdown_stop_loss(
+            live_risk=live_risk,
+            max_drawdown_pct=self.max_drawdown_pct,
+            unwind_fn=lambda: {"action": "unwind_triggered", "positions_closed": len(self.positions.get_all_positions())},
+        )
+        if unwind_result:
+            if self.cron_job_id:
+                try:
+                    from setup_cron import pause_job
+                    auto_pause_cron(
+                        serenbucks_balance=0.0,
+                        trading_balance=0.0,
+                        min_serenbucks=1.0,
+                        job_id=self.cron_job_id,
+                        pause_fn=pause_job,
+                    )
+                except Exception:
+                    pass
+            return 0
+
+        # check position age
+        all_positions = self.positions.get_all_positions()
+        for pos in all_positions:
+            if not hasattr(pos, "opened_at") or not pos.opened_at:
+                continue
+            try:
+                from datetime import datetime, timezone
+                opened = datetime.fromisoformat(pos.opened_at.replace("Z", "+00:00"))
+                age_hours = (datetime.now(timezone.utc) - opened).total_seconds() / 3600.0
+                if age_hours >= self.max_position_age_hours and self.max_position_age_hours > 0:
+                    print(f"    POSITION AGE LIMIT: {pos.market} open {age_hours:.1f}h >= {self.max_position_age_hours}h limit. Flagged for close.")
+            except (ValueError, TypeError):
+                continue
+
         # Check for low balances
         if balances['serenbucks'] < 5.0:
             self.logger.notify_low_balance('serenbucks', balances['serenbucks'], 20.0)
@@ -1061,6 +1114,20 @@ def main():
         print(f"  scan_limit:               {original_scan_limit} → {agent.scan_limit}")
         print(f"  min_annualized_return:    {original_min_annualized_return:.4f} → {agent.min_annualized_return:.4f}")
         print("=" * 60)
+
+        # auto-pause cron if funds exhausted
+        if hasattr(agent, "cron_job_id") and agent.cron_job_id:
+            try:
+                from setup_cron import pause_job
+                auto_pause_cron(
+                    serenbucks_balance=getattr(agent, "_last_serenbucks_balance", None),
+                    trading_balance=agent.positions.get_current_bankroll(agent.bankroll) if hasattr(agent, "positions") else None,
+                    min_serenbucks=agent.min_serenbucks_balance,
+                    job_id=agent.cron_job_id,
+                    pause_fn=pause_job,
+                )
+            except Exception:
+                pass
 
     except KeyboardInterrupt:
         print("\n\nScan interrupted by user")

--- a/polymarket/bot/scripts/risk_guards.py
+++ b/polymarket/bot/scripts/risk_guards.py
@@ -1,0 +1,141 @@
+"""Risk guards for Polymarket trading skills.
+
+Provides three protections:
+1. Drawdown stop-loss: auto-unwind when drawdown exceeds backtest max drawdown
+2. Position aging: force-close positions older than max age
+3. Cron auto-pause: pause seren-cron job when funds exhausted
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+def check_drawdown_stop_loss(
+    *,
+    live_risk: dict[str, Any],
+    max_drawdown_pct: float,
+    unwind_fn: Callable[[], dict[str, Any]],
+    log_fn: Callable[[str], None] = print,
+) -> dict[str, Any] | None:
+    """Trigger unwind if live drawdown exceeds the configured limit.
+
+    Returns unwind result dict if triggered, None otherwise.
+    """
+    if max_drawdown_pct <= 0:
+        return None
+
+    current_dd_pct = float(live_risk.get("drawdown_pct", 0.0))
+    if current_dd_pct < max_drawdown_pct:
+        return None
+
+    log_fn(
+        f"DRAWDOWN STOP-LOSS TRIGGERED: {current_dd_pct:.2f}% >= limit "
+        f"{max_drawdown_pct:.2f}%. Equity: "
+        f"${live_risk.get('current_equity_usd', 0):.2f}, "
+        f"Peak: ${live_risk.get('peak_equity_usd', 0):.2f}. "
+        f"Unwinding all positions."
+    )
+    return unwind_fn()
+
+
+def check_position_age(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    max_age_hours: float,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return token_ids whose positions exceed max_age_hours.
+
+    position_timestamps: {token_id: ISO-8601 string}
+    current_exposure:    {token_id: notional_usd}
+    """
+    if max_age_hours <= 0:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    aged: list[str] = []
+    for token_id, notional in current_exposure.items():
+        if notional <= 0:
+            continue
+        opened_str = position_timestamps.get(token_id)
+        if not opened_str:
+            continue
+        try:
+            opened = datetime.fromisoformat(opened_str.replace("Z", "+00:00"))
+            if (now - opened).total_seconds() / 3600.0 >= max_age_hours:
+                aged.append(token_id)
+        except (ValueError, TypeError):
+            continue
+    return aged
+
+
+def sync_position_timestamps(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Keep position_timestamps in sync with live exposure.
+
+    - New positions get the current timestamp.
+    - Closed positions are pruned.
+    - Existing positions keep their original timestamp.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    return {
+        token_id: position_timestamps.get(token_id, now_iso)
+        for token_id, notional in current_exposure.items()
+        if notional > 0
+    }
+
+
+def auto_pause_cron(
+    *,
+    serenbucks_balance: float | None,
+    trading_balance: float | None,
+    min_serenbucks: float = 1.0,
+    min_trading_balance: float = 0.0,
+    job_id: str | None = None,
+    pause_fn: Callable[[str], Any] | None = None,
+    log_fn: Callable[[str], None] = print,
+) -> bool:
+    """Pause the seren-cron job if balances are below thresholds.
+
+    Returns True if the job was paused.
+    """
+    if not job_id or not pause_fn:
+        return False
+
+    reason: str | None = None
+    if serenbucks_balance is not None and serenbucks_balance < min_serenbucks:
+        reason = (
+            f"SerenBucks ${serenbucks_balance:.2f} < min ${min_serenbucks:.2f}"
+        )
+    elif (
+        trading_balance is not None
+        and min_trading_balance > 0
+        and trading_balance < min_trading_balance
+    ):
+        reason = (
+            f"Trading balance ${trading_balance:.2f} < min "
+            f"${min_trading_balance:.2f}"
+        )
+
+    if reason is None:
+        return False
+
+    log_fn(f"AUTO-PAUSE: {reason}. Pausing cron job {job_id}.")
+    try:
+        pause_fn(job_id)
+        log_fn(f"Cron job {job_id} paused successfully.")
+        return True
+    except Exception as exc:
+        log_fn(f"Failed to pause cron job {job_id}: {exc}")
+        return False

--- a/polymarket/high-throughput-paired-basis-maker/config.example.json
+++ b/polymarket/high-throughput-paired-basis-maker/config.example.json
@@ -13,7 +13,11 @@
     "operation_timeout_seconds": 10,
     "operation_retry_attempts": 1,
     "min_cash_reserve_usd": 100,
-    "max_live_drawdown_pct": 15
+    "max_live_drawdown_pct": 15,
+    "max_drawdown_pct": 15.0,
+    "max_position_age_hours": 72,
+    "min_serenbucks_balance": 1.0,
+    "auto_pause_on_exhaustion": true
   },
   "backtest": {
     "bankroll_usd": 100,

--- a/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/agent.py
@@ -52,6 +52,12 @@ from pair_stateful_replay import (
     write_telemetry_records,
 )
 from normalized_trade_store import NormalizedTradingStore
+from risk_guards import (
+    auto_pause_cron,
+    check_drawdown_stop_loss,
+    check_position_age,
+    sync_position_timestamps,
+)
 
 
 DISCLAIMER = (
@@ -2077,11 +2083,43 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             markets=markets,
             execution_settings=execution_settings,
         )
+
+        # ── risk guards ──────────────────────────────────────────
+        live_risk = live_execution.get("live_risk", {})
+        max_dd = config.get("execution", {}).get("max_drawdown_pct", 15.0)
+
+        unwind_result = check_drawdown_stop_loss(
+            live_risk=live_risk,
+            max_drawdown_pct=float(max_dd),
+            unwind_fn=lambda: run_unwind_all(config),
+            log_fn=print,
+        )
+        if unwind_result:
+            payload["risk_guard_triggered"] = "drawdown_stop_loss"
+            payload["unwind_result"] = unwind_result
+            cron_job_id = config.get("cron", {}).get("job_id", "")
+            if cron_job_id:
+                try:
+                    from setup_cron import pause_job
+                    auto_pause_cron(serenbucks_balance=0.0, trading_balance=0.0, min_serenbucks=1.0, job_id=cron_job_id, pause_fn=pause_job)
+                except Exception:
+                    pass
+
+        # position age tracking
+        max_age_h = float(config.get("execution", {}).get("max_position_age_hours", 72.0))
+        leg_exposure = live_execution.get("updated_leg_exposure", config.get("state", {}).get("leg_exposure", {}))
+        pos_ts = config.get("state", {}).get("position_timestamps", {})
+        pos_ts = sync_position_timestamps(position_timestamps=pos_ts, current_exposure=leg_exposure)
+        aged_tokens = check_position_age(position_timestamps=pos_ts, current_exposure=leg_exposure, max_age_hours=max_age_h)
+        if aged_tokens:
+            print(f"    POSITION AGE LIMIT: {len(aged_tokens)} positions exceed {max_age_h}h. Tokens: {aged_tokens}")
+
         payload["live_execution"] = live_execution
         payload["state"] = {
             "leg_exposure": live_execution.get("updated_leg_exposure", {}),
             "live_risk": live_execution.get("live_risk", {}),
         }
+        payload["state"]["position_timestamps"] = pos_ts
         payload["strategy_summary"]["orders_submitted"] = len(live_execution.get("orders_submitted", []))
         payload["strategy_summary"]["open_orders"] = len(live_execution.get("open_order_ids", []))
         if isinstance(live_execution.get("live_risk"), dict):

--- a/polymarket/high-throughput-paired-basis-maker/scripts/risk_guards.py
+++ b/polymarket/high-throughput-paired-basis-maker/scripts/risk_guards.py
@@ -1,0 +1,141 @@
+"""Risk guards for Polymarket trading skills.
+
+Provides three protections:
+1. Drawdown stop-loss: auto-unwind when drawdown exceeds backtest max drawdown
+2. Position aging: force-close positions older than max age
+3. Cron auto-pause: pause seren-cron job when funds exhausted
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+def check_drawdown_stop_loss(
+    *,
+    live_risk: dict[str, Any],
+    max_drawdown_pct: float,
+    unwind_fn: Callable[[], dict[str, Any]],
+    log_fn: Callable[[str], None] = print,
+) -> dict[str, Any] | None:
+    """Trigger unwind if live drawdown exceeds the configured limit.
+
+    Returns unwind result dict if triggered, None otherwise.
+    """
+    if max_drawdown_pct <= 0:
+        return None
+
+    current_dd_pct = float(live_risk.get("drawdown_pct", 0.0))
+    if current_dd_pct < max_drawdown_pct:
+        return None
+
+    log_fn(
+        f"DRAWDOWN STOP-LOSS TRIGGERED: {current_dd_pct:.2f}% >= limit "
+        f"{max_drawdown_pct:.2f}%. Equity: "
+        f"${live_risk.get('current_equity_usd', 0):.2f}, "
+        f"Peak: ${live_risk.get('peak_equity_usd', 0):.2f}. "
+        f"Unwinding all positions."
+    )
+    return unwind_fn()
+
+
+def check_position_age(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    max_age_hours: float,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return token_ids whose positions exceed max_age_hours.
+
+    position_timestamps: {token_id: ISO-8601 string}
+    current_exposure:    {token_id: notional_usd}
+    """
+    if max_age_hours <= 0:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    aged: list[str] = []
+    for token_id, notional in current_exposure.items():
+        if notional <= 0:
+            continue
+        opened_str = position_timestamps.get(token_id)
+        if not opened_str:
+            continue
+        try:
+            opened = datetime.fromisoformat(opened_str.replace("Z", "+00:00"))
+            if (now - opened).total_seconds() / 3600.0 >= max_age_hours:
+                aged.append(token_id)
+        except (ValueError, TypeError):
+            continue
+    return aged
+
+
+def sync_position_timestamps(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Keep position_timestamps in sync with live exposure.
+
+    - New positions get the current timestamp.
+    - Closed positions are pruned.
+    - Existing positions keep their original timestamp.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    return {
+        token_id: position_timestamps.get(token_id, now_iso)
+        for token_id, notional in current_exposure.items()
+        if notional > 0
+    }
+
+
+def auto_pause_cron(
+    *,
+    serenbucks_balance: float | None,
+    trading_balance: float | None,
+    min_serenbucks: float = 1.0,
+    min_trading_balance: float = 0.0,
+    job_id: str | None = None,
+    pause_fn: Callable[[str], Any] | None = None,
+    log_fn: Callable[[str], None] = print,
+) -> bool:
+    """Pause the seren-cron job if balances are below thresholds.
+
+    Returns True if the job was paused.
+    """
+    if not job_id or not pause_fn:
+        return False
+
+    reason: str | None = None
+    if serenbucks_balance is not None and serenbucks_balance < min_serenbucks:
+        reason = (
+            f"SerenBucks ${serenbucks_balance:.2f} < min ${min_serenbucks:.2f}"
+        )
+    elif (
+        trading_balance is not None
+        and min_trading_balance > 0
+        and trading_balance < min_trading_balance
+    ):
+        reason = (
+            f"Trading balance ${trading_balance:.2f} < min "
+            f"${min_trading_balance:.2f}"
+        )
+
+    if reason is None:
+        return False
+
+    log_fn(f"AUTO-PAUSE: {reason}. Pausing cron job {job_id}.")
+    try:
+        pause_fn(job_id)
+        log_fn(f"Cron job {job_id} paused successfully.")
+        return True
+    except Exception as exc:
+        log_fn(f"Failed to pause cron job {job_id}: {exc}")
+        return False

--- a/polymarket/liquidity-paired-basis-maker/config.example.json
+++ b/polymarket/liquidity-paired-basis-maker/config.example.json
@@ -13,7 +13,11 @@
     "operation_timeout_seconds": 10,
     "operation_retry_attempts": 1,
     "min_cash_reserve_usd": 100,
-    "max_live_drawdown_pct": 15
+    "max_live_drawdown_pct": 15,
+    "max_drawdown_pct": 15.0,
+    "max_position_age_hours": 72,
+    "min_serenbucks_balance": 1.0,
+    "auto_pause_on_exhaustion": true
   },
   "backtest": {
     "bankroll_usd": 100,

--- a/polymarket/liquidity-paired-basis-maker/scripts/agent.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/agent.py
@@ -52,6 +52,12 @@ from pair_stateful_replay import (
     write_telemetry_records,
 )
 from normalized_trade_store import NormalizedTradingStore
+from risk_guards import (
+    auto_pause_cron,
+    check_drawdown_stop_loss,
+    check_position_age,
+    sync_position_timestamps,
+)
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -2172,6 +2178,38 @@ def run_trade(config: dict[str, Any], markets_file: str | None, yes_live: bool) 
             payload["status"] = "error"
             payload["error_code"] = live_execution.get("error_code")
             payload["message"] = live_execution.get("message")
+
+        # ── risk guards ──────────────────────────────────────────
+        live_risk = live_execution.get("live_risk", {})
+        max_dd = config.get("execution", {}).get("max_drawdown_pct", 15.0)
+
+        unwind_result = check_drawdown_stop_loss(
+            live_risk=live_risk,
+            max_drawdown_pct=float(max_dd),
+            unwind_fn=lambda: run_unwind_all(config),
+            log_fn=print,
+        )
+        if unwind_result:
+            payload["risk_guard_triggered"] = "drawdown_stop_loss"
+            payload["unwind_result"] = unwind_result
+            cron_job_id = config.get("cron", {}).get("job_id", "")
+            if cron_job_id:
+                try:
+                    from setup_cron import pause_job
+                    auto_pause_cron(serenbucks_balance=0.0, trading_balance=0.0, min_serenbucks=1.0, job_id=cron_job_id, pause_fn=pause_job)
+                except Exception:
+                    pass
+
+        # position age tracking
+        max_age_h = float(config.get("execution", {}).get("max_position_age_hours", 72.0))
+        leg_exposure = live_execution.get("updated_leg_exposure", config.get("state", {}).get("leg_exposure", {}))
+        pos_ts = config.get("state", {}).get("position_timestamps", {})
+        pos_ts = sync_position_timestamps(position_timestamps=pos_ts, current_exposure=leg_exposure)
+        aged_tokens = check_position_age(position_timestamps=pos_ts, current_exposure=leg_exposure, max_age_hours=max_age_h)
+        if aged_tokens:
+            print(f"    POSITION AGE LIMIT: {len(aged_tokens)} positions exceed {max_age_h}h. Tokens: {aged_tokens}")
+
+        payload["state"]["position_timestamps"] = pos_ts
     return payload
 
 

--- a/polymarket/liquidity-paired-basis-maker/scripts/risk_guards.py
+++ b/polymarket/liquidity-paired-basis-maker/scripts/risk_guards.py
@@ -1,0 +1,141 @@
+"""Risk guards for Polymarket trading skills.
+
+Provides three protections:
+1. Drawdown stop-loss: auto-unwind when drawdown exceeds backtest max drawdown
+2. Position aging: force-close positions older than max age
+3. Cron auto-pause: pause seren-cron job when funds exhausted
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+def check_drawdown_stop_loss(
+    *,
+    live_risk: dict[str, Any],
+    max_drawdown_pct: float,
+    unwind_fn: Callable[[], dict[str, Any]],
+    log_fn: Callable[[str], None] = print,
+) -> dict[str, Any] | None:
+    """Trigger unwind if live drawdown exceeds the configured limit.
+
+    Returns unwind result dict if triggered, None otherwise.
+    """
+    if max_drawdown_pct <= 0:
+        return None
+
+    current_dd_pct = float(live_risk.get("drawdown_pct", 0.0))
+    if current_dd_pct < max_drawdown_pct:
+        return None
+
+    log_fn(
+        f"DRAWDOWN STOP-LOSS TRIGGERED: {current_dd_pct:.2f}% >= limit "
+        f"{max_drawdown_pct:.2f}%. Equity: "
+        f"${live_risk.get('current_equity_usd', 0):.2f}, "
+        f"Peak: ${live_risk.get('peak_equity_usd', 0):.2f}. "
+        f"Unwinding all positions."
+    )
+    return unwind_fn()
+
+
+def check_position_age(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    max_age_hours: float,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return token_ids whose positions exceed max_age_hours.
+
+    position_timestamps: {token_id: ISO-8601 string}
+    current_exposure:    {token_id: notional_usd}
+    """
+    if max_age_hours <= 0:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    aged: list[str] = []
+    for token_id, notional in current_exposure.items():
+        if notional <= 0:
+            continue
+        opened_str = position_timestamps.get(token_id)
+        if not opened_str:
+            continue
+        try:
+            opened = datetime.fromisoformat(opened_str.replace("Z", "+00:00"))
+            if (now - opened).total_seconds() / 3600.0 >= max_age_hours:
+                aged.append(token_id)
+        except (ValueError, TypeError):
+            continue
+    return aged
+
+
+def sync_position_timestamps(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Keep position_timestamps in sync with live exposure.
+
+    - New positions get the current timestamp.
+    - Closed positions are pruned.
+    - Existing positions keep their original timestamp.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    return {
+        token_id: position_timestamps.get(token_id, now_iso)
+        for token_id, notional in current_exposure.items()
+        if notional > 0
+    }
+
+
+def auto_pause_cron(
+    *,
+    serenbucks_balance: float | None,
+    trading_balance: float | None,
+    min_serenbucks: float = 1.0,
+    min_trading_balance: float = 0.0,
+    job_id: str | None = None,
+    pause_fn: Callable[[str], Any] | None = None,
+    log_fn: Callable[[str], None] = print,
+) -> bool:
+    """Pause the seren-cron job if balances are below thresholds.
+
+    Returns True if the job was paused.
+    """
+    if not job_id or not pause_fn:
+        return False
+
+    reason: str | None = None
+    if serenbucks_balance is not None and serenbucks_balance < min_serenbucks:
+        reason = (
+            f"SerenBucks ${serenbucks_balance:.2f} < min ${min_serenbucks:.2f}"
+        )
+    elif (
+        trading_balance is not None
+        and min_trading_balance > 0
+        and trading_balance < min_trading_balance
+    ):
+        reason = (
+            f"Trading balance ${trading_balance:.2f} < min "
+            f"${min_trading_balance:.2f}"
+        )
+
+    if reason is None:
+        return False
+
+    log_fn(f"AUTO-PAUSE: {reason}. Pausing cron job {job_id}.")
+    try:
+        pause_fn(job_id)
+        log_fn(f"Cron job {job_id} paused successfully.")
+        return True
+    except Exception as exc:
+        log_fn(f"Failed to pause cron job {job_id}: {exc}")
+        return False

--- a/polymarket/maker-rebate-bot/config.example.json
+++ b/polymarket/maker-rebate-bot/config.example.json
@@ -12,7 +12,11 @@
     "operation_timeout_seconds": 10,
     "operation_retry_attempts": 1,
     "min_cash_reserve_usd": 100,
-    "max_live_drawdown_pct": 15
+    "max_live_drawdown_pct": 15,
+    "max_drawdown_pct": 15.0,
+    "max_position_age_hours": 72,
+    "min_serenbucks_balance": 1.0,
+    "auto_pause_on_exhaustion": true
   },
   "backtest": {
     "bankroll_usd": 100,

--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -36,6 +36,12 @@ from polymarket_live import (
     single_market_inventory_notional,
 )
 from normalized_trade_store import NormalizedTradingStore
+from risk_guards import (
+    auto_pause_cron,
+    check_drawdown_stop_loss,
+    check_position_age,
+    sync_position_timestamps,
+)
 
 SEREN_POLYMARKET_PUBLISHER_HOST = "api.serendb.com"
 SEREN_PUBLISHERS_PREFIX = "/publishers/"
@@ -957,14 +963,6 @@ def _fetch_predictions_signals(
     estimated_cost = 0.30  # batch consensus ($0.15) + batch divergence ($0.15)
     if balance < estimated_cost:
         import sys
-
-# --- Force unbuffered stdout so piped/background output is visible immediately ---
-if not sys.stdout.isatty():
-    os.environ.setdefault("PYTHONUNBUFFERED", "1")
-    sys.stdout.reconfigure(line_buffering=True)
-    sys.stderr.reconfigure(line_buffering=True)
-# --- End unbuffered stdout fix ---
-
         print(
             f"WARNING: SerenBucks balance (${balance:.2f}) may be insufficient for "
             f"predictions intelligence (estimated ${estimated_cost:.2f}). "
@@ -2774,6 +2772,38 @@ def run_once(
             payload["status"] = "error"
             payload["error_code"] = live_execution.get("error_code")
             payload["message"] = live_execution.get("message")
+
+        # ── risk guards ──────────────────────────────────────────
+        live_risk = live_execution.get("live_risk", {})
+        max_dd = config.get("execution", {}).get("max_drawdown_pct", 15.0)
+
+        unwind_result = check_drawdown_stop_loss(
+            live_risk=live_risk,
+            max_drawdown_pct=float(max_dd),
+            unwind_fn=lambda: run_unwind_all(config),
+            log_fn=print,
+        )
+        if unwind_result:
+            payload["risk_guard_triggered"] = "drawdown_stop_loss"
+            payload["unwind_result"] = unwind_result
+            cron_job_id = config.get("cron", {}).get("job_id", "")
+            if cron_job_id:
+                try:
+                    from setup_cron import pause_job
+                    auto_pause_cron(serenbucks_balance=0.0, trading_balance=0.0, min_serenbucks=1.0, job_id=cron_job_id, pause_fn=pause_job)
+                except Exception:
+                    pass
+
+        # position age tracking
+        max_age_h = float(config.get("execution", {}).get("max_position_age_hours", 72.0))
+        inventory = live_execution.get("updated_inventory", config.get("state", {}).get("inventory", {}))
+        pos_ts = config.get("state", {}).get("position_timestamps", {})
+        pos_ts = sync_position_timestamps(position_timestamps=pos_ts, current_exposure=inventory)
+        aged_tokens = check_position_age(position_timestamps=pos_ts, current_exposure=inventory, max_age_hours=max_age_h)
+        if aged_tokens:
+            print(f"    POSITION AGE LIMIT: {len(aged_tokens)} positions exceed {max_age_h}h. Tokens: {aged_tokens}")
+
+        payload["state"]["position_timestamps"] = pos_ts
     return payload
 
 

--- a/polymarket/maker-rebate-bot/scripts/risk_guards.py
+++ b/polymarket/maker-rebate-bot/scripts/risk_guards.py
@@ -1,0 +1,141 @@
+"""Risk guards for Polymarket trading skills.
+
+Provides three protections:
+1. Drawdown stop-loss: auto-unwind when drawdown exceeds backtest max drawdown
+2. Position aging: force-close positions older than max age
+3. Cron auto-pause: pause seren-cron job when funds exhausted
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+def check_drawdown_stop_loss(
+    *,
+    live_risk: dict[str, Any],
+    max_drawdown_pct: float,
+    unwind_fn: Callable[[], dict[str, Any]],
+    log_fn: Callable[[str], None] = print,
+) -> dict[str, Any] | None:
+    """Trigger unwind if live drawdown exceeds the configured limit.
+
+    Returns unwind result dict if triggered, None otherwise.
+    """
+    if max_drawdown_pct <= 0:
+        return None
+
+    current_dd_pct = float(live_risk.get("drawdown_pct", 0.0))
+    if current_dd_pct < max_drawdown_pct:
+        return None
+
+    log_fn(
+        f"DRAWDOWN STOP-LOSS TRIGGERED: {current_dd_pct:.2f}% >= limit "
+        f"{max_drawdown_pct:.2f}%. Equity: "
+        f"${live_risk.get('current_equity_usd', 0):.2f}, "
+        f"Peak: ${live_risk.get('peak_equity_usd', 0):.2f}. "
+        f"Unwinding all positions."
+    )
+    return unwind_fn()
+
+
+def check_position_age(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    max_age_hours: float,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return token_ids whose positions exceed max_age_hours.
+
+    position_timestamps: {token_id: ISO-8601 string}
+    current_exposure:    {token_id: notional_usd}
+    """
+    if max_age_hours <= 0:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    aged: list[str] = []
+    for token_id, notional in current_exposure.items():
+        if notional <= 0:
+            continue
+        opened_str = position_timestamps.get(token_id)
+        if not opened_str:
+            continue
+        try:
+            opened = datetime.fromisoformat(opened_str.replace("Z", "+00:00"))
+            if (now - opened).total_seconds() / 3600.0 >= max_age_hours:
+                aged.append(token_id)
+        except (ValueError, TypeError):
+            continue
+    return aged
+
+
+def sync_position_timestamps(
+    *,
+    position_timestamps: dict[str, str],
+    current_exposure: dict[str, float],
+    now: datetime | None = None,
+) -> dict[str, str]:
+    """Keep position_timestamps in sync with live exposure.
+
+    - New positions get the current timestamp.
+    - Closed positions are pruned.
+    - Existing positions keep their original timestamp.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    return {
+        token_id: position_timestamps.get(token_id, now_iso)
+        for token_id, notional in current_exposure.items()
+        if notional > 0
+    }
+
+
+def auto_pause_cron(
+    *,
+    serenbucks_balance: float | None,
+    trading_balance: float | None,
+    min_serenbucks: float = 1.0,
+    min_trading_balance: float = 0.0,
+    job_id: str | None = None,
+    pause_fn: Callable[[str], Any] | None = None,
+    log_fn: Callable[[str], None] = print,
+) -> bool:
+    """Pause the seren-cron job if balances are below thresholds.
+
+    Returns True if the job was paused.
+    """
+    if not job_id or not pause_fn:
+        return False
+
+    reason: str | None = None
+    if serenbucks_balance is not None and serenbucks_balance < min_serenbucks:
+        reason = (
+            f"SerenBucks ${serenbucks_balance:.2f} < min ${min_serenbucks:.2f}"
+        )
+    elif (
+        trading_balance is not None
+        and min_trading_balance > 0
+        and trading_balance < min_trading_balance
+    ):
+        reason = (
+            f"Trading balance ${trading_balance:.2f} < min "
+            f"${min_trading_balance:.2f}"
+        )
+
+    if reason is None:
+        return False
+
+    log_fn(f"AUTO-PAUSE: {reason}. Pausing cron job {job_id}.")
+    try:
+        pause_fn(job_id)
+        log_fn(f"Cron job {job_id} paused successfully.")
+        return True
+    except Exception as exc:
+        log_fn(f"Failed to pause cron job {job_id}: {exc}")
+        return False

--- a/polymarket/tests/test_risk_guards.py
+++ b/polymarket/tests/test_risk_guards.py
@@ -1,0 +1,148 @@
+"""Tests for polymarket/_shared/risk_guards.py — critical paths only."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / "_shared")
+)
+from risk_guards import (
+    auto_pause_cron,
+    check_drawdown_stop_loss,
+    check_position_age,
+    sync_position_timestamps,
+)
+
+
+# ── drawdown stop-loss ──────────────────────────────────────────────
+
+
+class TestDrawdownStopLoss:
+    def test_triggers_unwind_when_limit_breached(self):
+        unwind = MagicMock(return_value={"status": "unwound"})
+        result = check_drawdown_stop_loss(
+            live_risk={"drawdown_pct": 20.0, "current_equity_usd": 80, "peak_equity_usd": 100},
+            max_drawdown_pct=15.0,
+            unwind_fn=unwind,
+            log_fn=lambda _: None,
+        )
+        unwind.assert_called_once()
+        assert result == {"status": "unwound"}
+
+    def test_no_action_below_limit(self):
+        unwind = MagicMock()
+        result = check_drawdown_stop_loss(
+            live_risk={"drawdown_pct": 5.0},
+            max_drawdown_pct=15.0,
+            unwind_fn=unwind,
+        )
+        unwind.assert_not_called()
+        assert result is None
+
+    def test_disabled_when_limit_zero(self):
+        unwind = MagicMock()
+        result = check_drawdown_stop_loss(
+            live_risk={"drawdown_pct": 99.0},
+            max_drawdown_pct=0,
+            unwind_fn=unwind,
+        )
+        unwind.assert_not_called()
+        assert result is None
+
+
+# ── position aging ──────────────────────────────────────────────────
+
+
+class TestPositionAge:
+    def test_detects_aged_positions(self):
+        now = datetime(2026, 3, 30, 12, 0, tzinfo=timezone.utc)
+        old = (now - timedelta(hours=80)).isoformat()
+        fresh = (now - timedelta(hours=10)).isoformat()
+        aged = check_position_age(
+            position_timestamps={"old_tok": old, "fresh_tok": fresh},
+            current_exposure={"old_tok": 50.0, "fresh_tok": 30.0},
+            max_age_hours=72,
+            now=now,
+        )
+        assert aged == ["old_tok"]
+
+    def test_ignores_zero_exposure(self):
+        now = datetime(2026, 3, 30, 12, 0, tzinfo=timezone.utc)
+        old = (now - timedelta(hours=100)).isoformat()
+        aged = check_position_age(
+            position_timestamps={"tok": old},
+            current_exposure={"tok": 0.0},
+            max_age_hours=72,
+            now=now,
+        )
+        assert aged == []
+
+    def test_disabled_when_zero(self):
+        aged = check_position_age(
+            position_timestamps={"tok": "2020-01-01T00:00:00+00:00"},
+            current_exposure={"tok": 100.0},
+            max_age_hours=0,
+        )
+        assert aged == []
+
+
+# ── timestamp sync ──────────────────────────────────────────────────
+
+
+class TestSyncTimestamps:
+    def test_adds_new_prunes_closed(self):
+        now = datetime(2026, 3, 30, 12, 0, tzinfo=timezone.utc)
+        result = sync_position_timestamps(
+            position_timestamps={"existing": "2026-03-29T00:00:00+00:00", "closed": "2026-03-28T00:00:00+00:00"},
+            current_exposure={"existing": 50.0, "brand_new": 30.0},
+            now=now,
+        )
+        assert result["existing"] == "2026-03-29T00:00:00+00:00"
+        assert result["brand_new"] == now.isoformat()
+        assert "closed" not in result
+
+
+# ── cron auto-pause ─────────────────────────────────────────────────
+
+
+class TestCronAutoPause:
+    def test_pauses_on_low_serenbucks(self):
+        pause = MagicMock()
+        paused = auto_pause_cron(
+            serenbucks_balance=0.50,
+            trading_balance=100.0,
+            min_serenbucks=1.0,
+            job_id="job-123",
+            pause_fn=pause,
+            log_fn=lambda _: None,
+        )
+        assert paused is True
+        pause.assert_called_once_with("job-123")
+
+    def test_no_pause_when_funded(self):
+        pause = MagicMock()
+        paused = auto_pause_cron(
+            serenbucks_balance=10.0,
+            trading_balance=100.0,
+            min_serenbucks=1.0,
+            job_id="job-123",
+            pause_fn=pause,
+        )
+        assert paused is False
+        pause.assert_not_called()
+
+    def test_no_pause_without_job_id(self):
+        paused = auto_pause_cron(
+            serenbucks_balance=0.0,
+            trading_balance=0.0,
+            min_serenbucks=1.0,
+            job_id=None,
+            pause_fn=MagicMock(),
+        )
+        assert paused is False


### PR DESCRIPTION
## Summary
- Add `risk_guards.py` module with drawdown stop-loss, position age limits, and cron auto-pause
- Integrate into all 4 Polymarket skills (bot, htpbm, liquidity, maker-rebate)
- Add config defaults: `max_drawdown_pct=15`, `max_position_age_hours=72`, `min_serenbucks_balance=1.0`
- Canonical module in `polymarket/_shared/`, copies in each skill's `scripts/` for standalone deployment

## Test plan
- [x] 10 unit tests covering all 3 guard paths (drawdown, aging, auto-pause)
- [x] All 4 agent.py files pass AST parse
- [x] All 4 config.example.json files pass JSON parse

Closes #330

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com