### PR TITLE
fix(skills): add Schema Guard to prevent silent data loss on first run

### DIFF
--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -18,6 +18,50 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - show me the current working brief
 - what changed since the first brief
 
+## Schema Guard (Mandatory — runs every invoke)
+
+This rule overrides all other instructions and applies before ANY read or write to SerenDB. No data may be read from or written to the database until this guard passes.
+
+**On every invoke**, before loading the current brief or persisting anything:
+
+1. Resolve or create the Seren project for this skill via `list_projects` / `create_project`.
+2. Resolve or create the database for this skill via `list_databases` / `create_database`.
+3. Check whether the required tables exist by running:
+   ```sql
+   SELECT table_name FROM information_schema.tables
+   WHERE table_schema = 'public'
+   AND table_name IN ('knowledge_entries', 'knowledge_transcripts', 'knowledge_briefs', 'knowledge_retrieval_log', 'knowledge_rewards')
+   ```
+4. If **any** of the expected tables are missing, run the full DDL via `run_sql_transaction`:
+   ```sql
+   CREATE TABLE IF NOT EXISTS knowledge_entries (
+     id SERIAL PRIMARY KEY, entry_key TEXT NOT NULL, entry_value TEXT NOT NULL,
+     source TEXT, confidence TEXT, tags TEXT[],
+     created_by TEXT, created_at TIMESTAMPTZ DEFAULT now(),
+     updated_at TIMESTAMPTZ DEFAULT now(), expires_at TIMESTAMPTZ
+   );
+   CREATE TABLE IF NOT EXISTS knowledge_transcripts (
+     id SERIAL PRIMARY KEY, session_id TEXT, transcript TEXT NOT NULL,
+     created_by TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS knowledge_briefs (
+     id SERIAL PRIMARY KEY, brief_version INTEGER DEFAULT 1,
+     brief_content TEXT NOT NULL, entry_ids INTEGER[],
+     created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS knowledge_retrieval_log (
+     id SERIAL PRIMARY KEY, query TEXT, matched_entry_ids INTEGER[],
+     result_summary TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS knowledge_rewards (
+     id SERIAL PRIMARY KEY, user_id TEXT, action TEXT,
+     amount NUMERIC, reason TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   ```
+5. Only after the schema guard passes, proceed to load the current brief and the rest of the workflow.
+
+**Do not skip this guard.** Do not assume tables exist from a prior session. Do not proceed to any read or write if the check has not run. Violations of this rule are P0 data-loss defects.
+
 ## Capability Verification Rule
 
 This rule overrides all other instructions and applies whenever the agent is about to assert that a tool, integration, or external service is available or unavailable.

--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -9,19 +9,67 @@ description: "Supportive sales-executive coaching skill that runs a Behavior-Att
 
 Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
 
-## First-Run Setup
+## Schema Guard (Mandatory — runs every invoke)
 
-The runtime auto-bootstraps BAT storage on first run:
+This rule overrides all other instructions and applies before ANY read or write to SerenDB. No data may be read from or written to the database until this guard passes.
 
-1. Resolves or creates the Seren project `bat-sales-coach`.
-2. Resolves or creates the Seren database `bat_sales_coach`.
-3. Applies the `bat_sales_coach` schema and required tables: `prospects`, `behavior_tasks`, `behavior_journals`, `attitude_journals`, `technique_plans`, `coaching_sessions`.
+**On every invoke**, before loading pipeline context or persisting anything:
+
+1. Resolve or create the Seren project `bat-sales-coach` via `list_projects` / `create_project`.
+2. Resolve or create the Seren database `bat_sales_coach` via `list_databases` / `create_database`.
+3. Check whether the required tables exist by running:
+   ```sql
+   SELECT table_name FROM information_schema.tables
+   WHERE table_schema = 'public'
+   AND table_name IN ('prospects', 'behavior_tasks', 'behavior_journals', 'attitude_journals', 'technique_plans', 'coaching_sessions')
+   ```
+4. If **any** of the 6 tables are missing, run the following DDL via `run_sql_transaction`:
+   ```sql
+   CREATE TABLE IF NOT EXISTS prospects (
+     id SERIAL PRIMARY KEY, name TEXT NOT NULL, organization TEXT, email TEXT,
+     phone TEXT, pipeline_stage TEXT, opportunity_value NUMERIC,
+     expected_close_date TEXT, notes TEXT,
+     created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS behavior_tasks (
+     id SERIAL PRIMARY KEY, prospect_name TEXT, organization TEXT,
+     pipeline_stage TEXT, title TEXT NOT NULL, status TEXT DEFAULT 'planned',
+     due_date TEXT, start_time TIMESTAMPTZ, completion_time TIMESTAMPTZ,
+     opportunity_value NUMERIC, expected_close_date TEXT,
+     prospect_response TEXT, next_behavior TEXT,
+     created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS behavior_journals (
+     id SERIAL PRIMARY KEY, behavior_task_id INTEGER REFERENCES behavior_tasks(id),
+     journal_entry TEXT, outcome TEXT, wins TEXT,
+     created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS attitude_journals (
+     id SERIAL PRIMARY KEY, session_id INTEGER, score INTEGER,
+     feeling_note TEXT, can_tell_future TEXT, curiosity TEXT,
+     created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS technique_plans (
+     id SERIAL PRIMARY KEY, session_id INTEGER, technique_area TEXT,
+     behavior_experiment TEXT, practice_focus TEXT, behavior_quota TEXT,
+     next_steps TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS coaching_sessions (
+     id SERIAL PRIMARY KEY, session_date TIMESTAMPTZ DEFAULT now(),
+     behavior_completed BOOLEAN, attitude_completed BOOLEAN,
+     technique_completed BOOLEAN, notes TEXT,
+     created_at TIMESTAMPTZ DEFAULT now()
+   );
+   ```
+5. Only after the schema guard passes, proceed to the Returning-User Behavior Check.
+
+**Do not skip this guard.** Do not assume tables exist from a prior session. Do not proceed to any read or write if the check has not run. Violations of this rule are P0 data-loss defects.
 
 If `SEREN_API_KEY` is missing, the runtime fails immediately with a setup message pointing to `https://docs.serendb.com/skills.md`.
 
 ## Returning-User Behavior Check
 
-On each invoke, the skill queries `behavior_tasks` for planned behaviors due today or earlier:
+On each invoke (after the Schema Guard passes), the skill queries `behavior_tasks` for planned behaviors due today or earlier:
 - If behaviors are due, display them in a table and ask the sales executive which they completed.
 - If no behaviors are due, proceed directly to the behavior interview for new tasks.
 


### PR DESCRIPTION
## Summary
- Both `bat-sales-coach` and `knowledge` skills claimed "auto-bootstrap" but had no DDL or table-existence check
- Users could work a full session with zero data persisted because tables were never created
- Adds a **Schema Guard** section to both skills that runs on every invoke:
  1. Checks `information_schema.tables` for expected tables
  2. Applies `CREATE TABLE IF NOT EXISTS` via `run_sql_transaction` if any are missing
  3. Blocks all reads/writes until the guard passes

## Test plan
- [ ] Invoke BAT Sales Coach on a fresh database — schema guard should create tables before any persist
- [ ] Invoke Knowledge skill on a fresh database — same behavior
- [ ] Re-invoke on existing database — guard should pass instantly (idempotent)
- [ ] Verify no data loss: behavior entered during session must be queryable after session

Closes #357

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com