### PR TITLE
feat(sales): BAT sales coach first-run DB bootstrap, behavior check, OAuth

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -9,6 +9,29 @@ description: "Supportive sales-executive coaching skill that runs a Behavior-Att
 
 Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
 
+## First-Run Setup
+
+The runtime auto-bootstraps BAT storage on first run:
+
+1. Resolves or creates the Seren project `bat-sales-coach`.
+2. Resolves or creates the Seren database `bat_sales_coach`.
+3. Applies the `bat_sales_coach` schema and required tables: `prospects`, `behavior_tasks`, `behavior_journals`, `attitude_journals`, `technique_plans`, `coaching_sessions`.
+
+If `SEREN_API_KEY` is missing, the runtime fails immediately with a setup message pointing to `https://docs.serendb.com/skills.md`.
+
+## Returning-User Behavior Check
+
+On each invoke, the skill queries `behavior_tasks` for planned behaviors due today or earlier:
+- If behaviors are due, display them in a table and ask the sales executive which they completed.
+- If no behaviors are due, proceed directly to the behavior interview for new tasks.
+
+## Email/Calendar Integration (Optional)
+
+The skill checks for Microsoft Outlook or Google Mail OAuth tokens in SerenDesktop:
+- If authenticated, the agent can read emails, calendar, and contacts to enrich coaching context.
+- If not authenticated, the skill prompts the user to connect in SerenDesktop Settings.
+- Coaching works without email integration — it gracefully degrades to manual context.
+
 ## Overview
 
 BAT stands for `Behavior`, `Attitude`, and `Technique`.

--- a/sales/bat-sales-coach/config.example.json
+++ b/sales/bat-sales-coach/config.example.json
@@ -31,5 +31,11 @@
     "technique_focus": "",
     "training_request": ""
   },
-  "skill": "bat-sales-coach"
+  "skill": "bat-sales-coach",
+  "storage": {
+    "project_name": "bat-sales-coach",
+    "database_name": "bat_sales_coach",
+    "schema_name": "bat_sales_coach",
+    "region": "aws-us-east-2"
+  }
 }

--- a/sales/bat-sales-coach/scripts/agent.py
+++ b/sales/bat-sales-coach/scripts/agent.py
@@ -1,23 +1,77 @@
 #!/usr/bin/env python3
-"""Generated SkillForge runtime for bat-sales-coach."""
+"""BAT Sales Coach runtime with first-run DB bootstrap, returning-user behavior check, and OAuth verification."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# --- Force unbuffered stdout ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
 
 DEFAULT_DRY_RUN = True
-AVAILABLE_CONNECTORS = ['research', 'storage']
+DEFAULT_COMMAND = "start_loop"
+DEFAULT_PROJECT_NAME = "bat-sales-coach"
+DEFAULT_DATABASE_NAME = "bat_sales_coach"
+DEFAULT_SCHEMA_NAME = "bat_sales_coach"
+DEFAULT_REGION = "aws-us-east-2"
+SEREN_SKILLS_DOCS_URL = "https://docs.serendb.com/skills.md"
+AVAILABLE_CONNECTORS = ["research", "storage"]
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
+SEREN_API_BASE = "https://console.serendb.com/api/v2"
+
+
+class BatSkillError(Exception):
+    """Base error for BAT sales coach."""
+
+
+class SerenBootstrapError(BatSkillError):
+    """Raised when Seren storage bootstrap fails."""
+
+
+@dataclass
+class SerenDbTarget:
+    project_id: str
+    branch_id: str
+    database_name: str
+    connection_string: str
+    project_name: str
+    branch_name: str
+    created_project: bool = False
+    created_database: bool = False
+
+
+@dataclass
+class BehaviorDueToday:
+    task_id: str
+    prospect_name: str
+    organization: str
+    title: str
+    due_date: str
+    status: str
+
+
+@dataclass
+class OAuthStatus:
+    provider: str
+    authenticated: bool
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
-    parser.add_argument(
-        "--config",
-        default="config.json",
-        help="Path to runtime config file (default: config.json).",
-    )
+    parser = argparse.ArgumentParser(description="Run BAT Sales Coach agent.")
+    parser.add_argument("--config", default="config.json", help="Path to config (default: config.json).")
     return parser.parse_args()
 
 
@@ -28,13 +82,299 @@ def load_config(config_path: str) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+# ---------------------------------------------------------------------------
+# Seren API client (minimal, stdlib-only)
+# ---------------------------------------------------------------------------
+
+class SerenApi:
+    def __init__(self, *, api_key: str) -> None:
+        self._api_key = api_key
+
+    def _request(self, method: str, path: str, body: Optional[dict] = None) -> Any:
+        url = f"{SEREN_API_BASE}{path}"
+        data = json.dumps(body).encode() if body else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._api_key}")
+        req.add_header("Accept", "application/json")
+        if data:
+            req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+
+    def list_projects(self) -> list:
+        return self._request("GET", "/projects").get("data", {}).get("projects", [])
+
+    def create_project(self, *, name: str, region: str) -> dict:
+        body = {"project": {"name": name, "region_id": region, "pg_version": 17}}
+        return self._request("POST", "/projects", body).get("data", {}).get("project", {})
+
+    def list_branches(self, project_id: str) -> list:
+        return self._request("GET", f"/projects/{project_id}/branches").get("data", {}).get("branches", [])
+
+    def list_databases(self, project_id: str, branch_id: str) -> list:
+        return self._request("GET", f"/projects/{project_id}/branches/{branch_id}/databases").get("data", {}).get("databases", [])
+
+    def create_database(self, *, project_id: str, branch_id: str, name: str) -> dict:
+        body = {"database": {"name": name, "owner_name": "serendb_owner"}}
+        return self._request("POST", f"/projects/{project_id}/branches/{branch_id}/databases", body).get("data", {}).get("database", {})
+
+    def get_connection_string(self, *, project_id: str, branch_id: str) -> str:
+        resp = self._request("GET", f"/projects/{project_id}/connection_uri?branch_id={branch_id}")
+        return str(resp.get("data", {}).get("uri", ""))
+
+
+def resolve_secret(config: dict, key: str) -> Optional[str]:
+    val = os.getenv(key)
+    if val:
+        return val
+    env_file = Path(__file__).resolve().parents[1] / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB bootstrap
+# ---------------------------------------------------------------------------
+
+def _patch_database(uri: str, db_name: str) -> str:
+    parsed = urllib.parse.urlparse(uri)
+    return urllib.parse.urlunparse(parsed._replace(path=f"/{db_name}"))
+
+
+def resolve_or_create_serendb_target(
+    api_key: str,
+    *,
+    project_name: str,
+    database_name: str,
+    region: str,
+) -> SerenDbTarget:
+    api = SerenApi(api_key=api_key)
+
+    projects = api.list_projects()
+    project = next((p for p in projects if str(p.get("name", "")).lower() == project_name.lower()), None)
+    created_project = False
+    if not project:
+        project = api.create_project(name=project_name, region=region)
+        created_project = True
+
+    project_id = str(project.get("id") or "")
+    if not project_id:
+        raise SerenBootstrapError("Unable to determine BAT storage project_id")
+
+    branches = api.list_branches(project_id)
+    if not branches:
+        raise SerenBootstrapError(f"No branches available for BAT storage project {project_id}")
+
+    default_branch_id = project.get("default_branch_id") if isinstance(project, dict) else None
+    branch = None
+    if default_branch_id:
+        branch = next((b for b in branches if str(b.get("id")) == str(default_branch_id)), None)
+    if not branch:
+        branch = next((b for b in branches if str(b.get("name", "")).lower() in {"main", "production"}), None)
+    if not branch:
+        branch = branches[0]
+
+    branch_id = str(branch.get("id") or "")
+    branch_name = str(branch.get("name") or "main")
+    if not branch_id:
+        raise SerenBootstrapError("Unable to determine BAT storage branch_id")
+
+    databases = api.list_databases(project_id, branch_id)
+    db_names = {str(d.get("name")) for d in databases if d.get("name")}
+    created_database = False
+    if database_name not in db_names:
+        api.create_database(project_id=project_id, branch_id=branch_id, name=database_name)
+        created_database = True
+
+    conn = _patch_database(api.get_connection_string(project_id=project_id, branch_id=branch_id), database_name)
+    return SerenDbTarget(
+        project_id=project_id,
+        branch_id=branch_id,
+        database_name=database_name,
+        connection_string=conn,
+        project_name=str(project.get("name") or project_name),
+        branch_name=branch_name,
+        created_project=created_project,
+        created_database=created_database,
+    )
+
+
+def storage_bootstrap_sql(schema_name: str) -> List[str]:
+    if not SCHEMA_PATH.exists():
+        raise SerenBootstrapError(f"Schema file not found: {SCHEMA_PATH}")
+    raw = SCHEMA_PATH.read_text(encoding="utf-8")
+    rendered = raw.replace("{{schema_name}}", schema_name)
+    statements = [part.strip() for part in rendered.split(";") if part.strip()]
+    if not statements:
+        raise SerenBootstrapError(f"Schema file is empty: {SCHEMA_PATH}")
+    return statements
+
+
+def psycopg_connect(dsn: str):
+    import psycopg
+    return psycopg.connect(dsn)
+
+
+def apply_storage_bootstrap(connection_string: str, schema_name: str) -> int:
+    statements = storage_bootstrap_sql(schema_name)
+    try:
+        with psycopg_connect(connection_string) as conn:
+            with conn.cursor() as cur:
+                for stmt in statements:
+                    cur.execute(stmt)
+            conn.commit()
+    except Exception as exc:
+        raise SerenBootstrapError(f"Failed to apply BAT schema: {exc}") from exc
+    return len(statements)
+
+
+def ensure_storage(config: dict) -> dict:
+    storage_cfg = config.get("storage") if isinstance(config.get("storage"), dict) else {}
+
+    project_name = str(storage_cfg.get("project_name") or DEFAULT_PROJECT_NAME)
+    database_name = str(storage_cfg.get("database_name") or DEFAULT_DATABASE_NAME)
+    schema_name = str(storage_cfg.get("schema_name") or DEFAULT_SCHEMA_NAME)
+    region = str(storage_cfg.get("region") or DEFAULT_REGION)
+    connection_string = storage_cfg.get("connection_string") or os.getenv("SERENDB_URL")
+    api_key = resolve_secret(config, "SEREN_API_KEY")
+
+    target: Optional[SerenDbTarget] = None
+    if not connection_string:
+        if not api_key:
+            raise SerenBootstrapError(
+                f"SEREN_API_KEY is required to auto-provision BAT storage. "
+                f"Create an account at {SEREN_SKILLS_DOCS_URL}."
+            )
+        target = resolve_or_create_serendb_target(
+            api_key,
+            project_name=project_name,
+            database_name=database_name,
+            region=region,
+        )
+        connection_string = target.connection_string
+
+    executed = apply_storage_bootstrap(connection_string, schema_name)
+    result: Dict[str, Any] = {
+        "status": "ok",
+        "schema_name": schema_name,
+        "database_name": database_name,
+        "project_name": project_name,
+        "statements_executed": executed,
+        "connection_string": connection_string,
+    }
+    if target:
+        result.update({
+            "project_id": target.project_id,
+            "branch_id": target.branch_id,
+            "branch_name": target.branch_name,
+            "created_project": target.created_project,
+            "created_database": target.created_database,
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Returning-user behavior check
+# ---------------------------------------------------------------------------
+
+def query_behaviors_due_today(connection_string: str, schema_name: str) -> List[BehaviorDueToday]:
+    sql = f"""
+        SELECT id, prospect_name, organization, title, due_date, status
+        FROM {schema_name}.behavior_tasks
+        WHERE status = 'planned' AND due_date IS NOT NULL AND due_date <= CURRENT_DATE::text
+        ORDER BY due_date, created_at
+    """
+    rows: List[BehaviorDueToday] = []
+    try:
+        with psycopg_connect(connection_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                for row in cur.fetchall():
+                    rows.append(BehaviorDueToday(
+                        task_id=str(row[0]),
+                        prospect_name=str(row[1] or ""),
+                        organization=str(row[2] or ""),
+                        title=str(row[3] or ""),
+                        due_date=str(row[4] or ""),
+                        status=str(row[5] or "planned"),
+                    ))
+    except Exception:
+        pass  # Table may not exist yet on first run
+    return rows
+
+
+def format_behavior_table(behaviors: List[BehaviorDueToday]) -> str:
+    if not behaviors:
+        return "No behaviors due today."
+    header = "| Prospect | Organization | Behavior | Due Date | Status |"
+    sep = "|----------|--------------|----------|----------|--------|"
+    rows = [
+        f"| {b.prospect_name} | {b.organization} | {b.title} | {b.due_date} | {b.status} |"
+        for b in behaviors
+    ]
+    return "\n".join([header, sep] + rows)
+
+
+# ---------------------------------------------------------------------------
+# OAuth authentication check
+# ---------------------------------------------------------------------------
+
+def check_oauth_providers(config: dict) -> List[OAuthStatus]:
+    results: List[OAuthStatus] = []
+    for provider in ("microsoft", "google"):
+        env_key = f"{provider.upper()}_OAUTH_TOKEN"
+        token = os.getenv(env_key)
+        results.append(OAuthStatus(provider=provider, authenticated=bool(token)))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
 def run_once(config: dict, dry_run: bool) -> dict:
-    return {
+    result: Dict[str, Any] = {
         "status": "ok",
         "dry_run": dry_run,
         "connectors": AVAILABLE_CONNECTORS,
-        "input_keys": sorted(config.get("inputs", {}).keys()),
+        "skill": "bat-sales-coach",
     }
+
+    # Step 1: Ensure storage (first-run bootstrap)
+    try:
+        storage_result = ensure_storage(config)
+        result["storage"] = storage_result
+        connection_string = storage_result.get("connection_string")
+        schema_name = storage_result.get("schema_name", DEFAULT_SCHEMA_NAME)
+    except SerenBootstrapError as exc:
+        result["status"] = "error"
+        result["error_code"] = "storage_bootstrap_failed"
+        result["error_message"] = str(exc)
+        return result
+
+    # Step 2: Check for returning-user behaviors due today
+    behaviors_due: List[BehaviorDueToday] = []
+    if connection_string:
+        behaviors_due = query_behaviors_due_today(connection_string, schema_name)
+    result["behaviors_due_today"] = [
+        {"task_id": b.task_id, "prospect_name": b.prospect_name, "organization": b.organization,
+         "title": b.title, "due_date": b.due_date, "status": b.status}
+        for b in behaviors_due
+    ]
+    result["behaviors_due_count"] = len(behaviors_due)
+    result["behavior_table"] = format_behavior_table(behaviors_due)
+
+    # Step 3: Check OAuth authentication
+    oauth_statuses = check_oauth_providers(config)
+    result["oauth"] = [
+        {"provider": o.provider, "authenticated": o.authenticated}
+        for o in oauth_statuses
+    ]
+
+    return result
 
 
 def main() -> int:
@@ -42,8 +382,8 @@ def main() -> int:
     config = load_config(args.config)
     dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
     result = run_once(config=config, dry_run=dry_run)
-    print(json.dumps(result))
-    return 0
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("status") == "ok" else 1
 
 
 if __name__ == "__main__":

--- a/sales/bat-sales-coach/serendb_schema.sql
+++ b/sales/bat-sales-coach/serendb_schema.sql
@@ -1,0 +1,92 @@
+-- BAT Sales Coach schema for SerenDB
+-- Tables: prospects, behavior_tasks, behavior_journals, attitude_journals, technique_plans, coaching_sessions
+
+CREATE SCHEMA IF NOT EXISTS {{schema_name}};
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.prospects (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    name            TEXT NOT NULL,
+    organization    TEXT,
+    pipeline_stage  TEXT DEFAULT 'new_lead',
+    opportunity_value_usd NUMERIC(12,2) DEFAULT 0,
+    expected_close_date TEXT,
+    notes           TEXT,
+    created_at      TIMESTAMPTZ DEFAULT now(),
+    updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.behavior_tasks (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    session_id      TEXT,
+    prospect_id     TEXT REFERENCES {{schema_name}}.prospects(id),
+    prospect_name   TEXT,
+    organization    TEXT,
+    pipeline_stage  TEXT,
+    title           TEXT NOT NULL,
+    behavior_type   TEXT DEFAULT 'outreach',
+    status          TEXT DEFAULT 'planned',
+    due_date        TEXT,
+    started_at      TEXT,
+    completed_at    TEXT,
+    prospect_response TEXT,
+    next_behavior   TEXT,
+    next_behavior_due TEXT,
+    opportunity_value_usd NUMERIC(12,2) DEFAULT 0,
+    expected_close_date TEXT,
+    created_at      TIMESTAMPTZ DEFAULT now(),
+    updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.behavior_journals (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    session_id      TEXT,
+    task_id         TEXT REFERENCES {{schema_name}}.behavior_tasks(id),
+    planned_behavior TEXT,
+    actual_behavior  TEXT,
+    additional_wins  TEXT,
+    prospect_response TEXT,
+    next_behavior    TEXT,
+    created_at       TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.attitude_journals (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    session_id      TEXT,
+    score           INTEGER CHECK (score BETWEEN 1 AND 10),
+    body_signal     TEXT,
+    future_statement TEXT,
+    curiosity_state  TEXT DEFAULT 'unsure',
+    created_at       TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.technique_plans (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    session_id      TEXT,
+    technique_focus  TEXT,
+    behavior_experiment TEXT,
+    training_request TEXT,
+    self_chosen_quota INTEGER DEFAULT 0,
+    prospect_next_steps JSONB DEFAULT '[]'::jsonb,
+    created_at       TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS {{schema_name}}.coaching_sessions (
+    id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    session_date    TEXT,
+    phase_reached   TEXT DEFAULT 'behavior',
+    behaviors_planned INTEGER DEFAULT 0,
+    behaviors_completed INTEGER DEFAULT 0,
+    attitude_score  INTEGER,
+    curiosity_gate_passed BOOLEAN DEFAULT false,
+    summary         TEXT,
+    created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_behavior_tasks_status_due
+    ON {{schema_name}}.behavior_tasks (status, due_date);
+
+CREATE INDEX IF NOT EXISTS idx_behavior_tasks_prospect
+    ON {{schema_name}}.behavior_tasks (prospect_id);
+
+CREATE INDEX IF NOT EXISTS idx_coaching_sessions_date
+    ON {{schema_name}}.coaching_sessions (session_date);

--- a/sales/bat-sales-coach/tests/test_smoke.py
+++ b/sales/bat-sales-coach/tests/test_smoke.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 SKILL_PATH = Path(__file__).resolve().parents[1] / "SKILL.md"
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "serendb_schema.sql"
+
+# Add scripts dir to path so we can import agent
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import agent  # noqa: E402
 
 
 def _read_fixture(name: str) -> dict:
     return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
 
+
+# --- Existing fixture tests (unchanged) ---
 
 def test_happy_path_fixture_is_successful() -> None:
     payload = _read_fixture("happy_path.json")
@@ -43,3 +52,95 @@ def test_skill_instructions_require_user_stated_dates() -> None:
     assert "due date (user-stated only, never agent-computed)" in content
     assert "expected close date (user-stated only)" in content
     assert "What is the next behavior for this prospect, and when do you want to do it?" in content
+
+
+# --- New: Schema file exists and contains required tables ---
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.exists(), "serendb_schema.sql must exist for first-run bootstrap"
+
+
+def test_schema_contains_all_required_tables() -> None:
+    content = SCHEMA_PATH.read_text(encoding="utf-8")
+    required_tables = [
+        "prospects",
+        "behavior_tasks",
+        "behavior_journals",
+        "attitude_journals",
+        "technique_plans",
+        "coaching_sessions",
+    ]
+    for table in required_tables:
+        assert f"{{{{schema_name}}}}.{table}" in content, f"Schema must define table: {table}"
+
+
+def test_schema_bootstrap_sql_renders_without_error() -> None:
+    statements = agent.storage_bootstrap_sql("bat_sales_coach")
+    assert len(statements) >= 6, "Schema must produce at least 6 SQL statements (one per table)"
+    for stmt in statements:
+        assert "{{schema_name}}" not in stmt, "Template variable must be replaced"
+        assert "bat_sales_coach" in stmt, "Schema name must appear in rendered SQL"
+
+
+# --- New: ensure_storage fails fast without API key ---
+
+def test_ensure_storage_fails_without_api_key() -> None:
+    import pytest
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(agent.SerenBootstrapError, match="SEREN_API_KEY"):
+            agent.ensure_storage({})
+
+
+# --- New: Behavior table formatting ---
+
+def test_format_behavior_table_empty() -> None:
+    assert agent.format_behavior_table([]) == "No behaviors due today."
+
+
+def test_format_behavior_table_with_rows() -> None:
+    behaviors = [
+        agent.BehaviorDueToday(
+            task_id="t1", prospect_name="Alice", organization="Acme",
+            title="Send proposal", due_date="2026-03-31", status="planned",
+        ),
+    ]
+    table = agent.format_behavior_table(behaviors)
+    assert "Alice" in table
+    assert "Acme" in table
+    assert "Send proposal" in table
+    assert "|" in table
+
+
+# --- New: OAuth check returns both providers ---
+
+def test_check_oauth_returns_both_providers() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        statuses = agent.check_oauth_providers({})
+    providers = {s.provider for s in statuses}
+    assert providers == {"microsoft", "google"}
+    assert all(not s.authenticated for s in statuses)
+
+
+def test_check_oauth_detects_token() -> None:
+    with patch.dict("os.environ", {"MICROSOFT_OAUTH_TOKEN": "tok123"}, clear=True):
+        statuses = agent.check_oauth_providers({})
+    ms = next(s for s in statuses if s.provider == "microsoft")
+    assert ms.authenticated is True
+
+
+# --- New: SKILL.md documents first-run bootstrap ---
+
+def test_skill_md_documents_first_run_setup() -> None:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "## First-Run Setup" in content
+    assert "bat-sales-coach" in content
+    assert "bat_sales_coach" in content
+
+
+# --- New: run_once returns required keys ---
+
+def test_run_once_returns_error_without_storage() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        result = agent.run_once({}, dry_run=True)
+    assert result["status"] == "error"
+    assert result["error_code"] == "storage_bootstrap_failed"


### PR DESCRIPTION
## Summary

- Adds auto-provisioning of SerenDB project (`bat-sales-coach`) and database (`bat_sales_coach`) with full CRM schema on first invoke — prevents the data-loss bug where coaching sessions were never persisted
- Adds returning-user behavior check that queries `behavior_tasks` for tasks due today and displays them in a table before the coaching interview begins
- Adds OAuth token detection for Microsoft Outlook and Google Mail, with graceful degradation if not configured

## Files Changed

- `sales/bat-sales-coach/serendb_schema.sql` — new schema with 6 tables + indexes
- `sales/bat-sales-coach/scripts/agent.py` — rewritten with `ensure_storage`, `query_behaviors_due_today`, `check_oauth_providers`
- `sales/bat-sales-coach/SKILL.md` — documents First-Run Setup, Returning-User Behavior Check, Email/Calendar Integration
- `sales/bat-sales-coach/config.example.json` — adds `storage` config block
- `sales/bat-sales-coach/tests/test_smoke.py` — 10 new tests covering schema rendering, bootstrap failure, behavior table formatting, OAuth detection

## Test plan

- [x] All 15 tests pass (`pytest -v`)
- [x] Schema SQL renders correctly with template substitution
- [x] `ensure_storage` fails fast with clear message when `SEREN_API_KEY` missing
- [x] Behavior table formatter handles empty and populated cases
- [x] OAuth check detects both providers and returns correct status
- [x] SKILL.md contains First-Run Setup documentation

Closes #340

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com