### PR TITLE
fix(bat-sales-coach): add Behavior Readiness Check before Attitude transition

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -193,17 +193,27 @@ then immediately:
 
 Start with `Behavior` every time. The loop is **Behavior → Attitude → Technique**, in that order.
 
-**MANDATORY SEQUENCE RULE**: After Behavior completes, ALWAYS proceed to Attitude. After Attitude completes, ALWAYS proceed to Technique. Never skip a step. Never insert a session-close prompt, summary, or "anything else?" question between steps. The only valid exit before the full loop completes is if the user explicitly ends the session or the Distress Escalation Rule triggers.
+**MANDATORY SEQUENCE RULE**: After Behavior completes, ALWAYS proceed to Attitude. After Attitude completes, ALWAYS proceed to Technique. Never skip a step. The only valid exit before the full loop completes is if the user explicitly ends the session or the Distress Escalation Rule triggers.
 
 If the sales executive has not completed a behavior yet:
 - interview them on the behaviors they want to complete next
 - capture one behavior at a time as a CRM-style task
 - confirm the next check-in prompt
-- then proceed to Attitude
+- then proceed to the Behavior Readiness Check
 
 If the sales executive has completed a behavior:
 - capture the behavior record and outcome first
-- then proceed to Attitude immediately — do not ask whether they want to do it
+- then proceed to the Behavior Readiness Check
+
+## Behavior Readiness Check
+
+After all reported behaviors have been journaled, ask the sales executive whether they are finished with behaviors and ready to move on. Use a warm, open check-in — not a yes/no gate.
+
+Example: `That covers everything you mentioned. Is there anything else you want to log before we move to your attitude check?`
+
+- If the sales executive has more behaviors to report, capture them using the Behavior Interview before asking again.
+- If the sales executive confirms they are done, proceed to Attitude.
+- Do not skip this check. The purpose is to give the sales executive agency over the pacing of the session so they feel good about completing the behavior step before transitioning.
 
 ## Date and Time Rules
 
@@ -256,7 +266,7 @@ Ask concise questions that help the sales executive describe real work:
 
 ## Attitude
 
-Attitude is addressed immediately after behavior journaling. Do not ask permission, offer to skip, or insert any other prompt before starting the attitude loop. The transition from Behavior to Attitude must be seamless.
+Attitude is addressed after the Behavior Readiness Check confirms the sales executive is done journaling. Do not offer to skip or end the session between Behavior and Attitude. Once the readiness check passes, transition directly into the attitude loop.
 
 Always start with a specific reinforcement tied to the completed behavior.
 


### PR DESCRIPTION
## Summary
- Adds a **Behavior Readiness Check** section to SKILL.md that asks the sales executive if they are finished journaling before transitioning to Attitude
- Updates Default Flow to route through the readiness check instead of jumping straight to Attitude
- Updates Attitude section header to reference the readiness check instead of claiming immediate/seamless transition
- Preserves the mandatory B->A->T sequence — this is a pacing improvement, not a skip gate

Closes #363

## Test plan
- [ ] Invoke BAT Sales Coach with completed behaviors and verify the coach asks if you are done before starting attitude
- [ ] Confirm that saying you have more behaviors lets you log them
- [ ] Confirm that confirming readiness proceeds to attitude score question
- [ ] Confirm the B->A->T sequence still cannot be skipped

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com