### PR TITLE
fix: add cron-backed monitor guardrails to polymarket-bot

### DIFF
--- a/polymarket/bot/config.example.json
+++ b/polymarket/bot/config.example.json
@@ -25,6 +25,12 @@
   "execution": {
     "max_drawdown_pct": 15.0,
     "max_position_age_hours": 72,
+    "take_profit_pct": 0.1,
+    "position_stop_loss_pct": 0.1,
+    "alert_move_pct": 0.08,
+    "near_resolution_hours": 24,
+    "max_positions_per_event": 1,
+    "stale_order_max_age_seconds": 1800,
     "min_serenbucks_balance": 1.0,
     "auto_pause_on_exhaustion": true
   },

--- a/polymarket/bot/scripts/agent.py
+++ b/polymarket/bot/scripts/agent.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import sys
+from copy import deepcopy
 
 # --- Force unbuffered stdout so piped/background output is visible immediately ---
 if not sys.stdout.isatty():
@@ -28,7 +29,7 @@ if not sys.stdout.isatty():
 # --- End unbuffered stdout fix ---
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 
@@ -64,6 +65,10 @@ class TradingAgent:
         # Load config
         with open(config_path, 'r') as f:
             self.config = json.load(f)
+        self.config_path = Path(config_path).resolve()
+        self.logs_dir = self.config_path.parent / "logs"
+        self.state_file = self.logs_dir / "runtime_state.json"
+        self.runtime_state = self._load_runtime_state()
 
         self.dry_run = dry_run
 
@@ -101,6 +106,17 @@ class TradingAgent:
         self.max_drawdown_pct = float(self.config.get("execution", {}).get("max_drawdown_pct", self.config.get("max_drawdown_pct", 15.0)))
         self.max_position_age_hours = float(self.config.get("execution", {}).get("max_position_age_hours", 72.0))
         self.min_serenbucks_balance = float(self.config.get("execution", {}).get("min_serenbucks_balance", 1.0))
+        self.stale_order_max_age_seconds = int(self.config.get("execution", {}).get("stale_order_max_age_seconds", 1800))
+        self.take_profit_pct = float(self.config.get("execution", {}).get("take_profit_pct", 0.10))
+        self.position_stop_loss_pct = float(self.config.get("execution", {}).get("position_stop_loss_pct", 0.10))
+        self.alert_move_pct = float(self.config.get("execution", {}).get("alert_move_pct", 0.08))
+        self.near_resolution_hours = float(self.config.get("execution", {}).get("near_resolution_hours", 24.0))
+        self.max_positions_per_event = int(
+            self.config.get("execution", {}).get(
+                "max_positions_per_event",
+                self.config.get("max_per_category", 1),
+            )
+        )
         self.cron_job_id = self.config.get("cron", {}).get("job_id", os.environ.get("SEREN_CRON_JOB_ID", ""))
 
         # Safety guards (configurable, with backward-compatible defaults)
@@ -151,6 +167,125 @@ class TradingAgent:
             print(f"⚠️  Position sync failed: {e}")
         print()
 
+    def _load_runtime_state(self) -> Dict[str, Any]:
+        """Load cron-maintained local runtime state."""
+        if not self.state_file.exists():
+            return {
+                "order_timestamps": {},
+                "position_alerts": {},
+                "pending_exit_markets": {},
+            }
+        try:
+            with open(self.state_file, "r") as handle:
+                payload = json.load(handle)
+        except Exception:
+            return {
+                "order_timestamps": {},
+                "position_alerts": {},
+                "pending_exit_markets": {},
+            }
+        if not isinstance(payload, dict):
+            return {
+                "order_timestamps": {},
+                "position_alerts": {},
+                "pending_exit_markets": {},
+            }
+        payload.setdefault("order_timestamps", {})
+        payload.setdefault("position_alerts", {})
+        payload.setdefault("pending_exit_markets", {})
+        return payload
+
+    def _save_runtime_state(self) -> None:
+        """Persist cron-maintained local runtime state."""
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.state_file, "w") as handle:
+            json.dump(self.runtime_state, handle, indent=2, sort_keys=True)
+
+    @staticmethod
+    def _iso_to_datetime(raw_value: str) -> Optional[datetime]:
+        if not raw_value:
+            return None
+        try:
+            dt = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    @staticmethod
+    def _safe_float(value: Any, default: float = 0.0) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return default
+        if parsed != parsed:
+            return default
+        return parsed
+
+    @staticmethod
+    def _rows_from_payload(payload: Any) -> List[Dict[str, Any]]:
+        if isinstance(payload, list):
+            return [row for row in payload if isinstance(row, dict)]
+        if isinstance(payload, dict):
+            data = payload.get("data")
+            if isinstance(data, list):
+                return [row for row in data if isinstance(row, dict)]
+        return []
+
+    def _extract_order_timestamps(
+        self,
+        raw_orders: Any,
+        prior_order_timestamps: Dict[str, str],
+    ) -> Dict[str, str]:
+        """Build a best-effort order id -> first seen timestamp map."""
+        now_iso = datetime.now(timezone.utc).isoformat()
+        extracted: Dict[str, str] = {}
+        for row in self._rows_from_payload(raw_orders):
+            order_id = ""
+            for key in ("id", "orderID", "order_id"):
+                value = str(row.get(key, "")).strip()
+                if value:
+                    order_id = value
+                    break
+            if not order_id:
+                continue
+            timestamp = ""
+            for key in ("createdAt", "created_at", "placed_at", "updatedAt", "updated_at", "timestamp"):
+                value = str(row.get(key, "")).strip()
+                if value:
+                    timestamp = value
+                    break
+            extracted[order_id] = prior_order_timestamps.get(order_id) or timestamp or now_iso
+        return extracted
+
+    def _resolve_position_roi(self, position) -> float:
+        if position.size <= 0:
+            return 0.0
+        return position.unrealized_pnl / position.size
+
+    def _pending_exit_for_market(self, market_id: str) -> bool:
+        pending = self.runtime_state.get("pending_exit_markets", {})
+        raw = str(pending.get(market_id, "")).strip()
+        if not raw:
+            return False
+        pending_at = self._iso_to_datetime(raw)
+        if pending_at is None:
+            return False
+        return (datetime.now(timezone.utc) - pending_at).total_seconds() < self.stale_order_max_age_seconds
+
+    def _clear_pending_exit(self, market_id: str) -> None:
+        self.runtime_state.get("pending_exit_markets", {}).pop(market_id, None)
+
+    def _record_position_alert(self, market_id: str, key: str) -> bool:
+        """Return True if this alert should be emitted once."""
+        alerts = self.runtime_state.setdefault("position_alerts", {})
+        market_alerts = alerts.setdefault(market_id, {})
+        if market_alerts.get(key):
+            return False
+        market_alerts[key] = datetime.now(timezone.utc).isoformat()
+        return True
+
     def check_balances(self) -> Dict[str, float]:
         """
         Check SerenBucks and Polymarket balances
@@ -176,6 +311,168 @@ class TradingAgent:
             'serenbucks': serenbucks,
             'polymarket': polymarket
         }
+
+    def _close_position_via_guard(self, position, reason: str, roi_pct: float) -> Dict[str, Any]:
+        """Submit a marketable SELL to close a held YES/NO token position."""
+        from polymarket_live import build_marketable_sell_order
+
+        trader = self.polymarket._require_trader()
+        sell_plan = build_marketable_sell_order(position.token_id, position.quantity)
+        response = trader.create_order(
+            token_id=position.token_id,
+            side="SELL",
+            price=sell_plan["price"],
+            size=position.quantity,
+            tick_size=sell_plan["tick_size"],
+            neg_risk=sell_plan["neg_risk"],
+            fee_rate_bps=sell_plan["fee_rate_bps"],
+        )
+
+        self.runtime_state.setdefault("pending_exit_markets", {})[position.market_id] = datetime.now(timezone.utc).isoformat()
+        self.logger.log_trade(
+            market=position.market,
+            market_id=position.market_id,
+            side=position.thesis_side,
+            size=position.size,
+            price=position.current_price,
+            fair_value=position.current_price,
+            edge=0.0,
+            status="closing",
+            pnl=round(position.unrealized_pnl, 2),
+        )
+        self.logger.log_notification(
+            level="warning" if roi_pct < 0 else "info",
+            title=f"Guard Exit: {reason}",
+            message=(
+                f"Submitted marketable close for \"{position.market}\".\n"
+                f"  • Held side: {position.side}\n"
+                f"  • ROI: {roi_pct * 100:+.1f}%\n"
+                f"  • Quantity: {position.quantity:.6f}\n"
+                f"  • Estimated unfilled size: {sell_plan['estimated_unfilled_size']:.6f}"
+            ),
+            data={
+                "market_id": position.market_id,
+                "token_id": position.token_id,
+                "reason": reason,
+                "roi_pct": roi_pct,
+                "estimated_unfilled_size": sell_plan["estimated_unfilled_size"],
+                "response": response,
+            },
+        )
+        return {
+            "market_id": position.market_id,
+            "reason": reason,
+            "roi_pct": roi_pct,
+            "response": response,
+            "sell_plan": sell_plan,
+        }
+
+    def monitor_existing_risk(self) -> Dict[str, Any]:
+        """Use seren-cron runs to reconcile live orders/positions and act on guardrails."""
+        summary: Dict[str, Any] = {
+            "stale_orders_cancelled": 0,
+            "guard_exits": [],
+            "alerts": 0,
+        }
+        if self.dry_run:
+            return summary
+
+        from polymarket_live import cancel_stale_orders
+
+        prior_order_timestamps = deepcopy(self.runtime_state.get("order_timestamps", {}))
+        open_orders = []
+        try:
+            open_orders = self.polymarket.get_open_orders()
+        except Exception as exc:
+            self.logger.notify_api_error(f"Failed to load open orders for monitoring: {exc}")
+
+        if prior_order_timestamps:
+            stale_cleanup = cancel_stale_orders(
+                trader=self.polymarket._require_trader(),
+                prior_order_timestamps=prior_order_timestamps,
+                stale_order_max_age_seconds=self.stale_order_max_age_seconds,
+            )
+            summary["stale_orders_cancelled"] = int(stale_cleanup.get("stale_count", 0) or 0)
+            if summary["stale_orders_cancelled"] > 0:
+                self.logger.log_notification(
+                    level="warning",
+                    title="Stale Orders Cancelled",
+                    message=f"Cancelled {summary['stale_orders_cancelled']} stale open order(s) during cron monitoring.",
+                    data=stale_cleanup,
+                )
+                summary["alerts"] += 1
+                try:
+                    open_orders = self.polymarket.get_open_orders()
+                except Exception:
+                    open_orders = []
+
+        self.runtime_state["order_timestamps"] = self._extract_order_timestamps(open_orders, prior_order_timestamps)
+
+        try:
+            self.positions.sync_with_polymarket(self.polymarket)
+        except Exception as exc:
+            self.logger.notify_api_error(f"Position monitoring sync failed: {exc}")
+            return summary
+
+        now = datetime.now(timezone.utc)
+        for position in self.positions.get_all_positions():
+            if position.quantity <= 0:
+                continue
+
+            self._clear_pending_exit(position.market_id)
+            roi_pct = self._resolve_position_roi(position)
+
+            if abs(roi_pct) >= self.alert_move_pct:
+                direction = "gain" if roi_pct >= 0 else "loss"
+                alert_key = f"{direction}:{round(abs(roi_pct), 2)}"
+                if self._record_position_alert(position.market_id, alert_key):
+                    self.logger.log_notification(
+                        level="info" if roi_pct >= 0 else "warning",
+                        title=f"Position {direction.title()} Alert",
+                        message=(
+                            f"\"{position.market}\" moved {roi_pct * 100:+.1f}% since entry.\n"
+                            f"  • Held side: {position.side}\n"
+                            f"  • Entry: {position.entry_price:.4f}\n"
+                            f"  • Current: {position.current_price:.4f}"
+                        ),
+                        data={
+                            "market_id": position.market_id,
+                            "token_id": position.token_id,
+                            "roi_pct": roi_pct,
+                            "position_side": position.side,
+                        },
+                    )
+                    summary["alerts"] += 1
+
+            exit_reason = ""
+            if self.take_profit_pct > 0 and roi_pct >= self.take_profit_pct:
+                exit_reason = "take-profit"
+            elif self.position_stop_loss_pct > 0 and roi_pct <= -self.position_stop_loss_pct:
+                exit_reason = "stop-loss"
+            elif self.max_position_age_hours > 0:
+                opened = self._iso_to_datetime(position.opened_at)
+                if opened and ((now - opened).total_seconds() / 3600.0) >= self.max_position_age_hours:
+                    exit_reason = "max-age"
+            if not exit_reason and self.near_resolution_hours > 0 and position.end_date:
+                end_dt = self._iso_to_datetime(position.end_date)
+                if end_dt is not None:
+                    hours_to_resolution = (end_dt - now).total_seconds() / 3600.0
+                    if 0 <= hours_to_resolution <= self.near_resolution_hours:
+                        exit_reason = "near-resolution"
+
+            if exit_reason and not self._pending_exit_for_market(position.market_id):
+                try:
+                    summary["guard_exits"].append(
+                        self._close_position_via_guard(position, exit_reason, roi_pct)
+                    )
+                except Exception as exc:
+                    self.logger.notify_api_error(
+                        f"Failed to close \"{position.market}\" via {exit_reason}: {exc}",
+                        will_retry=False,
+                    )
+
+        self._save_runtime_state()
+        return summary
 
     def scan_markets(self, limit: int = 100) -> List[Dict]:
         """
@@ -604,9 +901,25 @@ class TradingAgent:
             return None
 
         # Check if we already have a position
-        if self.positions.has_position(market['market_id']):
+        if self.positions.has_exposure(
+            market['market_id'],
+            token_id=market.get('token_id', ''),
+            no_token_id=market.get('no_token_id', ''),
+        ):
             print(f"    ✗ Already have position in this market")
             return None
+
+        if self.max_positions_per_event > 0 and market.get('event_id'):
+            existing_in_event = [
+                pos for pos in self.positions.get_all_positions()
+                if getattr(pos, 'event_id', '') == market['event_id']
+            ]
+            if len(existing_in_event) >= self.max_positions_per_event:
+                print(
+                    f"    ✗ Event exposure cap reached "
+                    f"({len(existing_in_event)}/{self.max_positions_per_event})"
+                )
+                return None
 
         # Check if we're at max positions
         if len(self.positions.get_all_positions()) >= self.max_positions:
@@ -614,7 +927,10 @@ class TradingAgent:
             return None
 
         # Calculate current bankroll
-        current_bankroll = self.positions.get_current_bankroll(self.bankroll)
+        current_bankroll = self._safe_float(
+            self.positions.get_current_bankroll(self.bankroll),
+            self.bankroll,
+        )
 
         # Check stop loss
         if current_bankroll <= self.stop_loss_bankroll:
@@ -709,6 +1025,7 @@ class TradingAgent:
         if side == 'SELL' and market.get('no_token_id'):
             exec_token_id = market['no_token_id']
             exec_side = 'BUY'
+            position_side = 'NO'
             try:
                 no_ask_price = self.polymarket.get_price(exec_token_id, 'BUY')
                 exec_price = no_ask_price if no_ask_price and no_ask_price > 0 else 1.0 - price
@@ -719,6 +1036,7 @@ class TradingAgent:
             exec_token_id = market['token_id']
             exec_side = side
             exec_price = price
+            position_side = 'YES'
             print(f"    📊 Placing {side} order @ {exec_price:.4f}...")
 
         try:
@@ -729,16 +1047,24 @@ class TradingAgent:
                 price=exec_price
             )
 
-            print(f"    ✓ Order placed: {order.get('orderID', 'unknown')}")
+            order_id = str(order.get('orderID') or order.get('id') or order.get('order_id') or 'unknown')
+            print(f"    ✓ Order placed: {order_id}")
+            if order_id != 'unknown':
+                self.runtime_state.setdefault("order_timestamps", {})[order_id] = datetime.now(timezone.utc).isoformat()
+                self._save_runtime_state()
 
             # Add position to tracker
             self.positions.add_position(
                 market=market['question'],
                 market_id=market['market_id'],
                 token_id=exec_token_id,
-                side=side,
-                entry_price=price,
-                size=size
+                side=position_side,
+                thesis_side=side,
+                entry_price=exec_price,
+                size=size,
+                quantity=(size / exec_price) if exec_price > 0 else None,
+                event_id=market.get('event_id', ''),
+                end_date=market.get('end_date', ''),
             )
 
             # Log the trade
@@ -775,6 +1101,22 @@ class TradingAgent:
         print(f"  Polymarket: ${balances['polymarket']:.2f}")
         print()
 
+        print("Monitoring live positions and orders...")
+        monitor_summary = self.monitor_existing_risk()
+        if (
+            monitor_summary.get("stale_orders_cancelled")
+            or monitor_summary.get("guard_exits")
+            or monitor_summary.get("alerts")
+        ):
+            print(
+                f"  Cancelled stale orders: {monitor_summary.get('stale_orders_cancelled', 0)} | "
+                f"Guard exits: {len(monitor_summary.get('guard_exits', []))} | "
+                f"Alerts: {monitor_summary.get('alerts', 0)}"
+            )
+        else:
+            print("  No stale orders, guard exits, or alerts")
+        print()
+
         # Sync positions with Polymarket API
         print("Syncing positions...")
         try:
@@ -788,7 +1130,10 @@ class TradingAgent:
         print()
 
         # ── risk guards ──────────────────────────────────────────
-        current_bankroll = self.positions.get_current_bankroll(self.bankroll)
+        current_bankroll = self._safe_float(
+            self.positions.get_current_bankroll(self.bankroll),
+            self.bankroll,
+        )
         peak = getattr(self, "_peak_equity", self.bankroll)
         if current_bankroll > peak:
             peak = current_bankroll
@@ -798,18 +1143,18 @@ class TradingAgent:
         live_risk = {"drawdown_pct": dd_pct, "current_equity_usd": current_bankroll, "peak_equity_usd": peak}
         unwind_result = check_drawdown_stop_loss(
             live_risk=live_risk,
-            max_drawdown_pct=self.max_drawdown_pct,
+            max_drawdown_pct=getattr(self, "max_drawdown_pct", 0.0),
             unwind_fn=lambda: {"action": "unwind_triggered", "positions_closed": len(self.positions.get_all_positions())},
         )
         if unwind_result:
-            if self.cron_job_id:
+            if getattr(self, "cron_job_id", ""):
                 try:
                     from setup_cron import pause_job
                     auto_pause_cron(
                         serenbucks_balance=0.0,
                         trading_balance=0.0,
                         min_serenbucks=1.0,
-                        job_id=self.cron_job_id,
+                        job_id=getattr(self, "cron_job_id", ""),
                         pause_fn=pause_job,
                     )
                 except Exception:
@@ -822,11 +1167,11 @@ class TradingAgent:
             if not hasattr(pos, "opened_at") or not pos.opened_at:
                 continue
             try:
-                from datetime import datetime, timezone
                 opened = datetime.fromisoformat(pos.opened_at.replace("Z", "+00:00"))
                 age_hours = (datetime.now(timezone.utc) - opened).total_seconds() / 3600.0
-                if age_hours >= self.max_position_age_hours and self.max_position_age_hours > 0:
-                    print(f"    POSITION AGE LIMIT: {pos.market} open {age_hours:.1f}h >= {self.max_position_age_hours}h limit. Flagged for close.")
+                max_age_hours = getattr(self, "max_position_age_hours", 0.0)
+                if age_hours >= max_age_hours and max_age_hours > 0:
+                    print(f"    POSITION AGE LIMIT: {pos.market} open {age_hours:.1f}h >= {max_age_hours}h limit. Flagged for close.")
             except (ValueError, TypeError):
                 continue
 
@@ -958,6 +1303,29 @@ class TradingAgent:
 
         return len(opportunities)
 
+    def run_monitor_cycle(self) -> Dict[str, Any]:
+        """Run only the cron-backed monitoring pass."""
+        print("=" * 60)
+        print(f"👁️  Polymarket Monitor Starting - {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC")
+        print("=" * 60)
+        print()
+
+        balances = self.check_balances()
+        self._last_serenbucks_balance = balances['serenbucks']
+        print("Balances:")
+        print(f"  SerenBucks: ${balances['serenbucks']:.2f}")
+        print(f"  Polymarket: ${balances['polymarket']:.2f}")
+        print()
+
+        summary = self.monitor_existing_risk()
+        print(
+            "Monitor complete:"
+            f" stale_orders_cancelled={summary.get('stale_orders_cancelled', 0)}"
+            f" guard_exits={len(summary.get('guard_exits', []))}"
+            f" alerts={summary.get('alerts', 0)}"
+        )
+        return summary
+
 
 def print_trade_summary(opportunities, *, capital_deployed=0.0, file=None):
     """Print a structured, grep-able trade summary block.
@@ -1011,6 +1379,15 @@ def _bootstrap_config_path(config_path: str) -> Path:
 
 def main():
     """Main entry point"""
+    def _coerce_float(value: Any, default: float = 0.0) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return default
+        if parsed != parsed:
+            return default
+        return parsed
+
     parser = argparse.ArgumentParser(description='Polymarket Trading Agent')
     parser.add_argument(
         '--config',
@@ -1026,6 +1403,12 @@ def main():
         '--yes-live',
         action='store_true',
         help='Explicit startup-only opt-in for live trading.'
+    )
+    parser.add_argument(
+        '--run-type',
+        choices=('scan', 'monitor'),
+        default='scan',
+        help='Cron execution mode: full scan or monitor-only pass.',
     )
 
     args = parser.parse_args()
@@ -1054,7 +1437,7 @@ def main():
     # Run iterative scan cycle
     try:
         iter_cfg = agent.config.get("iteration", {})
-        max_iterations = min(int(iter_cfg.get("max_iterations", 15)), 2)
+        max_iterations = int(iter_cfg.get("max_iterations", 15))
         threshold_step = float(iter_cfg.get("threshold_step", 0.01))
         min_threshold_floor = float(iter_cfg.get("min_threshold_floor", 0.02))
         annualized_return_step = float(iter_cfg.get("annualized_return_step", 0.05))
@@ -1067,21 +1450,35 @@ def main():
         original_min_annualized_return = agent.min_annualized_return
 
         total_opportunities = 0
+        effective_threshold = _coerce_float(
+            getattr(
+                agent,
+                "effective_mispricing_threshold",
+                getattr(agent, "mispricing_threshold", 0.0),
+            ),
+            _coerce_float(getattr(agent, "mispricing_threshold", 0.0), 0.0),
+        )
 
         for iteration in range(1, max_iterations + 1):
             print(f"\n>>> Iteration {iteration}/{max_iterations}  "
-                  f"effective_threshold={agent.effective_mispricing_threshold:.4f}  "
+                  f"effective_threshold={effective_threshold:.4f}  "
                   f"scan_limit={agent.scan_limit}  "
                   f"min_annualized_return={agent.min_annualized_return:.4f}")
 
-            opportunities_found = agent.run_scan_cycle()
+            if args.run_type == 'monitor':
+                monitor_result = agent.run_monitor_cycle()
+                opportunities_found = len(monitor_result.get("guard_exits", []))
+            else:
+                opportunities_found = agent.run_scan_cycle()
             total_opportunities += (opportunities_found or 0)
 
             print(f"<<< Iteration {iteration} result: {opportunities_found or 0} opportunities found")
 
             # Early-exit: stop iterating once we find opportunities
-            if (opportunities_found or 0) > 0:
+            if args.run_type == 'scan' and (opportunities_found or 0) > 0:
                 print(f"    Found {opportunities_found} opportunities — stopping iteration loop.")
+                break
+            if args.run_type == 'monitor':
                 break
 
             # Check SerenBucks balance from the last scan cycle

--- a/polymarket/bot/scripts/polymarket_client.py
+++ b/polymarket/bot/scripts/polymarket_client.py
@@ -17,6 +17,24 @@ if str(_SCRIPT_DIR) not in sys.path:
 from seren_client import SerenClient
 
 
+def _extract_event_id(raw_market: Dict[str, Any]) -> str:
+    events = raw_market.get("events")
+    if isinstance(events, str):
+        try:
+            events = json.loads(events)
+        except Exception:
+            events = []
+    if isinstance(events, list) and events and isinstance(events[0], dict):
+        event_id = str(events[0].get("id", "")).strip()
+        if event_id:
+            return event_id
+    for key in ("event_id", "seriesSlug", "category"):
+        value = str(raw_market.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
 class PolymarketClient:
     """Client for Polymarket CLOB API.
 
@@ -189,6 +207,7 @@ class PolymarketClient:
                 'question': question,
                 'token_id': yes_token_id,
                 'no_token_id': no_token_id,
+                'event_id': _extract_event_id(market_data),
                 'outcomePrices': outcome_prices_csv,
                 'price': price,
                 'price_source': price_source,
@@ -238,9 +257,11 @@ class PolymarketClient:
         )
 
     def cancel_order(self, order_id: str) -> Dict:
-        """Cancel all open orders."""
+        """Cancel a single open order."""
         trader = self._require_trader()
-        return trader.cancel_all()
+        if hasattr(trader, "cancel_order"):
+            return trader.cancel_order(order_id)
+        raise RuntimeError("Underlying trader does not expose cancel_order")
 
     def get_positions(self) -> List[Dict]:
         """Get current positions."""

--- a/polymarket/bot/scripts/position_tracker.py
+++ b/polymarket/bot/scripts/position_tracker.py
@@ -1,5 +1,5 @@
 """
-Position Tracker - Manages open positions and P&L calculation
+Position Tracker - Manages open positions and P&L calculation.
 
 Tracks:
 - Open positions with entry prices
@@ -9,8 +9,9 @@ Tracks:
 """
 
 import json
+import math
 import os
-from typing import List, Dict, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime, timezone
 
 
@@ -32,31 +33,102 @@ class Position:
         side: str,
         entry_price: float,
         size: float,
-        opened_at: str
+        opened_at: str,
+        quantity: Optional[float] = None,
+        thesis_side: Optional[str] = None,
+        event_id: str = "",
+        end_date: str = "",
     ):
         self.market = market
         self.market_id = market_id
         self.token_id = token_id
-        self.side = side  # 'BUY' or 'SELL'
+        self.side = self._normalize_token_side(side)  # 'YES' or 'NO'
+        self.thesis_side = self._normalize_thesis_side(thesis_side or side, self.side)
         self.entry_price = entry_price
         self.size = size
         self.opened_at = opened_at
+        self.quantity = self._normalize_quantity(quantity)
+        if self.quantity <= 0 and self.entry_price > 0 and self.size > 0:
+            self.quantity = self.size / self.entry_price
         self.current_price = entry_price  # Will be updated
         self.unrealized_pnl = 0.0
+        self.event_id = event_id
+        self.end_date = end_date
 
     def update_price(self, current_price: float):
         """Update current price and calculate unrealized P&L"""
         self.current_price = current_price
+        if self.quantity > 0:
+            self.unrealized_pnl = (current_price - self.entry_price) * self.quantity
+        else:
+            self.unrealized_pnl = 0.0
 
-        if self.side == 'BUY':
-            # P&L = (current - entry) * shares
-            # shares = size / entry_price
-            shares = self.size / self.entry_price
-            self.unrealized_pnl = (current_price - self.entry_price) * shares
-        elif self.side == 'SELL':
-            # For SELL positions, we profit when price goes down
-            shares = self.size / (1 - self.entry_price)
-            self.unrealized_pnl = (self.entry_price - current_price) * shares
+    def update_snapshot(
+        self,
+        *,
+        market: Optional[str] = None,
+        token_id: Optional[str] = None,
+        entry_price: Optional[float] = None,
+        current_price: Optional[float] = None,
+        quantity: Optional[float] = None,
+        size: Optional[float] = None,
+        side: Optional[str] = None,
+        thesis_side: Optional[str] = None,
+        event_id: Optional[str] = None,
+        end_date: Optional[str] = None,
+        opened_at: Optional[str] = None,
+    ) -> None:
+        """Refresh a position snapshot from live data."""
+        if market:
+            self.market = market
+        if token_id:
+            self.token_id = token_id
+        if side:
+            self.side = self._normalize_token_side(side)
+        if thesis_side:
+            self.thesis_side = self._normalize_thesis_side(thesis_side, self.side)
+        if event_id is not None:
+            self.event_id = event_id
+        if end_date is not None:
+            self.end_date = end_date
+        if opened_at:
+            self.opened_at = opened_at
+        if quantity is not None:
+            self.quantity = self._normalize_quantity(quantity)
+        if entry_price is not None and entry_price > 0:
+            self.entry_price = entry_price
+        if size is not None and size > 0:
+            self.size = size
+        if self.quantity <= 0 and self.entry_price > 0 and self.size > 0:
+            self.quantity = self.size / self.entry_price
+        if current_price is not None and current_price > 0:
+            self.update_price(current_price)
+
+    @staticmethod
+    def _normalize_token_side(raw_side: str) -> str:
+        value = str(raw_side or "").strip().upper()
+        if value in {"NO", "SELL", "SHORT"}:
+            return "NO"
+        return "YES"
+
+    @staticmethod
+    def _normalize_thesis_side(raw_side: str, token_side: str) -> str:
+        value = str(raw_side or "").strip().upper()
+        if value in {"BUY", "SELL"}:
+            return value
+        return "BUY" if token_side == "YES" else "SELL"
+
+    @staticmethod
+    def _normalize_quantity(raw_quantity: Optional[float]) -> float:
+        if raw_quantity is None:
+            return 0.0
+        try:
+            quantity = float(raw_quantity)
+        except (TypeError, ValueError):
+            return 0.0
+        if math.isnan(quantity) or quantity < 0:
+            return 0.0
+        return quantity
 
     def to_dict(self) -> Dict:
         """Convert to dictionary for JSON serialization"""
@@ -65,11 +137,15 @@ class Position:
             'market_id': self.market_id,
             'token_id': self.token_id,
             'side': self.side,
+            'thesis_side': self.thesis_side,
             'entry_price': self.entry_price,
             'current_price': self.current_price,
             'size': self.size,
+            'quantity': self.quantity,
             'unrealized_pnl': round(self.unrealized_pnl, 2),
-            'opened_at': self.opened_at
+            'opened_at': self.opened_at,
+            'event_id': self.event_id,
+            'end_date': self.end_date,
         }
 
     @classmethod
@@ -82,7 +158,11 @@ class Position:
             side=data['side'],
             entry_price=data['entry_price'],
             size=data['size'],
-            opened_at=data['opened_at']
+            opened_at=data['opened_at'],
+            quantity=data.get('quantity'),
+            thesis_side=data.get('thesis_side'),
+            event_id=data.get('event_id', ''),
+            end_date=data.get('end_date', ''),
         )
         pos.current_price = data.get('current_price', data['entry_price'])
         pos.unrealized_pnl = data.get('unrealized_pnl', 0.0)
@@ -173,7 +253,12 @@ class PositionTracker:
         token_id: str,
         side: str,
         entry_price: float,
-        size: float
+        size: float,
+        *,
+        quantity: Optional[float] = None,
+        thesis_side: Optional[str] = None,
+        event_id: str = "",
+        end_date: str = "",
     ) -> Position:
         """
         Add a new position
@@ -182,7 +267,7 @@ class PositionTracker:
             market: Market question/name
             market_id: Market ID
             token_id: Token ID
-            side: 'BUY' or 'SELL'
+            side: 'YES' or 'NO' token being held
             entry_price: Entry price (0.0-1.0)
             size: Position size in USDC
 
@@ -196,7 +281,11 @@ class PositionTracker:
             side=side,
             entry_price=entry_price,
             size=size,
-            opened_at=datetime.now(timezone.utc).isoformat()
+            opened_at=datetime.now(timezone.utc).isoformat(),
+            quantity=quantity,
+            thesis_side=thesis_side,
+            event_id=event_id,
+            end_date=end_date,
         )
 
         self.positions[market_id] = pos
@@ -269,6 +358,153 @@ class PositionTracker:
         """Check if we have a position in this market"""
         return market_id in self.positions
 
+    def has_exposure(
+        self,
+        market_id: str,
+        *,
+        token_id: str = "",
+        no_token_id: str = "",
+    ) -> bool:
+        """Check for exposure by market id or token ids."""
+        if market_id in self.positions:
+            return True
+        candidate_tokens = {token_id, no_token_id}
+        candidate_tokens.discard("")
+        if not candidate_tokens:
+            return False
+        return any(position.token_id in candidate_tokens for position in self.positions.values())
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        if math.isnan(parsed):
+            return None
+        return parsed
+
+    @classmethod
+    def _first_numeric(cls, *values: Any) -> Optional[float]:
+        for value in values:
+            parsed = cls._safe_float(value)
+            if parsed is not None:
+                return parsed
+        return None
+
+    @staticmethod
+    def _first_text(*values: Any) -> str:
+        for value in values:
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return ""
+
+    @classmethod
+    def _infer_quantity(cls, api_pos: Dict[str, Any]) -> float:
+        for key in (
+            'size',
+            'amount',
+            'quantity',
+            'position',
+            'balance',
+            'shares',
+            'outcomeTokens',
+            'token_balance',
+        ):
+            parsed = cls._safe_float(api_pos.get(key))
+            if parsed is not None and parsed > 0:
+                return parsed
+        nested = api_pos.get('available')
+        if isinstance(nested, dict):
+            for key in ('amount', 'balance', 'position', 'shares'):
+                parsed = cls._safe_float(nested.get(key))
+                if parsed is not None and parsed > 0:
+                    return parsed
+        return 0.0
+
+    @classmethod
+    def _infer_entry_price(cls, api_pos: Dict[str, Any], quantity: float) -> Optional[float]:
+        direct = cls._first_numeric(
+            api_pos.get('entry_price'),
+            api_pos.get('avgPrice'),
+            api_pos.get('avg_price'),
+            api_pos.get('average_price'),
+            api_pos.get('price_paid'),
+        )
+        if direct is not None and direct > 0:
+            return direct
+
+        if quantity > 0:
+            initial_value = cls._first_numeric(
+                api_pos.get('initialValue'),
+                api_pos.get('initial_value'),
+                api_pos.get('cost_basis'),
+                api_pos.get('notional'),
+                api_pos.get('size_usd'),
+            )
+            if initial_value is not None and initial_value > 0:
+                return initial_value / quantity
+        return None
+
+    @classmethod
+    def _infer_current_price(
+        cls,
+        api_pos: Dict[str, Any],
+        quantity: float,
+        polymarket_client: Any,
+        token_id: str,
+    ) -> Optional[float]:
+        direct = cls._first_numeric(
+            api_pos.get('current_price'),
+            api_pos.get('currentPrice'),
+            api_pos.get('curPrice'),
+            api_pos.get('mark_price'),
+            api_pos.get('price'),
+        )
+        if direct is not None and direct > 0:
+            return direct
+
+        if quantity > 0:
+            current_value = cls._first_numeric(
+                api_pos.get('currentValue'),
+                api_pos.get('current_value'),
+                api_pos.get('value'),
+                api_pos.get('cashValue'),
+            )
+            if current_value is not None and current_value > 0:
+                return current_value / quantity
+
+        if token_id:
+            try:
+                live_mid = polymarket_client.get_midpoint(token_id)
+            except Exception:
+                live_mid = None
+            if live_mid and live_mid > 0:
+                return live_mid
+        return None
+
+    @classmethod
+    def _infer_position_side(cls, api_pos: Dict[str, Any], token_id: str = "") -> str:
+        outcome_text = cls._first_text(
+            api_pos.get('outcome'),
+            api_pos.get('position_side'),
+            api_pos.get('token_side'),
+            api_pos.get('title'),
+            api_pos.get('side'),
+        ).lower()
+        if ' no' in f" {outcome_text}" or outcome_text == 'no':
+            return 'NO'
+        if ' yes' in f" {outcome_text}" or outcome_text == 'yes':
+            return 'YES'
+        if str(api_pos.get('side', '')).upper() == 'SELL':
+            return 'NO'
+        if token_id and token_id == str(api_pos.get('no_asset_id', '')).strip():
+            return 'NO'
+        return 'YES'
+
     def sync_with_polymarket(self, polymarket_client) -> Dict[str, int]:
         """
         Sync positions with Polymarket API
@@ -282,6 +518,10 @@ class PositionTracker:
         try:
             # Get current positions from Polymarket API
             api_positions = polymarket_client.get_positions()
+            if isinstance(api_positions, dict):
+                api_positions = api_positions.get('data', [])
+            if not isinstance(api_positions, list):
+                api_positions = []
 
             # Track changes
             added = 0
@@ -294,35 +534,97 @@ class PositionTracker:
             # Process each API position
             for api_pos in api_positions:
                 # Extract market info (handle different possible formats)
-                market_id = api_pos.get('market_id') or api_pos.get('conditionId') or api_pos.get('market')
+                market_id = self._first_text(
+                    api_pos.get('market_id'),
+                    api_pos.get('conditionId'),
+                    api_pos.get('market'),
+                    api_pos.get('condition_id'),
+                    api_pos.get('market_slug'),
+                    api_pos.get('asset_id'),
+                    api_pos.get('token_id'),
+                )
                 if not market_id:
                     continue
 
                 api_market_ids.add(market_id)
+                token_id = self._first_text(
+                    api_pos.get('token_id'),
+                    api_pos.get('asset_id'),
+                    api_pos.get('assetId'),
+                    api_pos.get('market'),
+                    market_id,
+                )
+                quantity = self._infer_quantity(api_pos)
+                current_price = self._infer_current_price(api_pos, quantity, polymarket_client, token_id)
+                entry_price = self._infer_entry_price(api_pos, quantity)
+                position_side = self._infer_position_side(api_pos, token_id=token_id)
+                thesis_side = self._first_text(api_pos.get('thesis_side'), api_pos.get('side'))
+                market_name = self._first_text(
+                    api_pos.get('question'),
+                    api_pos.get('market_name'),
+                    api_pos.get('title'),
+                    api_pos.get('market'),
+                    market_id,
+                )
+                event_id = self._first_text(
+                    api_pos.get('event_id'),
+                    api_pos.get('seriesSlug'),
+                    api_pos.get('category'),
+                )
+                end_date = self._first_text(
+                    api_pos.get('end_date'),
+                    api_pos.get('endDate'),
+                    api_pos.get('endDateIso'),
+                    api_pos.get('end_date_iso'),
+                )
+                notional_size = self._first_numeric(
+                    api_pos.get('size_usd'),
+                    api_pos.get('notional'),
+                    api_pos.get('initialValue'),
+                    api_pos.get('initial_value'),
+                )
+                if notional_size is None and entry_price is not None and quantity > 0:
+                    notional_size = entry_price * quantity
+                if notional_size is None and current_price is not None and quantity > 0:
+                    notional_size = current_price * quantity
+                if notional_size is None:
+                    notional_size = 0.0
 
                 # Check if we already track this position
                 if market_id in self.positions:
-                    # Update existing position with latest price
-                    current_price = float(api_pos.get('current_price', 0) or api_pos.get('price', 0))
-                    if current_price > 0:
-                        self.positions[market_id].update_price(current_price)
-                        updated += 1
+                    self.positions[market_id].update_snapshot(
+                        market=market_name,
+                        token_id=token_id,
+                        entry_price=entry_price,
+                        current_price=current_price,
+                        quantity=quantity,
+                        size=notional_size,
+                        side=position_side,
+                        thesis_side=thesis_side,
+                        event_id=event_id,
+                        end_date=end_date,
+                        opened_at=self._first_text(api_pos.get('created_at'), api_pos.get('opened_at')),
+                    )
+                    updated += 1
                 else:
                     # Add new position from API
                     try:
                         pos = Position(
-                            market=api_pos.get('question', '') or api_pos.get('market_name', ''),
+                            market=market_name,
                             market_id=market_id,
-                            token_id=api_pos.get('token_id', ''),
-                            side=api_pos.get('side', 'BUY').upper(),
-                            entry_price=float(api_pos.get('entry_price', 0) or api_pos.get('price', 0)),
-                            size=float(api_pos.get('size', 0) or api_pos.get('amount', 0)),
-                            opened_at=api_pos.get('created_at', datetime.now(timezone.utc).isoformat())
+                            token_id=token_id,
+                            side=position_side,
+                            entry_price=entry_price or current_price or 0.0,
+                            size=notional_size,
+                            opened_at=self._first_text(api_pos.get('created_at'), api_pos.get('opened_at'))
+                            or datetime.now(timezone.utc).isoformat(),
+                            quantity=quantity,
+                            thesis_side=thesis_side,
+                            event_id=event_id,
+                            end_date=end_date,
                         )
 
-                        # Update with current price if available
-                        current_price = float(api_pos.get('current_price', 0) or api_pos.get('price', 0))
-                        if current_price > 0:
+                        if current_price is not None and current_price > 0:
                             pos.update_price(current_price)
 
                         self.positions[market_id] = pos

--- a/polymarket/bot/scripts/run_local_pull_runner.py
+++ b/polymarket/bot/scripts/run_local_pull_runner.py
@@ -71,6 +71,8 @@ def _build_command(local_payload: dict[str, Any], default_config: str) -> list[s
         "--config",
         safe_str(local_payload.get("config_path"), default_config) or default_config,
     ]
+    run_type = safe_str(local_payload.get("run_type"), "scan") or "scan"
+    command.extend(["--run-type", run_type])
     if local_payload.get("dry_run", False):
         command.append("--dry-run")
     return command

--- a/polymarket/bot/scripts/serendb_storage.py
+++ b/polymarket/bot/scripts/serendb_storage.py
@@ -86,14 +86,25 @@ class SerenDBStorage:
                     market TEXT NOT NULL,
                     token_id TEXT,
                     side TEXT NOT NULL,
+                    thesis_side TEXT,
                     entry_price REAL NOT NULL,
                     current_price REAL NOT NULL,
                     size REAL NOT NULL,
+                    quantity REAL DEFAULT 0.0,
                     unrealized_pnl REAL DEFAULT 0.0,
+                    event_id TEXT,
+                    end_date TEXT,
                     opened_at TIMESTAMP NOT NULL,
                     updated_at TIMESTAMP NOT NULL
                 )
             """)
+            for ddl in (
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS thesis_side TEXT",
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS quantity REAL DEFAULT 0.0",
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS event_id TEXT",
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS end_date TEXT",
+            ):
+                self._execute_sql(ddl)
 
             # Create trades table
             self._execute_sql("""
@@ -378,6 +389,11 @@ class SerenDBStorage:
             metadata_json = json.dumps({
                 'market': position.get('market', ''),
                 'opened_at': position.get('opened_at'),
+                'position_side': position.get('side'),
+                'thesis_side': position.get('thesis_side'),
+                'quantity': position.get('quantity'),
+                'event_id': position.get('event_id', ''),
+                'end_date': position.get('end_date', ''),
             })
 
             # Try to update existing position first
@@ -385,11 +401,19 @@ class SerenDBStorage:
                 UPDATE positions
                 SET current_price = ?,
                     unrealized_pnl = ?,
+                    quantity = ?,
+                    thesis_side = ?,
+                    event_id = ?,
+                    end_date = ?,
                     updated_at = ?
                 WHERE market_id = ?
             """, (
                 position['current_price'],
                 position['unrealized_pnl'],
+                position.get('quantity', 0.0),
+                position.get('thesis_side'),
+                position.get('event_id', ''),
+                position.get('end_date', ''),
                 now,
                 position['market_id']
             ))
@@ -398,19 +422,23 @@ class SerenDBStorage:
             if result.get('changes', 0) == 0:
                 self._execute_sql("""
                     INSERT INTO positions (
-                        market_id, market, token_id, side,
-                        entry_price, current_price, size,
-                        unrealized_pnl, opened_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        market_id, market, token_id, side, thesis_side,
+                        entry_price, current_price, size, quantity,
+                        unrealized_pnl, event_id, end_date, opened_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     position['market_id'],
                     position['market'],
                     position.get('token_id', ''),
                     position['side'],
+                    position.get('thesis_side'),
                     position['entry_price'],
                     position['current_price'],
                     position['size'],
+                    position.get('quantity', 0.0),
                     position['unrealized_pnl'],
+                    position.get('event_id', ''),
+                    position.get('end_date', ''),
                     position['opened_at'],
                     now
                 ))
@@ -440,8 +468,8 @@ class SerenDBStorage:
                 position['market_id'],
                 instrument_id,
                 position['market_id'],
-                position['side'],
-                position['size'],
+                position.get('thesis_side', position['side']),
+                position.get('quantity', position['size']),
                 position['entry_price'],
                 position['size'],
                 position['current_price'],

--- a/polymarket/bot/scripts/setup_cron.py
+++ b/polymarket/bot/scripts/setup_cron.py
@@ -73,6 +73,12 @@ def parse_args() -> argparse.Namespace:
     create.add_argument("--timezone", default="UTC", help="IANA timezone name.")
     create.add_argument("--config", default="config.json", help="Config path passed to scripts/agent.py.")
     create.add_argument(
+        "--run-type",
+        choices=("scan", "monitor"),
+        default=DEFAULT_RUN_TYPE,
+        help="Schedule a full scan or a monitor-only pass.",
+    )
+    create.add_argument(
         "--runner-name",
         default="",
         help="Optional runner name. Defaults to skill slug + hostname.",
@@ -138,8 +144,8 @@ def main() -> int:
                 cron_expression=args.schedule,
                 timezone_name=args.timezone,
                 config_path=args.config,
-                run_type=DEFAULT_RUN_TYPE,
-                local_payload={"dry_run": bool(args.dry_run)},
+                run_type=args.run_type,
+                local_payload={"dry_run": bool(args.dry_run), "run_type": args.run_type},
                 timeout_seconds=30.0,
             )
         elif args.command == "list":

--- a/polymarket/bot/tests/test_monitoring_guards.py
+++ b/polymarket/bot/tests/test_monitoring_guards.py
@@ -1,0 +1,161 @@
+"""Critical monitoring and tracker tests for polymarket-bot."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from agent import TradingAgent
+from position_tracker import PositionTracker
+
+
+class _FakePositionsClient:
+    def get_positions(self):
+        return [
+            {
+                "conditionId": "market-1",
+                "asset_id": "token-no-1",
+                "question": "Will outcome happen?",
+                "outcome": "No",
+                "avgPrice": "0.08",
+                "currentValue": "12.0",
+                "size": "100",
+                "event_id": "event-1",
+            }
+        ]
+
+    def get_midpoint(self, token_id):
+        raise AssertionError("currentValue/size should be enough to infer the mark")
+
+
+def test_position_tracker_sync_uses_live_token_side_and_prices(tmp_path):
+    tracker = PositionTracker(
+        positions_file=str(tmp_path / "positions.json"),
+        use_serendb=False,
+    )
+
+    summary = tracker.sync_with_polymarket(_FakePositionsClient())
+
+    assert summary == {"added": 1, "removed": 0, "updated": 0}
+    position = tracker.get_position("market-1")
+    assert position is not None
+    assert position.side == "NO"
+    assert position.thesis_side == "SELL"
+    assert position.entry_price == pytest.approx(0.08)
+    assert position.current_price == pytest.approx(0.12)
+    assert position.quantity == pytest.approx(100.0)
+    assert position.unrealized_pnl == pytest.approx(4.0)
+
+
+def test_evaluate_opportunity_blocks_event_clustering():
+    agent = TradingAgent.__new__(TradingAgent)
+    agent.min_buy_price = 0.02
+    agent.max_divergence = 0.50
+    agent.effective_mispricing_threshold = 0.08
+    agent.min_annualized_return = 0.25
+    agent.min_edge_to_spread_ratio = 3.0
+    agent.max_positions_per_event = 1
+    agent.max_positions = 10
+    agent.stop_loss_bankroll = 0.0
+    agent.bankroll = 100.0
+    agent.max_kelly_fraction = 0.06
+    agent.max_depth_fraction = 0.25
+    agent.positions = MagicMock()
+    agent.positions.has_exposure.return_value = False
+    agent.positions.get_all_positions.return_value = [SimpleNamespace(event_id="event-1")]
+    agent.positions.get_current_bankroll.return_value = 100.0
+    agent.positions.get_available_capital.return_value = 100.0
+    agent.polymarket = MagicMock()
+    agent.polymarket.get_book_metrics.return_value = {
+        "best_bid": 0.48,
+        "best_ask": 0.50,
+        "spread": 0.02,
+        "bid_depth_usd": 1000.0,
+        "ask_depth_usd": 1000.0,
+    }
+
+    market = {
+        "market_id": "market-2",
+        "token_id": "token-yes-2",
+        "no_token_id": "token-no-2",
+        "event_id": "event-1",
+        "price": 0.50,
+        "question": "Clustered market",
+        "days_to_resolution": 30,
+    }
+
+    result = agent.evaluate_opportunity(
+        market,
+        "research",
+        fair_value=0.65,
+        confidence="high",
+    )
+
+    assert result is None
+
+
+def test_monitor_existing_risk_cancels_stale_orders_and_triggers_take_profit(monkeypatch, tmp_path):
+    import polymarket_live
+
+    agent = TradingAgent.__new__(TradingAgent)
+    agent.dry_run = False
+    agent.logs_dir = tmp_path / "logs"
+    agent.state_file = agent.logs_dir / "runtime_state.json"
+    agent.runtime_state = {
+        "order_timestamps": {
+            "old-order": (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+        },
+        "position_alerts": {},
+        "pending_exit_markets": {},
+    }
+    agent.stale_order_max_age_seconds = 1800
+    agent.take_profit_pct = 0.10
+    agent.position_stop_loss_pct = 0.10
+    agent.alert_move_pct = 0.08
+    agent.max_position_age_hours = 72.0
+    agent.near_resolution_hours = 24.0
+    agent.logger = MagicMock()
+    agent.polymarket = MagicMock()
+    agent.polymarket.get_open_orders.return_value = []
+    agent.polymarket._require_trader.return_value = MagicMock()
+    agent.positions = MagicMock()
+    live_position = SimpleNamespace(
+        market="Winner market",
+        market_id="market-3",
+        token_id="token-3",
+        quantity=100.0,
+        size=10.0,
+        unrealized_pnl=2.0,
+        side="YES",
+        entry_price=0.10,
+        current_price=0.12,
+        opened_at=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        end_date="",
+    )
+    agent.positions.sync_with_polymarket.return_value = {"added": 0, "removed": 0, "updated": 1}
+    agent.positions.get_all_positions.return_value = [live_position]
+    agent._close_position_via_guard = MagicMock(return_value={"market_id": "market-3", "reason": "take-profit"})
+
+    monkeypatch.setattr(
+        polymarket_live,
+        "cancel_stale_orders",
+        lambda **kwargs: {
+            "stale_count": 1,
+            "cancelled": [{"order_id": "old-order", "status": "cancelled"}],
+        },
+    )
+
+    summary = agent.monitor_existing_risk()
+
+    assert summary["stale_orders_cancelled"] == 1
+    assert len(summary["guard_exits"]) == 1
+    agent._close_position_via_guard.assert_called_once()
+    assert agent.logger.log_notification.call_count >= 2


### PR DESCRIPTION
## Summary
- add a `monitor` run type for `polymarket/bot` and wire it through the local pull runner + `setup_cron.py`
- reconcile live positions with token-aware YES/NO semantics, live price marks, and quantity tracking
- add cron-driven stale-order cleanup, alerting, and guard exits for take-profit / stop-loss / max-age / near-resolution
- enforce a hard per-event exposure cap on new entries

## Testing
- `pytest polymarket/bot/tests/test_monitoring_guards.py polymarket/tests/test_iterative_scan.py polymarket/bot/tests/test_rank_candidates.py -q`

Closes #338
