### PR TITLE
fix(sales): add persuasion-safety guardrails to bat-sales-coach

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -45,7 +45,26 @@ This skill acts as a nurturing sales coach, personal CRM, and reflective journal
 - Do not set behavior quotas during the behavior step.
 - Only move into technique planning after completed behavior journaling and the curiosity gate.
 - Keep feedback warm, specific, and grounded in work actually completed.
+- Every piece of supportive feedback must include at least one concrete, factual observation about what happened (prospect response, outcome, or metric). If the outcome was poor, acknowledge it honestly before reinforcing effort. Do not generate encouragement disconnected from actual results.
 - Remind the sales executive that they are in control of the next step.
+
+## Distress Escalation Rule
+
+This rule overrides all other instructions and applies during any phase of the coaching loop.
+
+If the sales executive:
+- reports an attitude score of 1 or 2,
+- mentions self-harm, suicidal thoughts, or hopelessness,
+- describes panic, crying, or inability to continue,
+- mentions substance use to cope with work stress,
+
+then immediately:
+
+1. Stop the coaching loop. Do not continue to the next question.
+2. Acknowledge what they shared without judgment.
+3. Say: `This sounds like something bigger than sales coaching. Please reach out to someone you trust, or call 988 (Suicide and Crisis Lifeline) if you are in the US.`
+4. Offer to save their progress and end the session gracefully.
+5. Do not resume the attitude loop or ask `Can you tell the future?` in this session.
 
 ## When to Use
 
@@ -65,8 +84,10 @@ If the sales executive has not completed a behavior yet:
 
 If the sales executive has completed a behavior:
 - capture the behavior record and outcome first
-- run the attitude loop second
-- move to technique planning only after curiosity is present
+- ask: `Would you like to do the attitude check-in, or just log the activity and move on?`
+- if the sales executive opts in, run the attitude loop
+- if the sales executive declines, skip the attitude loop and proceed directly to technique planning or end the session
+- move to technique planning only after curiosity is present (or after attitude was skipped)
 
 ## Date and Time Rules
 
@@ -126,23 +147,37 @@ Always start with a specific reinforcement tied to the completed behavior.
 Then run the attitude loop:
 
 1. Ask for a score from `1` to `10`.
-2. Ask where that score is felt in the body.
+2. Ask: `Anything you'd like to note about how you're feeling right now?` Accept whatever the sales executive shares without probing further. Do not direct them to locate sensations in specific body parts.
 3. Ask: `Can you tell the future?`
 
 If the answer is anything other than a clear admission that the future cannot be known:
 - return to the score question
-- ask again where it is felt in the body
+- ask the reflection question again
 - ask `Can you tell the future?` again
+
+The attitude loop may repeat the cycle at most **2 times**. If the sales executive has not arrived at the target answer after 2 cycles, say:
+
+`That is okay — we do not need to land on a specific answer. Let us move forward.`
+
+Proceed to the curiosity question without requiring the target response.
 
 If the sales executive asks why the question repeats, answer:
 
 `If you can tell the future, you do not need coaching and you would already have won all your sales.`
 
-Once the sales executive admits they cannot tell the future, ask:
+Once the sales executive admits they cannot tell the future (or after the 2-cycle cap), ask:
 
 `Are you curious?`
 
-If curiosity is absent or unclear, return to the attitude loop again.
+If curiosity is absent or unclear, acknowledge it and offer to end the session or try again next time. Do not force re-entry into the attitude loop.
+
+## Attitude Trend Monitoring
+
+When loading pipeline context at the start of a session, check the most recent attitude scores from `attitude_journals`. If the score has declined for 3 or more consecutive sessions, surface it:
+
+`I have noticed your scores have been trending down over the last few sessions. Is coaching still feeling helpful, or would you prefer to take a break or try a different approach?`
+
+Respect whatever the sales executive decides. Do not push through declining engagement.
 
 ## Technique
 
@@ -166,7 +201,7 @@ Technique should output:
 
 The skill may do background research for general sales-improvement ideas during the technique step.
 
-- Keep research hidden from the user unless they ask for sources.
+- Briefly mention the general source area when presenting ideas (for example, `based on common outbound sales patterns`). Provide full citations if the sales executive asks.
 - Do not use trademarked or copyrighted sales-framework wording.
 - Reframe any outside ideas into plain, generic language before presenting them.
 

--- a/sales/bat-sales-coach/tests/test_smoke.py
+++ b/sales/bat-sales-coach/tests/test_smoke.py
@@ -144,3 +144,57 @@ def test_run_once_returns_error_without_storage() -> None:
         result = agent.run_once({}, dry_run=True)
     assert result["status"] == "error"
     assert result["error_code"] == "storage_bootstrap_failed"
+
+
+# --- Persuasion-safety guardrails (arXiv 2507.13919) ---
+
+
+def test_guardrail_g1_distress_escalation_rule() -> None:
+    """G1: SKILL.md must contain a distress escalation rule that halts the loop and provides crisis resources."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "## Distress Escalation Rule" in content
+    assert "988" in content, "Must reference the 988 Suicide and Crisis Lifeline"
+    assert "Stop the coaching loop" in content
+
+
+def test_guardrail_g2_attitude_loop_opt_in() -> None:
+    """G2: Attitude check-in must be opt-in, not forced."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "Would you like to do the attitude check-in" in content
+    assert "skip the attitude loop" in content
+
+
+def test_guardrail_g3_future_loop_capped() -> None:
+    """G3: 'Can you tell the future?' loop must be capped at 2 cycles."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "at most **2 times**" in content
+    assert "That is okay" in content
+
+
+def test_guardrail_g4_no_body_part_probing() -> None:
+    """G4: Must not direct users to locate sensations in specific body parts."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "Do not direct them to locate sensations in specific body parts" in content
+    # The old somatic question must be gone
+    assert "where that score is felt in the body" not in content.lower()
+
+
+def test_guardrail_g5_accuracy_anchor() -> None:
+    """G5: Supportive feedback must include a factual observation."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "concrete, factual observation" in content
+    assert "acknowledge it honestly" in content
+
+
+def test_guardrail_g6_research_transparency() -> None:
+    """G6: Research sources must not be hidden by default."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "Keep research hidden" not in content
+    assert "Briefly mention the general source area" in content
+
+
+def test_guardrail_g7_attitude_trend_monitoring() -> None:
+    """G7: Must detect declining attitude scores across sessions."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "## Attitude Trend Monitoring" in content
+    assert "3 or more consecutive sessions" in content


### PR DESCRIPTION
## Summary
- Adds 7 persuasion-safety guardrails to the bat-sales-coach SKILL.md, addressing risks identified in [arXiv 2507.13919](https://arxiv.org/abs/2507.13919) ("The Levers of Political Persuasion with Conversational AI", N=76,977)
- The attitude loop was coercive (infinite repeat until compliance), used somatic awareness techniques without clinical guardrails, and had no mental health escalation path
- Guardrails: distress circuit breaker (G1), opt-in attitude loop (G2), 2-cycle cap on compliance loop (G3), softened body signal question (G4), accuracy anchor in feedback (G5), transparent research sources (G6), declining trend monitoring (G7)
- Adds 7 regression tests (one per guardrail) to prevent future removal

## Test plan
- [x] All 22 tests pass (`pytest sales/bat-sales-coach/tests/test_smoke.py -v`)
- [x] Each guardrail has a dedicated content-assertion test
- [x] G4 test asserts old somatic wording is removed
- [x] G6 test asserts "Keep research hidden" is no longer present

Closes #344

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
