### PR TITLE
fix(sales): require user-stated dates in BAT sales coach

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -45,6 +45,15 @@ If the sales executive has completed a behavior:
 - run the attitude loop second
 - move to technique planning only after curiosity is present
 
+## Date and Time Rules
+
+- The agent does not reliably know the current date or time. It must not assume, compute, or suggest specific dates for follow-ups, due dates, or scheduling.
+- When recording a behavior, always ask the sales executive when they completed it and when they want to follow up. Record exactly what they say.
+- Never calculate relative dates such as `3 days from now` or `next Thursday`.
+- Never record a date as a confirmed decision unless the sales executive stated it. If a date is not confirmed, record the field as `TBD - user to confirm`.
+- When restoring from a prior session, treat all future-dated tasks as unconfirmed. Ask: `Last session noted a follow-up on [date]. Is that still your plan, or has it changed?`
+- If the runtime provides a current-date context value, use it only as display context. Do not perform date arithmetic on it.
+
 ## Behavior
 
 Behavior is the foundation of the loop. The skill tracks small, concrete sales actions such as:
@@ -63,10 +72,10 @@ The behavior record should feel like a personal CRM task or activity. Capture:
 - pipeline stage
 - task-style title
 - status
-- due date
+- due date (user-stated only, never agent-computed)
 - start and completion times
 - opportunity value
-- expected close date
+- expected close date (user-stated only)
 - prospect response
 - next behavior
 
@@ -83,7 +92,7 @@ Ask concise questions that help the sales executive describe real work:
 2. What did you actually do?
 3. Did anything else get done that we should count as a win?
 4. What did the prospect do or say in response?
-5. What is the next behavior for this prospect?
+5. What is the next behavior for this prospect, and when do you want to do it?
 
 ## Attitude
 

--- a/sales/bat-sales-coach/tests/test_smoke.py
+++ b/sales/bat-sales-coach/tests/test_smoke.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SKILL_PATH = Path(__file__).resolve().parents[1] / "SKILL.md"
 
 
 def _read_fixture(name: str) -> dict:
@@ -32,3 +33,13 @@ def test_dry_run_fixture_blocks_live_execution() -> None:
     payload = _read_fixture("dry_run_guard.json")
     assert payload["dry_run"] is True
     assert payload["blocked_action"] == "live_execution"
+
+
+def test_skill_instructions_require_user_stated_dates() -> None:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "## Date and Time Rules" in content
+    assert "must not assume, compute, or suggest specific dates" in content
+    assert "due date (user-stated only, never agent-computed)" in content
+    assert "expected close date (user-stated only)" in content
+    assert "What is the next behavior for this prospect, and when do you want to do it?" in content


### PR DESCRIPTION
## Summary
- add explicit date/time guardrails to the BAT Sales Coach skill
- require user-stated due dates and expected close dates instead of agent-computed dates
- add one regression test covering the new instruction contract

## Validation
- `pytest sales/bat-sales-coach/tests/test_smoke.py`

Closes #336
