### PR TITLE
fix(skills): route email through call_publisher, not Playwright

### DIFF
--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -34,13 +34,13 @@ Violations of this rule — asserting capability status without verification —
 
 ## Integration Checks (Optional)
 
-On each invoke, the agent checks for external integrations by **trying to use them**, not by searching for tool names:
+On each invoke, the agent checks for external integrations by calling them via the standard Seren publisher path — the same way every other skill accesses external services:
 
-1. **SharePoint**: Try calling `connector.sharepoint.get` or any available MCP tool that provides SharePoint access. If it works, sync context. If it fails or no tool exists after a concrete check, say "I checked and SharePoint integration is not available in this session. You can enable it in SerenDesktop Settings."
-2. **Asana**: Try calling `connector.asana.get` or any available MCP tool that provides Asana access. If it works, sync context. If it fails or no tool exists, say "I checked and Asana integration is not available in this session."
-3. **Email/Calendar**: Try direct access first — if Playwright is available, navigate to Gmail or Outlook. If a dedicated email MCP tool exists, call it. Use whatever tools are available. If direct access fails or no relevant tools exist, say "I checked for email access and it is not available in this session. You can enable Gmail or Outlook in SerenDesktop Settings."
+1. **SharePoint**: Call `connector.sharepoint.get` or the SharePoint publisher via `call_publisher`. If it works, sync context. If it fails or is not configured, say "I called the SharePoint publisher and it is not configured in this session. You can enable it in SerenDesktop Settings."
+2. **Asana**: Call `connector.asana.get` or the Asana publisher via `call_publisher`. If it works, sync context. If it fails, say "I called the Asana publisher and it is not configured in this session."
+3. **Email/Calendar**: Call the `gmail` or `outlook` publisher via `call_publisher` to read emails, calendar, or contacts. This is the same pattern used for `alpaca`, `kraken`, `perplexity`, and every other Seren publisher. If the call fails (not configured or OAuth not connected), say "I called the Gmail/Outlook publisher and it is not configured in this session. You can connect it in SerenDesktop Settings."
 
-**Never search for imagined tool names** (e.g., `gmail_read`, `connector.gmail`). List what tools are actually available and try them. Report on tools you tried, not tools you searched for.
+**Do not use Playwright to navigate to Gmail or Outlook.** Playwright is a browser automation tool, not an email API. Do not use it as a workaround for email access.
 
 All integrations are optional. The skill works without any of them — it gracefully degrades to guided interview and manual document input.
 

--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -41,12 +41,12 @@ Violations of this rule — asserting capability status without verification —
 
 ## Email/Calendar Integration (Optional)
 
-On each invoke, the agent checks for email/calendar integration by **trying to use it**, not by searching for tool names:
+Gmail and Microsoft Outlook are available as Seren publishers. Access email the same way every other skill accesses external services — via `call_publisher`.
 
-1. **Try direct access first.** If Playwright is available, navigate to Gmail or Outlook and check whether the user is logged in. If a dedicated email MCP tool is available, call it. Use whatever tools exist — do not search for tools you expect to find.
-2. If direct access works: use it to enrich coaching context (e.g., pull recent emails from prospects, check calendar for scheduled meetings).
-3. If direct access fails or no relevant tools exist after a concrete check: tell the user "I checked for email access and it is not available in this session. You can enable Gmail or Outlook in SerenDesktop Settings for richer coaching context."
-4. **Never search for imagined tool names** (e.g., `gmail_read`, `connector.gmail`). List what tools are actually available and try them. Do not report on tools you searched for — report on tools you tried.
+1. **Call the publisher.** Use `call_publisher` with the `gmail` or `outlook` publisher slug to read emails, calendar, or contacts. This is the same pattern used for `alpaca`, `kraken`, `perplexity`, and every other Seren publisher.
+2. If the call succeeds: use the result to enrich coaching context (e.g., recent emails from prospects, scheduled meetings, contact details).
+3. If the call fails (publisher not configured or OAuth not connected): tell the user "I called the Gmail/Outlook publisher and it is not configured in this session. You can connect it in SerenDesktop Settings for richer coaching context."
+4. **Do not use Playwright to navigate to Gmail.** Playwright is a browser automation tool, not an email API. Do not use it as a workaround for email access.
 5. Do not block the coaching flow — email integration is optional. Proceed with manual context if not available.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Replaces Playwright-first email integration with standard `call_publisher` flow using Gmail/Outlook publishers
- Same pattern as Alpaca, Kraken, Polymarket, Perplexity — email is just another publisher
- Explicitly prohibits Playwright as an email workaround in both `bat-sales-coach` and `family-office/knowledge`
- Root-cause fix for the Playwright-first bias introduced in #354

Closes #355

## Test plan
- [ ] Invoke BAT Sales Coach and ask to check Gmail — agent should call the gmail publisher, not open Playwright
- [ ] Invoke Knowledge skill and ask about email integration — same publisher-first behavior
- [ ] If gmail publisher is not configured, agent should report the call failure gracefully

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com