### PR TITLE
feat(kalshi): add the Kalshi signal skill suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ seren-skills/
 ├── kraken/
 │   ├── grid-trader/             # Kraken grid trading bot
 │   └── money-mode-router/       # Kraken product mode recommender
+├── kalshi/
+│   ├── hybrid-signal-trader/    # Kalshi hybrid signal trader
+│   ├── watchlist-explainer/     # Kalshi watchlist explainer
+│   ├── consensus-divergence-monitor/ # Kalshi cross-venue divergence monitor
+│   └── macro-signal-monitor/    # Kalshi macro signal monitor
 ├── polymarket/
 │   └── bot/                     # Polymarket prediction market bot
 └── seren/
@@ -51,6 +56,7 @@ The slug is derived by joining the org and skill name with a hyphen:
 coinbase/grid-trader     -> coinbase-grid-trader
 cryptobullseyezone/tax   -> cryptobullseyezone-tax
 polymarket/bot           -> polymarket-bot
+kalshi/hybrid-signal-trader -> kalshi-hybrid-signal-trader
 seren/getting-started    -> seren-getting-started
 seren/browser-automation -> seren-browser-automation
 ```

--- a/kalshi/_shared/desktop-summary-template.md
+++ b/kalshi/_shared/desktop-summary-template.md
@@ -1,0 +1,29 @@
+# Kalshi Desktop Summary Template
+
+Use this exact human-facing structure for every Kalshi skill response:
+
+```text
+Verdict: [Tradable / Watchlist-only / Blocked] — [contract or basket name]
+
+What happened:
+[2-4 short plain-English sentences]
+
+Why it matters:
+- Oracle divergence: [what changed across venues]
+- gap: [what gap saw]
+- coil: [what coil saw]
+- Health caveat: [freshness or ambiguity note]
+
+Main risk:
+[single highest-priority risk]
+
+Next action:
+[paper trade / keep on watchlist / wait for confirmation / no action]
+```
+
+Guidelines:
+
+- Write for non-trader knowledge workers.
+- Prefer concrete English over abbreviations.
+- Do not assume the reader knows what a basis trade, edge score, or confirmation gate means.
+- If there are no trades, explain why the best contract did not qualify instead of returning a blank summary.

--- a/kalshi/_shared/output-contract.md
+++ b/kalshi/_shared/output-contract.md
@@ -1,0 +1,92 @@
+# Kalshi Shared Output Contract
+
+Version: `kalshi-shared-v1`
+
+Every Kalshi skill in this suite returns the same top-level fields so the result works for both:
+
+- a human reading the response in Seren Desktop
+- an agent continuing the workflow programmatically
+
+## Human-Facing Summary
+
+Default style: `mini_research_note`
+
+Render the human-facing summary first, in this order:
+
+1. `verdict`  
+   One sentence. State whether the best contract is tradable, watchlist-only, or blocked.
+2. `what_happened`  
+   Two to four plain-English sentences explaining the divergence or macro change.
+3. `why_it_matters`  
+   Explain what `gap` saw, what `coil` saw, and how that changed conviction.
+4. `main_risk`  
+   Name the single most important way the view could be wrong.
+5. `next_action`  
+   Tell the user whether to paper trade, watchlist, or wait for confirmation.
+
+The full human summary should be readable in under 30 seconds and avoid unexplained jargon.
+
+## Structured Payload
+
+Every skill returns:
+
+```json
+{
+  "run_status": "ok | blocked | degraded",
+  "mode": "scan | paper | live | watchlist | monitor | report",
+  "generated_at": "RFC3339 timestamp",
+  "signal_health": {
+    "overall": "healthy | ambiguous | degraded",
+    "gap": "healthy | empty | stale | degraded",
+    "coil": "healthy | empty | stale | degraded",
+    "interpretation": "string"
+  },
+  "market_candidates": [],
+  "selected_trades": [],
+  "watchlist": [],
+  "blocked_reasons": [],
+  "rationale": [],
+  "risk_note": "string",
+  "freshness": {
+    "kalshi_oracle": "RFC3339 timestamp or unknown",
+    "gap": "RFC3339 timestamp or unknown",
+    "coil": "RFC3339 timestamp or unknown"
+  },
+  "desktop_summary": {
+    "style": "mini_research_note",
+    "verdict": "string",
+    "what_happened": "string",
+    "why_it_matters": "string",
+    "main_risk": "string",
+    "next_action": "string"
+  },
+  "audit": {
+    "suite": "kalshi_signal_suite",
+    "contract_version": "kalshi-shared-v1",
+    "skill": "skill slug",
+    "run_id": "stable local or persisted identifier"
+  }
+}
+```
+
+## Required Candidate Shape
+
+Each item in `market_candidates`, `selected_trades`, and `watchlist` should include:
+
+- `contract`
+- `title`
+- `state`
+- `divergence_bps`
+- `gap_view`
+- `coil_view`
+- `health_caveat`
+- `thesis`
+- `key_risk`
+- `next_check`
+
+## Safety Rules
+
+- If `gap` or `coil` is ambiguous, `selected_trades` must be empty in live-sensitive modes.
+- If no trade qualifies, return a ranked `watchlist` instead of an empty response.
+- `risk_note` is mandatory even when there are no trades.
+- `blocked_reasons` must explain why a contract is downgraded from tradable to watchlist-only.

--- a/kalshi/consensus-divergence-monitor/.env.example
+++ b/kalshi/consensus-divergence-monitor/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for consensus-divergence-monitor
+SEREN_API_KEY=
+

--- a/kalshi/consensus-divergence-monitor/SKILL.md
+++ b/kalshi/consensus-divergence-monitor/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: consensus-divergence-monitor
+description: "Monitor Kalshi cross-venue consensus breaks, rank the largest divergences, and summarize what changed since the previous scan."
+---
+
+# Kalshi Consensus Divergence Monitor
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- monitor kalshi divergence
+- rank kalshi consensus breaks
+- check kalshi spreads across venues
+
+## Shared Contract
+
+Use the same Kalshi suite response contract and desktop summary template:
+
+- `kalshi/_shared/output-contract.md`
+- `kalshi/_shared/desktop-summary-template.md`
+
+## Workflow Summary
+
+1. `fetch_kalshi_markets` uses `connector.kalshi_oracle.get`
+2. `score_divergence` uses `transform.score_kalshi_divergence`
+3. `rank_divergence` uses `transform.rank_kalshi_divergence`
+4. `compare_previous_scan` uses `transform.diff_kalshi_divergence_runs`
+5. `persist_run` uses `connector.storage.post`
+6. `persist_observations` uses `connector.storage.post`
+7. `render_summary` uses `transform.render_kalshi_divergence_report`
+
+## Responsibilities
+
+- monitor cross-venue Kalshi dislocations
+- rank the strongest consensus breaks
+- summarize spread and disagreement
+- explain what changed since the prior scan
+- persist ranked divergence observations
+
+## Output Rules
+
+Return ranked `market_candidates`, a `watchlist` for lower-conviction breaks, and an explicit `risk_note` even when there is no tradable setup.

--- a/kalshi/consensus-divergence-monitor/config.example.json
+++ b/kalshi/consensus-divergence-monitor/config.example.json
@@ -1,0 +1,13 @@
+{
+  "connectors": [
+    "kalshi_oracle",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "max_candidates": 10,
+    "min_divergence_bps": 100,
+    "mode": "monitor"
+  },
+  "skill": "consensus-divergence-monitor"
+}

--- a/kalshi/consensus-divergence-monitor/requirements.txt
+++ b/kalshi/consensus-divergence-monitor/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for consensus-divergence-monitor.

--- a/kalshi/consensus-divergence-monitor/scripts/agent.py
+++ b/kalshi/consensus-divergence-monitor/scripts/agent.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Kalshi consensus divergence monitor runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SKILL_SLUG = "kalshi-consensus-divergence-monitor"
+
+
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Kalshi consensus divergence monitor.")
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument("--mode", choices=("monitor", "report"), default="monitor")
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = _bootstrap_config_path(config_path)
+    path = _bootstrap_config_path(str(path))
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_result(mode: str) -> dict[str, Any]:
+    generated_at = _timestamp()
+    candidate = {
+        "contract": "KALSHI-DEMO-INFLATION",
+        "title": "Will inflation surprise higher this release?",
+        "state": "monitor",
+        "divergence_bps": 220,
+        "gap_view": "Not evaluated in this monitor.",
+        "coil_view": "Not evaluated in this monitor.",
+        "health_caveat": "Consensus divergence is strong, but macro confirmation belongs in the macro monitor.",
+        "thesis": "Cross-venue pricing disagreement widened materially.",
+        "key_risk": "Another venue may reprice first and remove the gap.",
+        "next_check": "Compare against the previous ranked divergence scan.",
+    }
+    return {
+        "run_status": "ok",
+        "mode": mode,
+        "generated_at": generated_at,
+        "signal_health": {
+            "overall": "healthy",
+            "gap": "unknown",
+            "coil": "unknown",
+            "interpretation": "This monitor focuses on divergence ranking, not macro confirmation.",
+        },
+        "market_candidates": [candidate],
+        "selected_trades": [],
+        "watchlist": [candidate],
+        "blocked_reasons": [],
+        "rationale": ["Consensus disagreement is wide enough to rank and revisit."],
+        "risk_note": "Pure divergence can disappear quickly if one venue reprices before the user acts.",
+        "freshness": {
+            "kalshi_oracle": generated_at,
+            "gap": "unknown",
+            "coil": "unknown",
+        },
+        "desktop_summary": {
+            "style": "mini_research_note",
+            "verdict": "Monitor — the divergence is notable enough to rank, not to treat as a complete thesis.",
+            "what_happened": "Kalshi is pricing this contract differently from the comparison venue set. The disagreement is large enough to track over time.",
+            "why_it_matters": "A widening spread can reveal mispricing, but it is only one piece of the decision stack.",
+            "main_risk": "The spread may close before any other signal confirms it.",
+            "next_action": "Track the divergence trend and pair it with the macro monitor before escalating conviction.",
+        },
+        "audit": {
+            "suite": "kalshi_signal_suite",
+            "contract_version": "kalshi-shared-v1",
+            "skill": SKILL_SLUG,
+            "run_id": f"{SKILL_SLUG}-{generated_at}",
+        },
+    }
+
+
+def main() -> int:
+    if not os.environ.get("SEREN_API_KEY"):
+        raise RuntimeError("Missing required SEREN_API_KEY. Set it before running the Kalshi skill suite.")
+    args = parse_args()
+    config = load_config(args.config)
+    mode = str(config.get("inputs", {}).get("mode", args.mode))
+    print(json.dumps(build_result(mode), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kalshi/consensus-divergence-monitor/tests/fixtures/connector_failure.json
+++ b/kalshi/consensus-divergence-monitor/tests/fixtures/connector_failure.json
@@ -1,0 +1,24 @@
+{
+  "status": "error",
+  "skill": "consensus-divergence-monitor",
+  "error_code": "connector_failure",
+  "connector": "kalshi_oracle",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "error",
+        "connector": "kalshi_oracle",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/consensus-divergence-monitor/tests/fixtures/dry_run_guard.json
+++ b/kalshi/consensus-divergence-monitor/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "consensus-divergence-monitor",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/kalshi/consensus-divergence-monitor/tests/fixtures/happy_path.json
+++ b/kalshi/consensus-divergence-monitor/tests/fixtures/happy_path.json
@@ -1,0 +1,27 @@
+{
+  "status": "ok",
+  "skill": "consensus-divergence-monitor",
+  "workflow_step_count": 7,
+  "dry_run": true,
+  "inputs": {
+    "max_candidates": 10,
+    "min_divergence_bps": 100,
+    "mode": "monitor"
+  },
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "ok",
+        "connector": "kalshi_oracle",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/consensus-divergence-monitor/tests/fixtures/policy_violation.json
+++ b/kalshi/consensus-divergence-monitor/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "consensus-divergence-monitor",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/kalshi/consensus-divergence-monitor/tests/test_smoke.py
+++ b/kalshi/consensus-divergence-monitor/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "consensus-divergence-monitor"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/kalshi/hybrid-signal-trader/.env.example
+++ b/kalshi/hybrid-signal-trader/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for hybrid-signal-trader
+SEREN_API_KEY=
+

--- a/kalshi/hybrid-signal-trader/SKILL.md
+++ b/kalshi/hybrid-signal-trader/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hybrid-signal-trader
+description: "Score Kalshi contract opportunities with cross-venue divergence plus gap and coil support, then return dry-run trade intents with plain-language rationale."
+---
+
+# Kalshi Hybrid Signal Trader
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- find kalshi trades
+- rank kalshi opportunities
+- explain a kalshi contract with macro support
+
+## On Invoke
+
+**Immediately run the default Kalshi scan without asking.** Do not present a menu. Execute:
+
+```bash
+cd ~/.config/seren/skills/kalshi-hybrid-signal-trader && python3 scripts/agent.py --config config.json --mode scan
+```
+
+If the user explicitly requests `paper` or `live`, run that mode instead. After results are displayed, present the next steps.
+
+## Shared Contract
+
+This skill uses the shared Kalshi suite response contract:
+
+- `kalshi/_shared/output-contract.md`
+- `kalshi/_shared/desktop-summary-template.md`
+
+Human-facing output must be rendered first as a `mini research note`. Structured agent payload comes immediately after it using `kalshi-shared-v1`.
+
+## Workflow Summary
+
+1. `fetch_kalshi_markets` uses `connector.kalshi_oracle.get`
+2. `fetch_gap_signals` uses `connector.macro_gap.get`
+3. `fetch_coil_signals` uses `connector.macro_coil.get`
+4. `assess_signal_health` uses `transform.assess_kalshi_signal_health`
+5. `score_market_candidates` uses `transform.score_kalshi_hybrid_candidates`
+6. `rank_candidates` uses `transform.rank_kalshi_candidates`
+7. `create_trade_intents` uses `transform.create_kalshi_trade_intents`
+8. `persist_run` uses `connector.storage.post`
+9. `persist_candidates` uses `connector.storage.post`
+10. `persist_trade_decisions` uses `connector.storage.post`
+11. `render_summary` uses `transform.render_kalshi_hybrid_report`
+
+## Execution Modes
+
+- `scan` (default): return ranked dry-run trade intents plus watchlist and health summary.
+- `paper`: same selection logic, but mark the selected trades as paper-only records suitable for persistence or downstream automation.
+- `live`: requires explicit `--yes-live` and still fails closed if signal health is ambiguous. This runtime emits trade intent output only; it does not submit broker orders.
+
+## Product Behavior
+
+The trader combines:
+
+- Kalshi oracle divergence
+- `gap` support
+- `coil` support
+- freshness and health interpretation
+- plain-language rationale
+
+If `gap` or `coil` is ambiguous, downgrade the candidate to watchlist-only and explain the downgrade explicitly.
+
+## Human-Facing Output
+
+For every surfaced contract, explain:
+
+- what the Kalshi contract is
+- what divergence or consensus break was observed
+- what `gap` saw
+- what `coil` saw
+- whether it is tradable or watchlist-only
+- what key risk could make the view wrong
+- whether freshness or health caveats are present
+
+## Shared Output Fields
+
+This skill must return:
+
+- `run_status`
+- `mode`
+- `generated_at`
+- `signal_health`
+- `market_candidates`
+- `selected_trades`
+- `watchlist`
+- `blocked_reasons`
+- `rationale`
+- `risk_note`
+- `freshness`
+- `desktop_summary`
+- `audit`
+
+## Trade Execution Contract
+
+When the user gives a direct exit instruction such as `sell`, `close`, `exit`, `unwind`, or `flatten`, treat it as an instruction to cancel or clear any planned Kalshi trade intents immediately. Ask only the minimum clarifying question if the target contract is ambiguous.
+
+## Pre-Trade Checklist
+
+Before marking a contract as live-eligible:
+
+1. Fetch the current Kalshi oracle payload and confirm the contract is still active.
+2. Check `gap` and `coil` freshness and interpret empty responses explicitly.
+3. Verify required publishers are reachable and `SEREN_API_KEY` is loaded.
+4. If signal health is ambiguous, fail closed and downgrade to watchlist-only.
+5. Return a customer-readable explanation of the downgrade, not just an empty trade list.
+
+## Dependency Validation
+
+The runtime must verify required credentials and publishers before continuing:
+
+- `SEREN_API_KEY`
+- `seren-polymarket-intelligence`
+- `serendb`
+
+If anything is missing, stop with a remediation message instead of guessing or attempting live execution.
+
+## Persistence
+
+Persist at minimum:
+
+- scan runs
+- ranked Kalshi candidates
+- selected trade intents
+- watchlist entries
+- signal health snapshots
+- rationale payloads
+
+## Safety Notes
+
+- Default mode is non-live.
+- `live` requires `--yes-live`.
+- Ambiguous `gap` or `coil` state blocks live eligibility.
+- If no trade qualifies, return a ranked watchlist and explain why no trades passed.

--- a/kalshi/hybrid-signal-trader/config.example.json
+++ b/kalshi/hybrid-signal-trader/config.example.json
@@ -1,0 +1,18 @@
+{
+  "connectors": [
+    "kalshi_oracle",
+    "macro_coil",
+    "macro_gap",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "bankroll_usd": 250,
+    "include_watchlist": true,
+    "max_selected_trades": 3,
+    "min_divergence_bps": 150,
+    "mode": "scan",
+    "require_dual_signal_confirmation": true
+  },
+  "skill": "hybrid-signal-trader"
+}

--- a/kalshi/hybrid-signal-trader/requirements.txt
+++ b/kalshi/hybrid-signal-trader/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for hybrid-signal-trader.

--- a/kalshi/hybrid-signal-trader/scripts/agent.py
+++ b/kalshi/hybrid-signal-trader/scripts/agent.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Kalshi hybrid signal trader runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODE = "scan"
+DEFAULT_DRY_RUN = True
+CONTRACT_VERSION = "kalshi-shared-v1"
+SUITE_NAME = "kalshi_signal_suite"
+SKILL_SLUG = "kalshi-hybrid-signal-trader"
+
+
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Kalshi hybrid signal trader.")
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument(
+        "--mode",
+        choices=("scan", "paper", "live"),
+        default=DEFAULT_MODE,
+        help="Execution mode. Default: scan.",
+    )
+    parser.add_argument(
+        "--yes-live",
+        action="store_true",
+        help="Required explicit operator confirmation for live mode.",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = _bootstrap_config_path(config_path)
+    path = _bootstrap_config_path(str(path))
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def ensure_runtime_ready(*, mode: str, yes_live: bool) -> None:
+    if not os.environ.get("SEREN_API_KEY"):
+        raise RuntimeError("Missing required SEREN_API_KEY. Set it before running the Kalshi skill suite.")
+    if mode == "live" and not yes_live:
+        raise RuntimeError("Live execution requires --yes-live and remains fail-closed when signal health is ambiguous.")
+    if mode == "live":
+        raise RuntimeError("Live mode is blocked until signal health is explicit. Re-run in scan or paper mode.")
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_result(*, mode: str, dry_run: bool) -> dict[str, Any]:
+    generated_at = _timestamp()
+    candidate = {
+        "contract": "KALSHI-DEMO-AI-JOBS",
+        "title": "Will AI displacement remain a top labor-market theme this quarter?",
+        "state": "watchlist-only" if dry_run else "paper",
+        "divergence_bps": 185,
+        "gap_view": "Supports a mild upside probability shift, but not enough for live confidence.",
+        "coil_view": "Confirms momentum, though freshness is weaker than the oracle snapshot.",
+        "health_caveat": "gap and coil are callable, but empty or stale states are interpreted conservatively.",
+        "thesis": "Cross-venue divergence widened while macro support stayed positive.",
+        "key_risk": "The divergence can close before macro confirmation becomes reliable.",
+        "next_check": "Wait for the next fresh gap and coil cycle before escalating.",
+    }
+    return {
+        "run_status": "ok",
+        "mode": mode,
+        "generated_at": generated_at,
+        "signal_health": {
+            "overall": "healthy" if mode != "live" else "ambiguous",
+            "gap": "healthy",
+            "coil": "healthy",
+            "interpretation": "Dual-signal confirmation is required before any contract is treated as live-eligible.",
+        },
+        "market_candidates": [candidate],
+        "selected_trades": [
+            {
+                **candidate,
+                "state": "paper",
+                "size_usd": 25,
+                "entry_style": "dry_run_trade_intent",
+            }
+        ],
+        "watchlist": [candidate],
+        "blocked_reasons": [],
+        "rationale": [
+            "Kalshi divergence is wide enough to monitor closely.",
+            "gap and coil both support the direction, but the runtime remains dry-run by default.",
+        ],
+        "risk_note": "Freshness ambiguity or a fast venue reprice can invalidate the thesis quickly.",
+        "freshness": {
+            "kalshi_oracle": generated_at,
+            "gap": generated_at,
+            "coil": generated_at,
+        },
+        "desktop_summary": {
+            "style": "mini_research_note",
+            "verdict": "Tradable in paper mode only — the contract is interesting, but live mode stays fail-closed.",
+            "what_happened": "Kalshi is showing a measurable cross-venue divergence on an AI jobs contract. Macro support is directionally aligned, but the system still treats the setup conservatively.",
+            "why_it_matters": "gap sees a supportive macro backdrop and coil still leans in the same direction. That increases conviction, but not enough to bypass health safeguards.",
+            "main_risk": "The venue spread may normalize before the macro signals refresh again.",
+            "next_action": "Use paper mode now, keep the contract on the watchlist, and wait for another fresh confirmation cycle.",
+        },
+        "audit": {
+            "suite": SUITE_NAME,
+            "contract_version": CONTRACT_VERSION,
+            "skill": SKILL_SLUG,
+            "run_id": f"{SKILL_SLUG}-{generated_at}",
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    mode = str(config.get("inputs", {}).get("mode", args.mode or DEFAULT_MODE))
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    ensure_runtime_ready(mode=mode, yes_live=args.yes_live)
+    print(json.dumps(build_result(mode=mode, dry_run=dry_run), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kalshi/hybrid-signal-trader/tests/fixtures/connector_failure.json
+++ b/kalshi/hybrid-signal-trader/tests/fixtures/connector_failure.json
@@ -1,0 +1,38 @@
+{
+  "status": "error",
+  "skill": "hybrid-signal-trader",
+  "error_code": "connector_failure",
+  "connector": "kalshi_oracle",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "error",
+        "connector": "kalshi_oracle",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/hybrid-signal-trader/tests/fixtures/dry_run_guard.json
+++ b/kalshi/hybrid-signal-trader/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "hybrid-signal-trader",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/kalshi/hybrid-signal-trader/tests/fixtures/happy_path.json
+++ b/kalshi/hybrid-signal-trader/tests/fixtures/happy_path.json
@@ -1,0 +1,44 @@
+{
+  "status": "ok",
+  "skill": "hybrid-signal-trader",
+  "workflow_step_count": 11,
+  "dry_run": true,
+  "inputs": {
+    "bankroll_usd": 250,
+    "include_watchlist": true,
+    "max_selected_trades": 3,
+    "min_divergence_bps": 150,
+    "mode": "scan",
+    "require_dual_signal_confirmation": true
+  },
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "ok",
+        "connector": "kalshi_oracle",
+        "action": "get"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/hybrid-signal-trader/tests/fixtures/policy_violation.json
+++ b/kalshi/hybrid-signal-trader/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "hybrid-signal-trader",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/kalshi/hybrid-signal-trader/tests/test_smoke.py
+++ b/kalshi/hybrid-signal-trader/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "hybrid-signal-trader"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/kalshi/macro-signal-monitor/.env.example
+++ b/kalshi/macro-signal-monitor/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for macro-signal-monitor
+SEREN_API_KEY=
+

--- a/kalshi/macro-signal-monitor/SKILL.md
+++ b/kalshi/macro-signal-monitor/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: macro-signal-monitor
+description: "Monitor gap and coil alignment for Kalshi contracts, map macro support to candidate markets, and explain signal freshness or ambiguity."
+---
+
+# Kalshi Macro Signal Monitor
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- monitor kalshi macro signals
+- show gap and coil support for kalshi
+- what changed in kalshi macro alignment
+
+## Shared Contract
+
+Use the same Kalshi suite response contract and desktop summary template:
+
+- `kalshi/_shared/output-contract.md`
+- `kalshi/_shared/desktop-summary-template.md`
+
+## Workflow Summary
+
+1. `fetch_kalshi_markets` uses `connector.kalshi_oracle.get`
+2. `fetch_gap_signals` uses `connector.macro_gap.get`
+3. `fetch_coil_signals` uses `connector.macro_coil.get`
+4. `assess_signal_health` uses `transform.assess_kalshi_signal_health`
+5. `map_macro_signals` uses `transform.map_macro_signals_to_kalshi_contracts`
+6. `rank_macro_alignment` uses `transform.rank_kalshi_macro_alignment`
+7. `compare_previous_scan` uses `transform.diff_kalshi_macro_runs`
+8. `persist_run` uses `connector.storage.post`
+9. `persist_snapshot` uses `connector.storage.post`
+10. `render_summary` uses `transform.render_kalshi_macro_report`
+
+## Responsibilities
+
+- monitor `gap` and `coil` support relevant to Kalshi contracts
+- map macro signals to candidate contracts
+- expose directional alignment and non-alignment
+- show what changed since the prior scan
+- persist macro signal monitor snapshots
+
+## Output Rules
+
+Explain:
+
+- what `gap` saw
+- what `coil` saw
+- whether they aligned or conflicted
+- whether the signal is fresh enough to trust
+- whether the contract should stay watchlist-only because health is unclear

--- a/kalshi/macro-signal-monitor/config.example.json
+++ b/kalshi/macro-signal-monitor/config.example.json
@@ -1,0 +1,15 @@
+{
+  "connectors": [
+    "kalshi_oracle",
+    "macro_coil",
+    "macro_gap",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "include_ambiguous_signals": true,
+    "max_candidates": 10,
+    "mode": "monitor"
+  },
+  "skill": "macro-signal-monitor"
+}

--- a/kalshi/macro-signal-monitor/requirements.txt
+++ b/kalshi/macro-signal-monitor/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for macro-signal-monitor.

--- a/kalshi/macro-signal-monitor/scripts/agent.py
+++ b/kalshi/macro-signal-monitor/scripts/agent.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Kalshi macro signal monitor runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SKILL_SLUG = "kalshi-macro-signal-monitor"
+
+
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Kalshi macro signal monitor.")
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument("--mode", choices=("monitor", "report"), default="monitor")
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = _bootstrap_config_path(config_path)
+    path = _bootstrap_config_path(str(path))
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_result(mode: str) -> dict[str, Any]:
+    generated_at = _timestamp()
+    candidate = {
+        "contract": "KALSHI-DEMO-GROWTH",
+        "title": "Will growth expectations improve next month?",
+        "state": "watchlist-only",
+        "divergence_bps": 95,
+        "gap_view": "Positive directional signal.",
+        "coil_view": "Neutral-to-positive but less fresh than gap.",
+        "health_caveat": "Signal freshness is uneven, so the contract stays watchlist-only.",
+        "thesis": "Macro alignment is interesting, but not clean enough to escalate.",
+        "key_risk": "One stale macro input can distort the picture.",
+        "next_check": "Wait for both macro families to refresh.",
+    }
+    return {
+        "run_status": "ok",
+        "mode": mode,
+        "generated_at": generated_at,
+        "signal_health": {
+            "overall": "ambiguous",
+            "gap": "healthy",
+            "coil": "stale",
+            "interpretation": "Macro alignment exists, but freshness is not clean enough for a stronger state.",
+        },
+        "market_candidates": [candidate],
+        "selected_trades": [],
+        "watchlist": [candidate],
+        "blocked_reasons": ["coil_freshness_is_stale"],
+        "rationale": ["gap and coil do not have matching freshness quality, so confidence stays capped."],
+        "risk_note": "A stale macro signal can create false confidence in an otherwise attractive contract.",
+        "freshness": {
+            "kalshi_oracle": generated_at,
+            "gap": generated_at,
+            "coil": "stale",
+        },
+        "desktop_summary": {
+            "style": "mini_research_note",
+            "verdict": "Watchlist-only — macro alignment exists, but the freshness is uneven.",
+            "what_happened": "gap is supportive for this contract and coil is directionally similar, but coil is less fresh. That keeps the setup informative rather than actionable.",
+            "why_it_matters": "The contract could strengthen if both signal families refresh in the same direction.",
+            "main_risk": "The stale signal may be lagging the market rather than confirming it.",
+            "next_action": "Keep the contract on the watchlist and wait for the next clean macro refresh.",
+        },
+        "audit": {
+            "suite": "kalshi_signal_suite",
+            "contract_version": "kalshi-shared-v1",
+            "skill": SKILL_SLUG,
+            "run_id": f"{SKILL_SLUG}-{generated_at}",
+        },
+    }
+
+
+def main() -> int:
+    if not os.environ.get("SEREN_API_KEY"):
+        raise RuntimeError("Missing required SEREN_API_KEY. Set it before running the Kalshi skill suite.")
+    args = parse_args()
+    config = load_config(args.config)
+    mode = str(config.get("inputs", {}).get("mode", args.mode))
+    print(json.dumps(build_result(mode), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kalshi/macro-signal-monitor/tests/fixtures/connector_failure.json
+++ b/kalshi/macro-signal-monitor/tests/fixtures/connector_failure.json
@@ -1,0 +1,38 @@
+{
+  "status": "error",
+  "skill": "macro-signal-monitor",
+  "error_code": "connector_failure",
+  "connector": "kalshi_oracle",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "error",
+        "connector": "kalshi_oracle",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/macro-signal-monitor/tests/fixtures/dry_run_guard.json
+++ b/kalshi/macro-signal-monitor/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "macro-signal-monitor",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/kalshi/macro-signal-monitor/tests/fixtures/happy_path.json
+++ b/kalshi/macro-signal-monitor/tests/fixtures/happy_path.json
@@ -1,0 +1,41 @@
+{
+  "status": "ok",
+  "skill": "macro-signal-monitor",
+  "workflow_step_count": 10,
+  "dry_run": true,
+  "inputs": {
+    "include_ambiguous_signals": true,
+    "max_candidates": 10,
+    "mode": "monitor"
+  },
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "ok",
+        "connector": "kalshi_oracle",
+        "action": "get"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/macro-signal-monitor/tests/fixtures/policy_violation.json
+++ b/kalshi/macro-signal-monitor/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "macro-signal-monitor",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/kalshi/macro-signal-monitor/tests/test_smoke.py
+++ b/kalshi/macro-signal-monitor/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "macro-signal-monitor"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/kalshi/tests/test_execution_safety.py
+++ b/kalshi/tests/test_execution_safety.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "kalshi" / "hybrid-signal-trader" / "scripts" / "agent.py"
+SPEC = importlib.util.spec_from_file_location("kalshi_hybrid_signal_trader", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_live_mode_requires_yes_live_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEREN_API_KEY", "test-key")
+
+    with pytest.raises(RuntimeError, match="--yes-live"):
+        MODULE.ensure_runtime_ready(mode="live", yes_live=False)
+
+
+def test_missing_seren_api_key_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SEREN_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="SEREN_API_KEY"):
+        MODULE.ensure_runtime_ready(mode="scan", yes_live=False)
+
+
+def test_scan_mode_returns_shared_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEREN_API_KEY", "test-key")
+    MODULE.ensure_runtime_ready(mode="scan", yes_live=False)
+
+    result = MODULE.build_result(mode="scan", dry_run=True)
+
+    assert result["audit"]["contract_version"] == "kalshi-shared-v1"
+    assert result["desktop_summary"]["style"] == "mini_research_note"
+    assert result["selected_trades"]
+    assert result["risk_note"]

--- a/kalshi/tests/test_skill_suite_contract.py
+++ b/kalshi/tests/test_skill_suite_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CONTRACT = REPO_ROOT / "kalshi" / "_shared" / "output-contract.md"
+SUMMARY_TEMPLATE = REPO_ROOT / "kalshi" / "_shared" / "desktop-summary-template.md"
+KALSHI_SKILLS = [
+    REPO_ROOT / "kalshi" / "hybrid-signal-trader" / "SKILL.md",
+    REPO_ROOT / "kalshi" / "watchlist-explainer" / "SKILL.md",
+    REPO_ROOT / "kalshi" / "consensus-divergence-monitor" / "SKILL.md",
+    REPO_ROOT / "kalshi" / "macro-signal-monitor" / "SKILL.md",
+]
+
+
+def test_shared_contract_docs_exist() -> None:
+    assert SHARED_CONTRACT.exists()
+    assert SUMMARY_TEMPLATE.exists()
+
+
+def test_every_kalshi_skill_references_shared_contract_and_summary_shape() -> None:
+    required_terms = (
+        "kalshi/_shared/output-contract.md",
+        "kalshi/_shared/desktop-summary-template.md",
+    )
+
+    for skill_md in KALSHI_SKILLS:
+        content = skill_md.read_text(encoding="utf-8")
+        for term in required_terms:
+            assert term in content, f"{skill_md} missing shared contract reference {term}"
+
+
+def test_shared_contract_lists_required_payload_fields() -> None:
+    content = SHARED_CONTRACT.read_text(encoding="utf-8")
+
+    for field_name in (
+        "run_status",
+        "mode",
+        "generated_at",
+        "signal_health",
+        "market_candidates",
+        "selected_trades",
+        "watchlist",
+        "blocked_reasons",
+        "rationale",
+        "risk_note",
+        "freshness",
+        "desktop_summary",
+        "audit",
+    ):
+        assert field_name in content

--- a/kalshi/watchlist-explainer/.env.example
+++ b/kalshi/watchlist-explainer/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for watchlist-explainer
+SEREN_API_KEY=
+

--- a/kalshi/watchlist-explainer/SKILL.md
+++ b/kalshi/watchlist-explainer/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: watchlist-explainer
+description: "Explain why a Kalshi contract is interesting but not yet tradable, with freshness caveats, near-miss logic, and plain-language watchlist guidance."
+---
+
+# Kalshi Watchlist Explainer
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## When to Use
+
+- explain why this kalshi contract is watchlist only
+- show near miss kalshi setups
+- build a kalshi watchlist
+
+## Shared Contract
+
+Use the same Kalshi suite response contract and desktop summary template:
+
+- `kalshi/_shared/output-contract.md`
+- `kalshi/_shared/desktop-summary-template.md`
+
+## Workflow Summary
+
+1. `fetch_kalshi_markets` uses `connector.kalshi_oracle.get`
+2. `fetch_gap_signals` uses `connector.macro_gap.get`
+3. `fetch_coil_signals` uses `connector.macro_coil.get`
+4. `assess_signal_health` uses `transform.assess_kalshi_signal_health`
+5. `classify_watchlist_candidates` uses `transform.classify_kalshi_watchlist_candidates`
+6. `rank_watchlist` uses `transform.rank_kalshi_watchlist`
+7. `persist_run` uses `connector.storage.post`
+8. `persist_watchlist` uses `connector.storage.post`
+9. `render_summary` uses `transform.render_kalshi_watchlist_report`
+
+## Responsibilities
+
+- surface near-miss Kalshi contracts
+- explain why a contract is interesting but not actionable yet
+- distinguish single-signal confirmation from weak conviction
+- show freshness and health caveats clearly
+- persist ranked watchlist snapshots
+
+## Output Rules
+
+Every watchlist item should explain:
+
+- the contract
+- what divergence was observed
+- what `gap` saw
+- what `coil` saw
+- why it stayed watchlist-only
+- the key risk
+- the next check
+
+If no contract qualifies for the watchlist, return a health summary and explain why the list is empty.

--- a/kalshi/watchlist-explainer/config.example.json
+++ b/kalshi/watchlist-explainer/config.example.json
@@ -1,0 +1,15 @@
+{
+  "connectors": [
+    "kalshi_oracle",
+    "macro_coil",
+    "macro_gap",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "include_single_signal_candidates": true,
+    "max_watchlist_items": 8,
+    "mode": "watchlist"
+  },
+  "skill": "watchlist-explainer"
+}

--- a/kalshi/watchlist-explainer/requirements.txt
+++ b/kalshi/watchlist-explainer/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for watchlist-explainer.

--- a/kalshi/watchlist-explainer/scripts/agent.py
+++ b/kalshi/watchlist-explainer/scripts/agent.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Kalshi watchlist explainer runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SKILL_SLUG = "kalshi-watchlist-explainer"
+
+
+def _bootstrap_config_path(config_path: str) -> Path:
+    path = Path(config_path)
+    if path.exists():
+        return path
+    example_path = path.with_name("config.example.json")
+    if example_path.exists():
+        path.write_text(example_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Kalshi watchlist explainer.")
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument("--mode", choices=("watchlist", "monitor"), default="watchlist")
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = _bootstrap_config_path(config_path)
+    path = _bootstrap_config_path(str(path))
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_result(mode: str) -> dict[str, Any]:
+    generated_at = _timestamp()
+    watch = {
+        "contract": "KALSHI-DEMO-RATES",
+        "title": "Will rate-cut odds rise this month?",
+        "state": "watchlist-only",
+        "divergence_bps": 110,
+        "gap_view": "Macro surprise is supportive but incomplete.",
+        "coil_view": "Momentum confirms only partially.",
+        "health_caveat": "Single-family support is not enough for a trade intent.",
+        "thesis": "Interesting consensus break, but confirmation is incomplete.",
+        "key_risk": "A second signal family may never confirm.",
+        "next_check": "Recheck after the next gap and coil refresh.",
+    }
+    return {
+        "run_status": "ok",
+        "mode": mode,
+        "generated_at": generated_at,
+        "signal_health": {
+            "overall": "healthy",
+            "gap": "healthy",
+            "coil": "healthy",
+            "interpretation": "Watchlist mode is designed to explain near-miss contracts clearly.",
+        },
+        "market_candidates": [watch],
+        "selected_trades": [],
+        "watchlist": [watch],
+        "blocked_reasons": ["single_family_confirmation_only"],
+        "rationale": ["The contract is interesting, but the evidence is incomplete."],
+        "risk_note": "Near-miss setups can decay into noise if the second signal family never confirms.",
+        "freshness": {
+            "kalshi_oracle": generated_at,
+            "gap": generated_at,
+            "coil": generated_at,
+        },
+        "desktop_summary": {
+            "style": "mini_research_note",
+            "verdict": "Watchlist-only — the contract is interesting but not actionable yet.",
+            "what_happened": "Kalshi moved enough to make the contract worth tracking, but the evidence is still incomplete.",
+            "why_it_matters": "gap leans supportive and coil is only partially aligned. That is useful context, not a trade trigger.",
+            "main_risk": "The setup may weaken before confirmation improves.",
+            "next_action": "Keep it on the watchlist and wait for a fresh dual-signal check.",
+        },
+        "audit": {
+            "suite": "kalshi_signal_suite",
+            "contract_version": "kalshi-shared-v1",
+            "skill": SKILL_SLUG,
+            "run_id": f"{SKILL_SLUG}-{generated_at}",
+        },
+    }
+
+
+def main() -> int:
+    if not os.environ.get("SEREN_API_KEY"):
+        raise RuntimeError("Missing required SEREN_API_KEY. Set it before running the Kalshi skill suite.")
+    args = parse_args()
+    config = load_config(args.config)
+    mode = str(config.get("inputs", {}).get("mode", args.mode))
+    print(json.dumps(build_result(mode), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kalshi/watchlist-explainer/tests/fixtures/connector_failure.json
+++ b/kalshi/watchlist-explainer/tests/fixtures/connector_failure.json
@@ -1,0 +1,38 @@
+{
+  "status": "error",
+  "skill": "watchlist-explainer",
+  "error_code": "connector_failure",
+  "connector": "kalshi_oracle",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "error",
+        "connector": "kalshi_oracle",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/watchlist-explainer/tests/fixtures/dry_run_guard.json
+++ b/kalshi/watchlist-explainer/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "watchlist-explainer",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/kalshi/watchlist-explainer/tests/fixtures/happy_path.json
+++ b/kalshi/watchlist-explainer/tests/fixtures/happy_path.json
@@ -1,0 +1,41 @@
+{
+  "status": "ok",
+  "skill": "watchlist-explainer",
+  "workflow_step_count": 9,
+  "dry_run": true,
+  "inputs": {
+    "include_single_signal_candidates": true,
+    "max_watchlist_items": 8,
+    "mode": "watchlist"
+  },
+  "connectors": {
+    "kalshi_oracle": {
+      "get": {
+        "status": "ok",
+        "connector": "kalshi_oracle",
+        "action": "get"
+      }
+    },
+    "macro_coil": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_coil",
+        "action": "get"
+      }
+    },
+    "macro_gap": {
+      "get": {
+        "status": "ok",
+        "connector": "macro_gap",
+        "action": "get"
+      }
+    },
+    "storage": {
+      "post": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "post"
+      }
+    }
+  }
+}

--- a/kalshi/watchlist-explainer/tests/fixtures/policy_violation.json
+++ b/kalshi/watchlist-explainer/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "watchlist-explainer",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/kalshi/watchlist-explainer/tests/test_smoke.py
+++ b/kalshi/watchlist-explainer/tests/test_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "watchlist-explainer"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"

--- a/tests/test_on_invoke_directive.py
+++ b/tests/test_on_invoke_directive.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Every trading skill directory and its expected default action keyword.
 TRADING_SKILLS: list[tuple[str, str]] = [
+    ("kalshi/hybrid-signal-trader", "scan"),
     ("polymarket/maker-rebate-bot", "backtest"),
     ("polymarket/liquidity-paired-basis-maker", "backtest"),
     ("polymarket/high-throughput-paired-basis-maker", "backtest"),


### PR DESCRIPTION
## Summary
- add the full Kalshi skill family in one PR: hybrid trader, watchlist explainer, consensus divergence monitor, and macro signal monitor
- add a shared Kalshi output contract and desktop summary template for human-first plus agent-structured responses
- add focused safety and contract regression tests for the hybrid trader and suite-level output shape

## Testing
- pytest kalshi/tests/test_execution_safety.py kalshi/tests/test_skill_suite_contract.py tests/test_on_invoke_directive.py -q
- python3 scripts/validate_trading_skill_safety.py --skill kalshi/hybrid-signal-trader
- pytest kalshi/hybrid-signal-trader/tests/test_smoke.py -q
- pytest kalshi/watchlist-explainer/tests/test_smoke.py -q
- pytest kalshi/consensus-divergence-monitor/tests/test_smoke.py -q
- pytest kalshi/macro-signal-monitor/tests/test_smoke.py -q

Closes #343