### PR TITLE
feat: build skills index JSON and upload to R2

### DIFF
--- a/.github/workflows/build-skills-index.yml
+++ b/.github/workflows/build-skills-index.yml
@@ -1,0 +1,55 @@
+name: Build Skills Index
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build index.json
+        run: |
+          node scripts/build-index.mjs > index.json
+          echo "Skills in index:"
+          node -e "const idx = JSON.parse(require('fs').readFileSync('index.json','utf8')); console.log(idx.skills.length, 'skills,', idx.tree.length, 'tree entries')"
+
+      - name: Upload to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+        run: |
+          npm install @aws-sdk/client-s3
+          node -e "
+          const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+          const fs = require('fs');
+          const client = new S3Client({
+            region: 'auto',
+            endpoint: process.env.R2_ENDPOINT,
+            credentials: {
+              accessKeyId: process.env.R2_ACCESS_KEY_ID,
+              secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+            },
+          });
+          async function upload() {
+            const body = fs.readFileSync('index.json');
+            await client.send(new PutObjectCommand({
+              Bucket: process.env.R2_BUCKET_NAME,
+              Key: 'skills/index.json',
+              Body: body,
+              ContentType: 'application/json',
+              CacheControl: 'public, max-age=300',
+            }));
+            console.log('Uploaded skills/index.json to R2 (' + body.length + ' bytes)');
+          }
+          upload().catch(e => { console.error(e); process.exit(1); });
+          "

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// ABOUTME: Builds a skills index JSON from all SKILL.md files in the repo.
+// ABOUTME: Output is uploaded to Cloudflare R2 by the build-skills-index workflow.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+const RAW_BASE = "https://raw.githubusercontent.com/serenorg/seren-skills/main";
+
+function walkDir(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.name.startsWith(".")) continue;
+    if (entry.isDirectory()) {
+      results.push(...walkDir(fullPath));
+    } else {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function parseFrontmatter(content) {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("---")) return {};
+  const endIndex = trimmed.indexOf("---", 3);
+  if (endIndex === -1) return {};
+  const yaml = trimmed.slice(3, endIndex).trim();
+  const result = {};
+  for (const line of yaml.split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    let value = line.slice(colonIndex + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function parseTags(fm) {
+  if (!fm.tags) return [];
+  // tags can be comma-separated or YAML array
+  if (fm.tags.startsWith("[")) {
+    return fm.tags.slice(1, -1).split(",").map(t => t.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+  }
+  return fm.tags.split(",").map(t => t.trim()).filter(Boolean);
+}
+
+const allFiles = walkDir(REPO_ROOT);
+const skillFiles = allFiles.filter(f => f.endsWith("/SKILL.md"));
+
+const skills = [];
+const tree = [];
+
+// Build tree listing (all files, relative paths)
+for (const f of allFiles) {
+  const rel = relative(REPO_ROOT, f);
+  if (!rel.startsWith(".") && !rel.startsWith("node_modules")) {
+    tree.push(rel);
+  }
+}
+
+for (const skillPath of skillFiles) {
+  const rel = relative(REPO_ROOT, skillPath);
+  const parts = rel.split("/");
+  if (parts.length !== 3) continue; // expect org/skill/SKILL.md
+
+  const org = parts[0];
+  const skillName = parts[1];
+  const slug = `${org}-${skillName}`.toLowerCase();
+
+  const content = readFileSync(skillPath, "utf-8");
+  const fm = parseFrontmatter(content);
+
+  const sourceUrl = `${RAW_BASE}/${encodeURIComponent(org)}/${encodeURIComponent(skillName)}/SKILL.md`;
+
+  skills.push({
+    slug,
+    name: fm.name || skillName,
+    description: fm.description || "",
+    source: "serenorg",
+    sourceUrl,
+    tags: parseTags(fm),
+    author: fm.author,
+    version: fm.version,
+  });
+}
+
+skills.sort((a, b) => a.name.localeCompare(b.name));
+
+const index = {
+  version: "1",
+  updatedAt: new Date().toISOString(),
+  skills,
+  tree: tree.sort(),
+};
+
+process.stdout.write(JSON.stringify(index));


### PR DESCRIPTION
Adds workflow + build script to parse all SKILL.md files into a single index.json and upload to Cloudflare R2. Eliminates 70 rate-limited GitHub API calls per skills refresh.