### PR TITLE
feat(seren): add BAT sales coach skill

### DIFF
--- a/seren/bat-sales-coach/.env.example
+++ b/seren/bat-sales-coach/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for bat-sales-coach
+SEREN_API_KEY=
+

--- a/seren/bat-sales-coach/SKILL.md
+++ b/seren/bat-sales-coach/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: bat-sales-coach
+description: "Supportive sales-executive coaching skill that runs a Behavior-Attitude-Technique loop, journals completed sales work, tracks pipeline progress in SerenDB, reinforces momentum without pressure, and turns self-directed technique reviews into the next behavior plan."
+---
+
+# BAT Sales Coach
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## Overview
+
+BAT stands for `Behavior`, `Attitude`, and `Technique`.
+
+This skill acts as a nurturing sales coach, personal CRM, and reflective journal for a sales executive. It starts with behavior, records what actually happened, reinforces completed work with supportive feedback, and only then moves into technique planning that the sales executive chooses for themself.
+
+## Coaching Contract
+
+- Do not push, pressure, shame, or weaponize quota.
+- Pace is self-determined by the sales executive.
+- Do not set behavior quotas during the behavior step.
+- Only move into technique planning after completed behavior journaling and the curiosity gate.
+- Keep feedback warm, specific, and grounded in work actually completed.
+- Remind the sales executive that they are in control of the next step.
+
+## When to Use
+
+- coach my sales behaviors
+- log sales activity and attitude
+- review my sales pipeline progress
+- plan my next sales technique experiment
+
+## Default Flow
+
+Start with `Behavior` every time.
+
+If the sales executive has not completed a behavior yet:
+- interview them on the behaviors they want to complete next
+- capture one behavior at a time as a CRM-style task
+- confirm the next check-in prompt
+
+If the sales executive has completed a behavior:
+- capture the behavior record and outcome first
+- run the attitude loop second
+- move to technique planning only after curiosity is present
+
+## Behavior
+
+Behavior is the foundation of the loop. The skill tracks small, concrete sales actions such as:
+
+- sourcing a lead
+- sending outreach
+- preparing a proposal
+- scheduling a meeting or follow-up
+- thanking a contact
+- finding events and places to meet prospects
+
+The behavior record should feel like a personal CRM task or activity. Capture:
+
+- prospect or account
+- organization
+- pipeline stage
+- task-style title
+- status
+- due date
+- start and completion times
+- opportunity value
+- expected close date
+- prospect response
+- next behavior
+
+Use task and activity conventions inspired by modern CRM systems:
+- behavior tasks should look like linked activities, not vague goals
+- each record should tie back to a prospect, stage, and next step
+- completed work should roll forward into the next activity instead of disappearing into notes
+
+## Behavior Interview
+
+Ask concise questions that help the sales executive describe real work:
+
+1. What behavior did you plan to complete?
+2. What did you actually do?
+3. Did anything else get done that we should count as a win?
+4. What did the prospect do or say in response?
+5. What is the next behavior for this prospect?
+
+## Attitude
+
+Attitude is only addressed after behavior journaling. The purpose is to help the sales executive recover perspective, notice progress, and stay engaged in the work.
+
+Always start with a specific reinforcement tied to the completed behavior.
+
+Then run the attitude loop:
+
+1. Ask for a score from `1` to `10`.
+2. Ask where that score is felt in the body.
+3. Ask: `Can you tell the future?`
+
+If the answer is anything other than a clear admission that the future cannot be known:
+- return to the score question
+- ask again where it is felt in the body
+- ask `Can you tell the future?` again
+
+If the sales executive asks why the question repeats, answer:
+
+`If you can tell the future, you do not need coaching and you would already have won all your sales.`
+
+Once the sales executive admits they cannot tell the future, ask:
+
+`Are you curious?`
+
+If curiosity is absent or unclear, return to the attitude loop again.
+
+## Technique
+
+Technique is a self-directed review of what to try next. Do not use it to impose pressure. Do not set quotas until this stage.
+
+Once curiosity is present:
+
+- identify the technique area the sales executive wants to improve
+- suggest small behavior changes tied to current prospects
+- suggest practice or training ideas in general terms
+- let the sales executive choose the next behavior target
+
+Technique should output:
+
+- a behavior experiment for the next cycle
+- any requested practice or training focus
+- a self-chosen behavior quota for the next cycle
+- updated next steps per active prospect
+
+## Research Rule
+
+The skill may do background research for general sales-improvement ideas during the technique step.
+
+- Keep research hidden from the user unless they ask for sources.
+- Do not use trademarked or copyrighted sales-framework wording.
+- Reframe any outside ideas into plain, generic language before presenting them.
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_sales_coaching_request`
+2. `load_pipeline_context` uses `connector.storage.query`
+3. `shape_behavior_task` uses `transform.shape_behavior_task`
+4. `persist_behavior_task` uses `connector.storage.upsert`
+5. `capture_behavior_journal` uses `transform.capture_behavior_journal`
+6. `persist_behavior_journal` uses `connector.storage.upsert`
+7. `run_attitude_loop` uses `transform.run_attitude_loop`
+8. `persist_attitude_journal` uses `connector.storage.upsert`
+9. `compose_positive_feedback` uses `transform.compose_supportive_feedback`
+10. `research_technique_options` uses `connector.research.post`
+11. `draft_technique_plan` uses `transform.draft_self_directed_technique_plan`
+12. `persist_technique_plan` uses `connector.storage.upsert`
+13. `render_pipeline_progress` uses `transform.render_pipeline_progress`
+
+## SerenDB State
+
+Persist BAT progress in SerenDB so the skill becomes a durable personal CRM and coaching memory:
+
+- `prospects`
+- `behavior_tasks`
+- `behavior_journals`
+- `attitude_journals`
+- `technique_plans`
+- `coaching_sessions`
+
+## Output Expectations
+
+Each run should return:
+
+- what behavior was planned or completed
+- what win was recognized
+- current prospect-specific next steps
+- current attitude state
+- whether the curiosity gate passed
+- the next technique experiment, if applicable
+- the next behavior target chosen by the sales executive

--- a/seren/bat-sales-coach/config.example.json
+++ b/seren/bat-sales-coach/config.example.json
@@ -1,0 +1,35 @@
+{
+  "connectors": [
+    "research",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "attitude_journal": "",
+    "attitude_score": 5,
+    "behavior_description": "",
+    "behavior_status": "planned",
+    "behavior_title": "",
+    "behavior_type": "outreach",
+    "body_signal": "",
+    "command": "start_loop",
+    "completed_at": "",
+    "curiosity_state": "unsure",
+    "deal_stage": "new_lead",
+    "due_date": "",
+    "expected_close_date": "",
+    "future_statement": "",
+    "next_behavior": "",
+    "next_behavior_quota": 0,
+    "opportunity_value_usd": 0,
+    "organization_name": "",
+    "prospect_name": "",
+    "prospect_response": "",
+    "research_enabled": true,
+    "sales_executive_name": "",
+    "started_at": "",
+    "technique_focus": "",
+    "training_request": ""
+  },
+  "skill": "bat-sales-coach"
+}

--- a/seren/bat-sales-coach/requirements.txt
+++ b/seren/bat-sales-coach/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for bat-sales-coach.

--- a/seren/bat-sales-coach/scripts/agent.py
+++ b/seren/bat-sales-coach/scripts/agent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for bat-sales-coach."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['research', 'storage']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seren/bat-sales-coach/tests/fixtures/connector_failure.json
+++ b/seren/bat-sales-coach/tests/fixtures/connector_failure.json
@@ -1,0 +1,29 @@
+{
+  "status": "error",
+  "skill": "bat-sales-coach",
+  "error_code": "connector_failure",
+  "connector": "research",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "research": {
+      "post": {
+        "status": "error",
+        "connector": "research",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    },
+    "storage": {
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/seren/bat-sales-coach/tests/fixtures/dry_run_guard.json
+++ b/seren/bat-sales-coach/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "bat-sales-coach",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/seren/bat-sales-coach/tests/fixtures/happy_path.json
+++ b/seren/bat-sales-coach/tests/fixtures/happy_path.json
@@ -1,0 +1,54 @@
+{
+  "status": "ok",
+  "skill": "bat-sales-coach",
+  "workflow_step_count": 13,
+  "dry_run": true,
+  "inputs": {
+    "attitude_journal": "",
+    "attitude_score": 5,
+    "behavior_description": "",
+    "behavior_status": "planned",
+    "behavior_title": "",
+    "behavior_type": "outreach",
+    "body_signal": "",
+    "command": "start_loop",
+    "completed_at": "",
+    "curiosity_state": "unsure",
+    "deal_stage": "new_lead",
+    "due_date": "",
+    "expected_close_date": "",
+    "future_statement": "",
+    "next_behavior": "",
+    "next_behavior_quota": 0,
+    "opportunity_value_usd": 0,
+    "organization_name": "",
+    "prospect_name": "",
+    "prospect_response": "",
+    "research_enabled": true,
+    "sales_executive_name": "",
+    "started_at": "",
+    "technique_focus": "",
+    "training_request": ""
+  },
+  "connectors": {
+    "research": {
+      "post": {
+        "status": "ok",
+        "connector": "research",
+        "action": "post"
+      }
+    },
+    "storage": {
+      "query": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "query"
+      },
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/seren/bat-sales-coach/tests/fixtures/policy_violation.json
+++ b/seren/bat-sales-coach/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "bat-sales-coach",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/seren/bat-sales-coach/tests/test_smoke.py
+++ b/seren/bat-sales-coach/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "bat-sales-coach"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"


### PR DESCRIPTION
Closes #332

## Summary
- add a new generated `seren/bat-sales-coach` skill via SkillForge
- model the BAT loop around behavior logging, a separate attitude journal, and self-directed technique planning
- publish a richer `SKILL.md` coaching contract so the shipped skill is supportive, self-paced, and curiosity-gated

## Validation
- `python3 seren/bat-sales-coach/scripts/agent.py --config seren/bat-sales-coach/config.example.json`
- `pytest seren/bat-sales-coach/tests/test_smoke.py`
