### PR TITLE
fix(skills): try direct access before searching for tool names

### DIFF
--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -34,11 +34,13 @@ Violations of this rule — asserting capability status without verification —
 
 ## Integration Checks (Optional)
 
-On each invoke, the agent checks for external integration availability:
+On each invoke, the agent checks for external integrations by **trying to use them**, not by searching for tool names:
 
-1. **SharePoint**: Attempt to call `connector.sharepoint.get` or list relevant MCP tools. If available, sync context. If not, say "I checked and SharePoint integration is not connected in this session. You can enable it in SerenDesktop Settings."
-2. **Asana**: Attempt to call `connector.asana.get` or list relevant MCP tools. If available, sync context. If not, say "I checked and Asana integration is not connected in this session."
-3. **Email/Calendar**: Attempt to list available Gmail or Outlook MCP tools. If available, use them to enrich knowledge context. If not, say "I checked and email integration is not connected in this session. You can enable Gmail or Outlook in SerenDesktop Settings."
+1. **SharePoint**: Try calling `connector.sharepoint.get` or any available MCP tool that provides SharePoint access. If it works, sync context. If it fails or no tool exists after a concrete check, say "I checked and SharePoint integration is not available in this session. You can enable it in SerenDesktop Settings."
+2. **Asana**: Try calling `connector.asana.get` or any available MCP tool that provides Asana access. If it works, sync context. If it fails or no tool exists, say "I checked and Asana integration is not available in this session."
+3. **Email/Calendar**: Try direct access first — if Playwright is available, navigate to Gmail or Outlook. If a dedicated email MCP tool exists, call it. Use whatever tools are available. If direct access fails or no relevant tools exist, say "I checked for email access and it is not available in this session. You can enable Gmail or Outlook in SerenDesktop Settings."
+
+**Never search for imagined tool names** (e.g., `gmail_read`, `connector.gmail`). List what tools are actually available and try them. Report on tools you tried, not tools you searched for.
 
 All integrations are optional. The skill works without any of them — it gracefully degrades to guided interview and manual document input.
 

--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -41,12 +41,13 @@ Violations of this rule — asserting capability status without verification —
 
 ## Email/Calendar Integration (Optional)
 
-On each invoke, the agent checks for email/calendar integration availability:
+On each invoke, the agent checks for email/calendar integration by **trying to use it**, not by searching for tool names:
 
-1. Attempt to list available MCP tools or Playwright-accessible services that could provide Gmail or Outlook access.
-2. If an email integration is detected and accessible: use it to enrich coaching context (e.g., pull recent emails from prospects, check calendar for scheduled meetings).
-3. If no email integration is detected after checking: tell the user "I checked for email integration and it is not connected in this session. You can enable Gmail or Outlook in SerenDesktop Settings for richer coaching context."
-4. Do not block the coaching flow — email integration is optional. Proceed with manual context if not available.
+1. **Try direct access first.** If Playwright is available, navigate to Gmail or Outlook and check whether the user is logged in. If a dedicated email MCP tool is available, call it. Use whatever tools exist — do not search for tools you expect to find.
+2. If direct access works: use it to enrich coaching context (e.g., pull recent emails from prospects, check calendar for scheduled meetings).
+3. If direct access fails or no relevant tools exist after a concrete check: tell the user "I checked for email access and it is not available in this session. You can enable Gmail or Outlook in SerenDesktop Settings for richer coaching context."
+4. **Never search for imagined tool names** (e.g., `gmail_read`, `connector.gmail`). List what tools are actually available and try them. Do not report on tools you searched for — report on tools you tried.
+5. Do not block the coaching flow — email integration is optional. Proceed with manual context if not available.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Rewrites Email/Calendar Integration section in `bat-sales-coach` to prioritize trying available tools (Playwright, MCP) over searching for imagined tool names
- Rewrites Integration Checks section in `family-office/knowledge` with the same pattern for SharePoint, Asana, and Email
- Adds explicit prohibition against searching for non-existent tool names (`gmail_read`, `connector.gmail`, etc.)

Closes #353

## Test plan
- [ ] Invoke BAT Sales Coach and ask about email — agent should try Playwright or available tools, not search for `gmail_read`
- [ ] Invoke Knowledge skill and ask about integrations — same behavior
- [ ] Verify coaching flow still works when no email integration is available

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com