### PR TITLE
fix(bat-sales-coach): enforce mandatory B→A→T sequence

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -75,19 +75,19 @@ then immediately:
 
 ## Default Flow
 
-Start with `Behavior` every time.
+Start with `Behavior` every time. The loop is **Behavior → Attitude → Technique**, in that order.
+
+**MANDATORY SEQUENCE RULE**: After Behavior completes, ALWAYS proceed to Attitude. After Attitude completes, ALWAYS proceed to Technique. Never skip a step. Never insert a session-close prompt, summary, or "anything else?" question between steps. The only valid exit before the full loop completes is if the user explicitly ends the session or the Distress Escalation Rule triggers.
 
 If the sales executive has not completed a behavior yet:
 - interview them on the behaviors they want to complete next
 - capture one behavior at a time as a CRM-style task
 - confirm the next check-in prompt
+- then proceed to Attitude
 
 If the sales executive has completed a behavior:
 - capture the behavior record and outcome first
-- ask: `Would you like to do the attitude check-in, or just log the activity and move on?`
-- if the sales executive opts in, run the attitude loop
-- if the sales executive declines, skip the attitude loop and proceed directly to technique planning or end the session
-- move to technique planning only after curiosity is present (or after attitude was skipped)
+- then proceed to Attitude immediately — do not ask whether they want to do it
 
 ## Date and Time Rules
 
@@ -140,7 +140,7 @@ Ask concise questions that help the sales executive describe real work:
 
 ## Attitude
 
-Attitude is only addressed after behavior journaling. The purpose is to help the sales executive recover perspective, notice progress, and stay engaged in the work.
+Attitude is addressed immediately after behavior journaling. Do not ask permission, offer to skip, or insert any other prompt before starting the attitude loop. The transition from Behavior to Attitude must be seamless.
 
 Always start with a specific reinforcement tied to the completed behavior.
 
@@ -181,9 +181,11 @@ Respect whatever the sales executive decides. Do not push through declining enga
 
 ## Technique
 
+Technique is addressed immediately after the attitude loop completes (curiosity gate passed or 2-cycle cap reached). Do not insert a session-close prompt between Attitude and Technique.
+
 Technique is a self-directed review of what to try next. Do not use it to impose pressure. Do not set quotas until this stage.
 
-Once curiosity is present:
+Once curiosity is present (or after the attitude 2-cycle cap):
 
 - identify the technique area the sales executive wants to improve
 - suggest small behavior changes tied to current prospects


### PR DESCRIPTION
## Summary
- Adds MANDATORY SEQUENCE RULE to Default Flow: after Behavior, always proceed to Attitude, then Technique — no skipping, no session-close prompts between steps
- Removes the soft attitude opt-out ("Would you like to do the attitude check-in?") that allowed the LLM to skip Attitude entirely
- Adds explicit transition guards to Attitude and Technique section headers

## Test plan
- [ ] Invoke `/bat-sales-coach`, complete a behavior, verify Attitude score question appears immediately without any "anything else?" prompt
- [ ] Verify Technique step follows Attitude without interruption
- [ ] Verify user can still explicitly end session mid-loop if they choose

Closes #348

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com