### PR TITLE
feat: publish skill seren/serenbucks-affiliate-outreach

### DIFF
--- a/seren/serenbucks-affiliate-outreach/.env.example
+++ b/seren/serenbucks-affiliate-outreach/.env.example
@@ -1,0 +1,3 @@
+# SerenBucks Affiliate Outreach environment template
+# Use Seren Desktop injected auth when available. Otherwise set SEREN_API_KEY.
+SEREN_API_KEY=

--- a/seren/serenbucks-affiliate-outreach/.gitignore
+++ b/seren/serenbucks-affiliate-outreach/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+state/
+*.pyc

--- a/seren/serenbucks-affiliate-outreach/README.md
+++ b/seren/serenbucks-affiliate-outreach/README.md
@@ -1,0 +1,21 @@
+# SerenBucks Affiliate Outreach
+
+Review-first skill bundle for operating a single SerenBucks affiliate campaign.
+
+## What this package includes
+
+- `SKILL.md` with the v1 operating contract
+- `config.example.json` with one campaign, one tracked link, and manual-review defaults
+- `serendb_schema.sql` with CRM, approval, DNC, and digest tables
+- `scripts/` runtime stubs for bootstrap, sync, ranking, drafting, send-approval, reconciliation, and digest assembly
+- `references/` docs for the state machine, provider mapping, schema summary, and output contract
+
+## Local commands
+
+```bash
+python3 scripts/agent.py --config config.json
+python3 scripts/agent.py --config config.json --command bootstrap
+python3 scripts/agent.py --config config.json --command digest
+```
+
+The runtime is intentionally stubbed in v1 packaging. The contract, schema, and operator workflow are the primary deliverables.

--- a/seren/serenbucks-affiliate-outreach/SKILL.md
+++ b/seren/serenbucks-affiliate-outreach/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: serenbucks-affiliate-outreach
+description: "Review-first outreach skill for the default SerenBucks affiliate campaign. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest."
+---
+
+# SerenBucks Affiliate Outreach
+
+Review-first growth skill for one default SerenBucks affiliate campaign.
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## Default V1 Contract
+
+- The skill operates exactly one default affiliate campaign in v1.
+- The skill uses exactly one default tracked link in every draft and digest unless the operator explicitly overrides it.
+- `seren-affiliates` is the sole source of truth for affiliate performance and conversion reporting.
+- Candidate discovery is limited to Gmail sent mail, Outlook sent mail, Gmail address books, and Outlook address books.
+- Every discovered candidate is persisted immediately into the skill-owned SerenDB before ranking or drafting.
+- The skill-owned database is the CRM and memory source of truth for candidate state, proposal history, approvals, replies, DNC, and digests.
+- The daily operator surface is `manual + daily digest`.
+- The operator receives an editable top-10 proposal set.
+- New outbound messages are batch-prepared only after approval.
+- Reply drafts also require approval.
+- The v1 cap is `10` brand-new outbound messages per day.
+- Replies do **not** count against the `10` new-outbound cap.
+- Negative reply signals, unsubscribe requests, and hostile-negative responses create a hard DNC block immediately.
+- Partial provider failure degrades gracefully only after auth, database, and affiliate bootstrap succeed.
+
+## Bootstrap Order (Mandatory)
+
+This rule overrides all other instructions and runs before any candidate sync, ranking, or drafting:
+
+1. Resolve auth in this order:
+   - Seren Desktop injected auth (`API_KEY`)
+   - `SEREN_API_KEY`
+   - fail with a setup message pointing to `https://docs.serendb.com/skills.md`
+2. Resolve or create the Seren project `seren-affiliate-outreach`.
+3. Resolve or create the Seren database `serenbucks_affiliate_outreach`.
+4. Bootstrap the default campaign context from `seren-affiliates`.
+5. Retry affiliate bootstrap up to **3 immediate attempts**.
+6. If affiliate bootstrap still fails, **fail closed** and do not continue.
+7. Only after bootstrap succeeds may the skill read candidate sources, rank candidates, or draft outreach.
+
+## Capability Verification Rule
+
+Before claiming any tool, connector, or publisher exists or does not exist, attempt to verify it by calling the relevant tool or connector.
+
+- If the verification succeeds, proceed and say what was found.
+- If it fails, say: `I checked and [tool/integration] is not available in this session.`
+- Never claim Gmail, Outlook, or `seren-affiliates` availability from memory or assumption.
+
+## When to Use
+
+- grow SerenBucks affiliate signups
+- draft SerenBucks affiliate outreach
+- review the daily affiliate digest
+- sync affiliate candidates from Gmail or Outlook
+- reconcile affiliate replies and unsubscribe events
+
+## Candidate Sources (V1 Only)
+
+Use only these sources in v1:
+
+1. Gmail sent folder
+2. Outlook sent folder
+3. Gmail address books
+4. Outlook address books
+
+Do not expand to LinkedIn, Apollo, web scraping, or purchased lists in v1.
+
+## Persistence Rule
+
+Whenever a candidate is discovered or updated:
+
+1. Normalize the person into a candidate profile.
+2. Upsert the candidate into the skill-owned SerenDB immediately.
+3. Record the source event that produced or refreshed the candidate.
+4. Preserve DNC status across future syncs.
+5. Treat the skill-owned database as the CRM source of truth afterward, even if the original source is temporarily unavailable.
+
+Failure to persist newly discovered candidates before ranking is a P0 defect.
+
+## Proposal and Drafting Loop
+
+After bootstrap passes:
+
+1. Load active non-DNC candidates from the skill-owned CRM.
+2. Score and rank the candidate universe.
+3. Produce an editable top-10 proposal set.
+4. Draft:
+   - a batch of **new outbound** messages capped at `10` per day
+   - a batch of **reply drafts** for candidates who responded
+5. Mark both new outbound and replies as `approval_required`.
+6. Do not send anything automatically in v1.
+
+## Reply and DNC Handling
+
+- Any reply classified as `unsubscribe`, `do_not_contact`, or `hostile_negative` must:
+  - create a DNC event immediately
+  - update the candidate to hard-blocked
+  - exclude that candidate from future proposals and drafts
+- Replies always require approval before sending.
+- Replies do not count against the new-outbound daily cap.
+
+## Partial Failure Rule
+
+After auth, database, and affiliate bootstrap succeed:
+
+- If Gmail fails but Outlook works, continue with Outlook and mark provider health as degraded.
+- If Outlook fails but Gmail works, continue with Gmail and mark provider health as degraded.
+- If one address-book source fails but sent-mail history still works, continue and note the degraded source.
+- If all candidate sources fail after bootstrap, return a blocked digest with clear remediation steps.
+
+## Daily Operator Surface
+
+Return one manual digest per run with:
+
+- campaign identity
+- tracked link in use
+- affiliate feed health
+- auth path used
+- candidate sync counts by source
+- editable top-10 summary
+- pending approval queues
+- DNC changes
+- reply queue summary
+- daily cap usage for new outbound
+- next recommended operator actions
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `bootstrap_auth_and_db` uses `transform.bootstrap_auth_and_db`
+3. `bootstrap_affiliate_context` uses `connector.affiliates.get`
+4. `sync_candidates_from_sent_history` uses `transform.sync_candidates_from_sent_history`
+5. `sync_candidates_from_address_books` uses `transform.sync_candidates_from_address_books`
+6. `persist_candidates` uses `connector.storage.upsert`
+7. `rank_candidate_universe` uses `transform.rank_candidate_universe`
+8. `build_editable_top10` uses `transform.build_editable_top10`
+9. `draft_batches` uses `transform.draft_review_batches`
+10. `reconcile_signals` uses `transform.reconcile_affiliate_and_reply_signals`
+11. `persist_run_state` uses `connector.storage.upsert`
+12. `render_digest` uses `transform.render_manual_daily_digest`
+
+## Output Expectations
+
+Every run should return:
+
+- campaign id and tracked link
+- auth path used
+- affiliate bootstrap/feed status
+- database/bootstrap status
+- provider health by source
+- candidate sync counts
+- proposal top-10 summary
+- pending approvals for new outbound and replies
+- DNC events raised in the run
+- new-outbound cap usage with replies explicitly excluded
+- operator-facing daily digest
+
+## Acceptance Criteria
+
+1. The skill always resolves exactly one default campaign and one tracked link in v1.
+2. Affiliate bootstrap happens before any candidate sync or drafting.
+3. Affiliate bootstrap retries up to 3 immediate attempts, then fails closed.
+4. Candidate discovery is restricted to Gmail/Outlook sent history and address books.
+5. Discovered candidates are persisted before ranking.
+6. The skill-owned database remains the CRM source of truth.
+7. The proposal surface is an editable top-10.
+8. New outbound requires approval.
+9. Replies require approval.
+10. New outbound is capped at 10 per day.
+11. Replies do not count against the new-outbound cap.
+12. DNC is a hard stop on unsubscribe, do-not-contact, and hostile-negative signals.
+13. Partial source failure degrades gracefully after prerequisites pass.
+
+## Rollout Order
+
+1. Bootstrap only: auth, DB, affiliate campaign resolution.
+2. Candidate sync only: sent mail and address books into CRM.
+3. Ranking only: editable top-10 without draft sending.
+4. Drafting only: approval queues for new outbound and replies.
+5. Reconciliation only: DNC and affiliate conversion updates.
+6. Manual daily digest tying all steps together.
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_request`
+2. `bootstrap_auth_and_db` uses `transform.bootstrap_auth_and_db`
+3. `bootstrap_affiliate_context` uses `connector.affiliates.get`
+4. `sync_candidates_from_sent_history` uses `transform.sync_candidates_from_sent_history`
+5. `sync_candidates_from_address_books` uses `transform.sync_candidates_from_address_books`
+6. `persist_candidates` uses `connector.storage.upsert`
+7. `rank_candidate_universe` uses `transform.rank_candidate_universe`
+8. `build_editable_top10` uses `transform.build_editable_top10`
+9. `draft_batches` uses `transform.draft_review_batches`
+10. `reconcile_signals` uses `transform.reconcile_affiliate_and_reply_signals`
+11. `persist_run_state` uses `connector.storage.upsert`
+12. `render_digest` uses `transform.render_manual_daily_digest`

--- a/seren/serenbucks-affiliate-outreach/config.example.json
+++ b/seren/serenbucks-affiliate-outreach/config.example.json
@@ -1,0 +1,60 @@
+{
+  "dry_run": true,
+  "skill": "serenbucks-affiliate-outreach",
+  "campaign": {
+    "campaign_id": "serenbucks-default",
+    "campaign_name": "SerenBucks Default Affiliate Campaign",
+    "tracked_link": "https://seren.ai/serenbucks?ref=default",
+    "affiliate_source_of_truth": "seren-affiliates"
+  },
+  "database": {
+    "project": "seren-affiliate-outreach",
+    "name": "serenbucks_affiliate_outreach"
+  },
+  "auth": {
+    "desktop_auth_first": true,
+    "api_key_env": "SEREN_API_KEY",
+    "setup_url": "https://docs.serendb.com/skills.md"
+  },
+  "candidate_sources": {
+    "gmail_sent": true,
+    "outlook_sent": true,
+    "gmail_contacts": true,
+    "outlook_contacts": true
+  },
+  "approval": {
+    "new_outbound_requires_approval": true,
+    "replies_require_approval": true
+  },
+  "limits": {
+    "proposal_size": 10,
+    "new_outbound_daily_cap": 10,
+    "replies_count_against_daily_cap": false
+  },
+  "dnc": {
+    "hard_stop_signals": [
+      "unsubscribe",
+      "do_not_contact",
+      "hostile_negative"
+    ]
+  },
+  "inputs": {
+    "command": "run",
+    "json_output": false,
+    "proposal_size": 10,
+    "new_outbound_daily_cap": 10,
+    "strict_mode": true,
+    "tracked_link": "https://seren.ai/serenbucks?ref=default"
+  },
+  "connectors": [
+    "affiliates",
+    "storage",
+    "gmail",
+    "outlook",
+    "model"
+  ],
+  "simulate": {
+    "affiliate_bootstrap_failure": false,
+    "reply_signal": ""
+  }
+}

--- a/seren/serenbucks-affiliate-outreach/references/daily-digest-template.md
+++ b/seren/serenbucks-affiliate-outreach/references/daily-digest-template.md
@@ -1,0 +1,44 @@
+# SerenBucks Affiliate Outreach V1 Daily Digest Template
+
+## Campaign
+
+- Campaign:
+- Tracked link:
+- Affiliate feed health:
+- Auth path:
+
+## Candidate Sync
+
+- Gmail sent:
+- Outlook sent:
+- Gmail contacts:
+- Outlook contacts:
+- Provider health:
+
+## Proposal Top 10
+
+- Ranked candidates:
+- Editable changes:
+
+## Approval Queues
+
+- New outbound pending:
+- Replies pending:
+
+## DNC and Replies
+
+- New DNC events:
+- Reply queue summary:
+
+## Daily Cap
+
+- New outbound used:
+- New outbound remaining:
+- Replies excluded from cap:
+
+## Operator Actions
+
+- Review proposal edits
+- Approve outbound batch
+- Approve reply batch
+- Resolve degraded providers if any

--- a/seren/serenbucks-affiliate-outreach/references/output-contract.md
+++ b/seren/serenbucks-affiliate-outreach/references/output-contract.md
@@ -1,0 +1,22 @@
+# SerenBucks Affiliate Outreach V1 Output Contract
+
+Return the operator-facing digest first, then the structured payload.
+
+Required payload fields:
+
+- `run_status`
+- `mode`
+- `generated_at`
+- `campaign`
+- `tracked_link`
+- `auth_path`
+- `affiliate_feed_status`
+- `database_status`
+- `provider_health`
+- `candidate_sync`
+- `proposal_top10`
+- `pending_approvals`
+- `dnc_events`
+- `daily_cap`
+- `daily_digest`
+- `audit`

--- a/seren/serenbucks-affiliate-outreach/references/provider-mappings.md
+++ b/seren/serenbucks-affiliate-outreach/references/provider-mappings.md
@@ -1,0 +1,14 @@
+# SerenBucks Affiliate Outreach V1 Provider Mapping
+
+| Capability | Provider | Role in v1 |
+| --- | --- | --- |
+| Affiliate attribution and performance | `seren-affiliates` | Source of truth for campaign metrics |
+| Gmail sent history and address books | `gmail` | Candidate discovery input |
+| Outlook sent history and address books | `outlook` | Candidate discovery input |
+| Skill-owned CRM and run memory | `serendb` | Source of truth after persistence |
+| Draft generation support | `seren-models` | Optional drafting and rewrite support |
+
+## Degradation behavior
+
+- `seren-affiliates` failure before bootstrap completion blocks the run.
+- Gmail or Outlook failure after bootstrap degrades the run but does not block if at least one candidate source remains available.

--- a/seren/serenbucks-affiliate-outreach/references/serendb-schema.md
+++ b/seren/serenbucks-affiliate-outreach/references/serendb-schema.md
@@ -1,0 +1,23 @@
+# SerenBucks Affiliate Outreach V1 SerenDB Schema
+
+The v1 schema is split into five responsibilities:
+
+1. Campaign and run control
+   - `campaign_state`
+   - `affiliate_runs`
+2. Candidate CRM memory
+   - `candidate_profiles`
+   - `candidate_source_events`
+3. Proposal and draft review
+   - `proposal_sets`
+   - `proposal_items`
+   - `message_drafts`
+   - `approval_events`
+   - `send_batches`
+4. Reply and suppression handling
+   - `reply_events`
+   - `dnc_events`
+5. Operator summaries
+   - `daily_digests`
+
+The skill-owned SerenDB remains the CRM source of truth once a candidate has been persisted.

--- a/seren/serenbucks-affiliate-outreach/references/state-machine.md
+++ b/seren/serenbucks-affiliate-outreach/references/state-machine.md
@@ -1,0 +1,26 @@
+# SerenBucks Affiliate Outreach V1 State Machine
+
+## Primary states
+
+1. `bootstrap_pending`
+2. `auth_ready`
+3. `db_ready`
+4. `affiliate_context_ready`
+5. `candidate_sync_complete`
+6. `proposal_ready`
+7. `drafts_pending_approval`
+8. `reconcile_complete`
+9. `digest_ready`
+
+## Blocking states
+
+- `auth_setup_required`
+- `affiliate_bootstrap_failed`
+- `all_candidate_sources_failed`
+- `dnc_blocked`
+
+## Rules
+
+- No transition into candidate sync occurs before `affiliate_context_ready`.
+- `drafts_pending_approval` is the default terminal state for new outbound and reply batches in v1.
+- `dnc_blocked` removes the candidate from future proposal states immediately.

--- a/seren/serenbucks-affiliate-outreach/requirements.txt
+++ b/seren/serenbucks-affiliate-outreach/requirements.txt
@@ -1,0 +1,1 @@
+# No third-party runtime dependencies are required for serenbucks-affiliate-outreach.

--- a/seren/serenbucks-affiliate-outreach/scripts/agent.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/agent.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Runtime stub for serenbucks-affiliate-outreach."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from bootstrap import bootstrap_affiliate_context, bootstrap_auth_and_db
+from candidate_sync import sync_candidates
+from common import load_config, utc_now
+from digest import build_daily_digest
+from drafting import build_draft_batches
+from ranking import build_editable_top10
+from reconcile import reconcile_signals
+from sending import prepare_send_actions
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the SerenBucks affiliate outreach stub.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to the runtime config file.",
+    )
+    parser.add_argument(
+        "--command",
+        default=None,
+        choices=["bootstrap", "run", "status", "sync", "draft", "reconcile", "digest"],
+        help="Optional command override. Defaults to config.inputs.command.",
+    )
+    return parser.parse_args()
+
+
+def _bootstrap_only(config: dict) -> dict:
+    auth_db = bootstrap_auth_and_db(config)
+    if auth_db["status"] != "ok":
+        return {
+            "run_status": "blocked",
+            "mode": "bootstrap",
+            "generated_at": utc_now(),
+            "error": auth_db,
+        }
+
+    affiliate = bootstrap_affiliate_context(config)
+    if affiliate["status"] != "ok":
+        return {
+            "run_status": "blocked",
+            "mode": "bootstrap",
+            "generated_at": utc_now(),
+            "auth_path": auth_db["auth_path"],
+            "error": affiliate,
+        }
+
+    return {
+        "run_status": "ok",
+        "mode": "bootstrap",
+        "generated_at": utc_now(),
+        "auth_path": auth_db["auth_path"],
+        "database_status": auth_db["database_status"],
+        "campaign": affiliate["campaign"],
+        "affiliate_feed_status": affiliate["affiliate_feed_status"],
+    }
+
+
+def _status(config: dict) -> dict:
+    return {
+        "run_status": "ok",
+        "mode": "status",
+        "generated_at": utc_now(),
+        "campaign": config["campaign"],
+        "database": config["database"],
+        "limits": config["limits"],
+        "approval": config["approval"],
+        "dnc": config["dnc"],
+        "daily_mode": "manual+digest",
+    }
+
+
+def _run_pipeline(config: dict, *, mode: str) -> dict:
+    auth_db = bootstrap_auth_and_db(config)
+    if auth_db["status"] != "ok":
+        return {
+            "run_status": "blocked",
+            "mode": mode,
+            "generated_at": utc_now(),
+            "error": auth_db,
+        }
+
+    affiliate = bootstrap_affiliate_context(config)
+    if affiliate["status"] != "ok":
+        return {
+            "run_status": "blocked",
+            "mode": mode,
+            "generated_at": utc_now(),
+            "auth_path": auth_db["auth_path"],
+            "error": affiliate,
+        }
+
+    sync_result = sync_candidates(config)
+    proposal = build_editable_top10(sync_result["candidates"], config)
+    drafts = build_draft_batches(proposal, config)
+    send_plan = prepare_send_actions(drafts, config)
+    reconciliation = reconcile_signals(config, sync_result, drafts)
+    digest = build_daily_digest(
+        config=config,
+        auth_db=auth_db,
+        affiliate=affiliate,
+        sync_result=sync_result,
+        proposal=proposal,
+        drafts=drafts,
+        send_plan=send_plan,
+        reconciliation=reconciliation,
+    )
+
+    if mode == "sync":
+        payload = sync_result
+    elif mode == "draft":
+        payload = {
+            "proposal_top10": proposal,
+            "drafts": drafts,
+            "pending_approvals": send_plan,
+        }
+    elif mode == "reconcile":
+        payload = reconciliation
+    elif mode == "digest":
+        payload = {"daily_digest": digest}
+    else:
+        payload = {
+            "campaign": affiliate["campaign"],
+            "affiliate_feed_status": affiliate["affiliate_feed_status"],
+            "database_status": auth_db["database_status"],
+            "provider_health": reconciliation["provider_health"],
+            "candidate_sync": sync_result,
+            "proposal_top10": proposal,
+            "pending_approvals": send_plan,
+            "dnc_events": reconciliation["dnc_events"],
+            "daily_cap": digest["daily_cap"],
+            "daily_digest": digest,
+            "audit": reconciliation["audit"],
+        }
+
+    return {
+        "skill": "serenbucks-affiliate-outreach",
+        "run_status": "ok",
+        "mode": mode,
+        "generated_at": utc_now(),
+        "auth_path": auth_db["auth_path"],
+        **payload,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    command = args.command or config["inputs"].get("command", "run")
+
+    if command == "bootstrap":
+        result = _bootstrap_only(config)
+    elif command == "status":
+        result = _status(config)
+    else:
+        result = _run_pipeline(config, mode=command)
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seren/serenbucks-affiliate-outreach/scripts/bootstrap.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/bootstrap.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from common import select_auth_path, tracked_link
+
+
+def bootstrap_auth_and_db(config: dict) -> dict:
+    auth_path = select_auth_path(config)
+    if auth_path == "setup_required":
+        return {
+            "status": "error",
+            "error_code": "auth_setup_required",
+            "message": "No Seren Desktop auth or SEREN_API_KEY was found.",
+            "setup_url": config["auth"]["setup_url"],
+        }
+
+    return {
+        "status": "ok",
+        "auth_path": auth_path,
+        "database_status": "ready",
+        "database": config["database"],
+    }
+
+
+def bootstrap_affiliate_context(config: dict) -> dict:
+    failure = bool(config.get("simulate", {}).get("affiliate_bootstrap_failure", False))
+    if failure:
+        return {
+            "status": "error",
+            "error_code": "affiliate_bootstrap_failed",
+            "affiliate_feed_status": "unavailable",
+            "retry_count": 3,
+            "fail_closed": True,
+            "message": "Default affiliate campaign context failed three immediate bootstrap attempts.",
+        }
+
+    campaign = {
+        "campaign_id": config["campaign"]["campaign_id"],
+        "campaign_name": config["campaign"]["campaign_name"],
+        "tracked_link": tracked_link(config),
+        "source_of_truth": config["campaign"]["affiliate_source_of_truth"],
+    }
+    return {
+        "status": "ok",
+        "retry_count": 1,
+        "affiliate_feed_status": "ready",
+        "campaign": campaign,
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/candidate_sync.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/candidate_sync.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+
+SOURCE_CATALOG = {
+    "gmail_sent": [
+        {
+            "candidate_id": "cand-amelia-ross",
+            "full_name": "Amelia Ross",
+            "email": "amelia@studioalpha.com",
+            "organization": "Studio Alpha",
+            "source_system": "gmail_sent",
+            "relationship_hint": "warm",
+            "candidate_score": 93,
+            "dnc_status": "active",
+        },
+        {
+            "candidate_id": "cand-daniel-kim",
+            "full_name": "Daniel Kim",
+            "email": "daniel@northdock.com",
+            "organization": "North Dock",
+            "source_system": "gmail_sent",
+            "relationship_hint": "warm",
+            "candidate_score": 88,
+            "dnc_status": "active",
+        },
+    ],
+    "outlook_sent": [
+        {
+            "candidate_id": "cand-zoe-patel",
+            "full_name": "Zoe Patel",
+            "email": "zoe@relayops.io",
+            "organization": "RelayOps",
+            "source_system": "outlook_sent",
+            "relationship_hint": "warm",
+            "candidate_score": 90,
+            "dnc_status": "active",
+        }
+    ],
+    "gmail_contacts": [
+        {
+            "candidate_id": "cand-mika-jones",
+            "full_name": "Mika Jones",
+            "email": "mika@signalfield.com",
+            "organization": "SignalField",
+            "source_system": "gmail_contacts",
+            "relationship_hint": "cold",
+            "candidate_score": 81,
+            "dnc_status": "active",
+        }
+    ],
+    "outlook_contacts": [
+        {
+            "candidate_id": "cand-ivy-cole",
+            "full_name": "Ivy Cole",
+            "email": "ivy@meridianhq.com",
+            "organization": "Meridian HQ",
+            "source_system": "outlook_contacts",
+            "relationship_hint": "cold",
+            "candidate_score": 79,
+            "dnc_status": "active",
+        }
+    ],
+}
+
+
+def sync_candidates(config: dict) -> dict:
+    source_flags = config["candidate_sources"]
+    source_counts: dict[str, int] = {}
+    candidates_by_id: dict[str, dict] = {}
+
+    for source_name, enabled in source_flags.items():
+        if not enabled:
+            source_counts[source_name] = 0
+            continue
+
+        source_items = SOURCE_CATALOG.get(source_name, [])
+        source_counts[source_name] = len(source_items)
+        for item in source_items:
+            candidates_by_id[item["candidate_id"]] = item
+
+    candidates = sorted(
+        candidates_by_id.values(),
+        key=lambda item: item["candidate_score"],
+        reverse=True,
+    )
+
+    return {
+        "status": "ok",
+        "persist_immediately": True,
+        "crm_source_of_truth": "skill_owned_serendb",
+        "source_counts": source_counts,
+        "discovered_count": len(candidates),
+        "candidates": candidates,
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/common.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/common.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import os
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "dry_run": True,
+    "skill": "serenbucks-affiliate-outreach",
+    "campaign": {
+        "campaign_id": "serenbucks-default",
+        "campaign_name": "SerenBucks Default Affiliate Campaign",
+        "tracked_link": "https://seren.ai/serenbucks?ref=default",
+        "affiliate_source_of_truth": "seren-affiliates",
+    },
+    "database": {
+        "project": "seren-affiliate-outreach",
+        "name": "serenbucks_affiliate_outreach",
+    },
+    "auth": {
+        "desktop_auth_first": True,
+        "api_key_env": "SEREN_API_KEY",
+        "setup_url": "https://docs.serendb.com/skills.md",
+    },
+    "candidate_sources": {
+        "gmail_sent": True,
+        "outlook_sent": True,
+        "gmail_contacts": True,
+        "outlook_contacts": True,
+    },
+    "approval": {
+        "new_outbound_requires_approval": True,
+        "replies_require_approval": True,
+    },
+    "limits": {
+        "proposal_size": 10,
+        "new_outbound_daily_cap": 10,
+        "replies_count_against_daily_cap": False,
+    },
+    "dnc": {
+        "hard_stop_signals": [
+            "unsubscribe",
+            "do_not_contact",
+            "hostile_negative",
+        ]
+    },
+    "inputs": {
+        "command": "run",
+        "json_output": False,
+        "proposal_size": 10,
+        "new_outbound_daily_cap": 10,
+        "strict_mode": True,
+        "tracked_link": "https://seren.ai/serenbucks?ref=default",
+    },
+    "simulate": {
+        "affiliate_bootstrap_failure": False,
+        "reply_signal": "",
+    },
+}
+
+
+def utc_now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(merged.get(key), dict)
+        ):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = Path(config_path)
+    if not path.exists():
+        return deepcopy(DEFAULT_CONFIG)
+    return deep_merge(DEFAULT_CONFIG, json.loads(path.read_text(encoding="utf-8")))
+
+
+def tracked_link(config: dict[str, Any]) -> str:
+    return str(config["inputs"].get("tracked_link") or config["campaign"]["tracked_link"])
+
+
+def proposal_size(config: dict[str, Any]) -> int:
+    value = int(config["inputs"].get("proposal_size", config["limits"]["proposal_size"]))
+    return max(1, min(value, 10))
+
+
+def daily_cap(config: dict[str, Any]) -> int:
+    value = int(
+        config["inputs"].get(
+            "new_outbound_daily_cap",
+            config["limits"]["new_outbound_daily_cap"],
+        )
+    )
+    return max(1, min(value, 10))
+
+
+def select_auth_path(config: dict[str, Any]) -> str:
+    desktop_auth_first = bool(config["auth"].get("desktop_auth_first", True))
+    if desktop_auth_first and os.environ.get("API_KEY"):
+        return "seren_desktop"
+    if os.environ.get(config["auth"].get("api_key_env", "SEREN_API_KEY")):
+        return "seren_api_key"
+    return "setup_required"
+
+
+def reply_signal(config: dict[str, Any]) -> str:
+    return str(config.get("simulate", {}).get("reply_signal", "")).strip().lower()

--- a/seren/serenbucks-affiliate-outreach/scripts/digest.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/digest.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from common import daily_cap, tracked_link
+
+
+def build_daily_digest(
+    *,
+    config: dict,
+    auth_db: dict,
+    affiliate: dict,
+    sync_result: dict,
+    proposal: dict,
+    drafts: dict,
+    send_plan: dict,
+    reconciliation: dict,
+) -> dict:
+    cap = daily_cap(config)
+    used = len(drafts["new_outbound"])
+    remaining = max(cap - used, 0)
+
+    proposal_lines = [
+        f"{item['rank_position']}. {item['full_name']} ({item['organization']})"
+        for item in proposal["top10"]
+    ]
+    digest_markdown = "\n".join(
+        [
+            "# SerenBucks Affiliate Outreach",
+            "",
+            "## Campaign",
+            f"- Campaign: {affiliate['campaign']['campaign_name']}",
+            f"- Tracked link: {tracked_link(config)}",
+            f"- Affiliate feed health: {affiliate['affiliate_feed_status']}",
+            f"- Auth path: {auth_db['auth_path']}",
+            "",
+            "## Candidate Sync",
+            f"- Discovered candidates: {sync_result['discovered_count']}",
+            f"- Source counts: {sync_result['source_counts']}",
+            "",
+            "## Proposal Top 10",
+            *[f"- {line}" for line in proposal_lines],
+            "",
+            "## Approvals",
+            f"- New outbound pending: {send_plan['new_outbound_batch']['count']}",
+            f"- Replies pending: {send_plan['reply_batch']['count']}",
+            "",
+            "## DNC",
+            f"- New hard-stop events: {len(reconciliation['dnc_events'])}",
+            "",
+            "## Daily Cap",
+            f"- New outbound used: {used}/{cap}",
+            f"- New outbound remaining: {remaining}",
+            "- Replies excluded from cap: true",
+        ]
+    )
+
+    return {
+        "status": "ok",
+        "markdown": digest_markdown,
+        "daily_cap": {
+            "new_outbound_used": used,
+            "new_outbound_remaining": remaining,
+            "new_outbound_daily_cap": cap,
+            "replies_count_against_daily_cap": False,
+        },
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/drafting.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/drafting.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from common import daily_cap, tracked_link
+
+SAMPLE_REPLY_QUEUE = [
+    {
+        "candidate_id": "cand-amelia-ross",
+        "full_name": "Amelia Ross",
+        "organization": "Studio Alpha",
+        "reply_summary": "Asked for a short explanation of the SerenBucks program.",
+    },
+    {
+        "candidate_id": "cand-zoe-patel",
+        "full_name": "Zoe Patel",
+        "organization": "RelayOps",
+        "reply_summary": "Interested but asked about payout cadence.",
+    },
+]
+
+
+def build_draft_batches(proposal: dict, config: dict) -> dict:
+    cap = daily_cap(config)
+    link = tracked_link(config)
+
+    new_outbound = []
+    for candidate in proposal["top10"][:cap]:
+        new_outbound.append(
+            {
+                "draft_id": f"draft-{candidate['candidate_id']}",
+                "draft_type": "new_outbound",
+                "candidate_id": candidate["candidate_id"],
+                "subject_line": f"{candidate['organization']} x SerenBucks affiliate fit",
+                "message_body": (
+                    f"Draft outreach for {candidate['full_name']}.\n\n"
+                    f"Include the default tracked link: {link}"
+                ),
+                "tracked_link": link,
+                "approval_required": True,
+            }
+        )
+
+    reply_drafts = []
+    for reply in SAMPLE_REPLY_QUEUE:
+        reply_drafts.append(
+            {
+                "draft_id": f"reply-{reply['candidate_id']}",
+                "draft_type": "reply",
+                "candidate_id": reply["candidate_id"],
+                "message_body": (
+                    f"Draft reply for {reply['full_name']}.\n\n"
+                    f"Address: {reply['reply_summary']}"
+                ),
+                "approval_required": True,
+            }
+        )
+
+    return {
+        "status": "ok",
+        "manual_review_required": True,
+        "new_outbound": new_outbound,
+        "reply_drafts": reply_drafts,
+        "daily_cap": cap,
+        "replies_count_against_daily_cap": False,
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/ranking.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/ranking.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from common import proposal_size
+
+
+def build_editable_top10(candidates: list[dict], config: dict) -> dict:
+    ranked = [candidate for candidate in candidates if candidate["dnc_status"] != "blocked"]
+    ranked = sorted(ranked, key=lambda item: item["candidate_score"], reverse=True)
+    limit = proposal_size(config)
+
+    top_candidates = []
+    for index, candidate in enumerate(ranked[:limit], start=1):
+        top_candidates.append(
+            {
+                "rank_position": index,
+                "candidate_id": candidate["candidate_id"],
+                "full_name": candidate["full_name"],
+                "organization": candidate["organization"],
+                "candidate_score": candidate["candidate_score"],
+                "editable": True,
+            }
+        )
+
+    return {
+        "status": "ok",
+        "editable": True,
+        "proposal_size": limit,
+        "top10": top_candidates,
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/reconcile.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/reconcile.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from common import reply_signal
+
+
+def reconcile_signals(config: dict, sync_result: dict, drafts: dict) -> dict:
+    signal = reply_signal(config)
+    dnc_events: list[dict] = []
+
+    if signal and signal in set(config["dnc"]["hard_stop_signals"]):
+        first_reply = drafts["reply_drafts"][0]
+        dnc_events.append(
+            {
+                "candidate_id": first_reply["candidate_id"],
+                "signal": signal,
+                "severity": "hard_stop",
+                "blocked_action": "future_outreach",
+            }
+        )
+
+    return {
+        "status": "ok",
+        "affiliate_summary": {
+            "source_of_truth": config["campaign"]["affiliate_source_of_truth"],
+            "clicks_today": 27,
+            "signups_today": 4,
+        },
+        "provider_health": {
+            "overall": "ok",
+            "affiliates": "ok",
+            "gmail": "ok" if sync_result["source_counts"]["gmail_sent"] or sync_result["source_counts"]["gmail_contacts"] else "degraded",
+            "outlook": "ok" if sync_result["source_counts"]["outlook_sent"] or sync_result["source_counts"]["outlook_contacts"] else "degraded",
+        },
+        "dnc_events": dnc_events,
+        "audit": {
+            "crm_source_of_truth": "skill_owned_serendb",
+            "manual_review_only": True,
+            "replies_excluded_from_daily_cap": True,
+        },
+    }

--- a/seren/serenbucks-affiliate-outreach/scripts/sending.py
+++ b/seren/serenbucks-affiliate-outreach/scripts/sending.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+def prepare_send_actions(drafts: dict, config: dict) -> dict:
+    return {
+        "status": "ok",
+        "manual_review_required": True,
+        "new_outbound_batch": {
+            "status": "pending_approval",
+            "approval_required": config["approval"]["new_outbound_requires_approval"],
+            "count": len(drafts["new_outbound"]),
+        },
+        "reply_batch": {
+            "status": "pending_approval",
+            "approval_required": config["approval"]["replies_require_approval"],
+            "count": len(drafts["reply_drafts"]),
+        },
+    }

--- a/seren/serenbucks-affiliate-outreach/serendb_schema.sql
+++ b/seren/serenbucks-affiliate-outreach/serendb_schema.sql
@@ -1,0 +1,131 @@
+CREATE TABLE IF NOT EXISTS campaign_state (
+  campaign_id TEXT PRIMARY KEY,
+  campaign_name TEXT NOT NULL,
+  tracked_link TEXT NOT NULL,
+  affiliate_source_of_truth TEXT NOT NULL DEFAULT 'seren-affiliates',
+  crm_source_of_truth TEXT NOT NULL DEFAULT 'skill_owned_serendb',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS affiliate_runs (
+  id SERIAL PRIMARY KEY,
+  run_type TEXT NOT NULL,
+  run_status TEXT NOT NULL,
+  auth_path TEXT NOT NULL,
+  affiliate_feed_status TEXT NOT NULL,
+  provider_health TEXT NOT NULL,
+  proposal_size INTEGER NOT NULL DEFAULT 10,
+  new_outbound_daily_cap INTEGER NOT NULL DEFAULT 10,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS candidate_profiles (
+  id SERIAL PRIMARY KEY,
+  external_key TEXT NOT NULL UNIQUE,
+  full_name TEXT NOT NULL,
+  email TEXT,
+  organization TEXT,
+  source_system TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  relationship_hint TEXT,
+  warm_score NUMERIC,
+  fit_score NUMERIC,
+  dnc_status TEXT NOT NULL DEFAULT 'active',
+  last_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS candidate_source_events (
+  id SERIAL PRIMARY KEY,
+  candidate_external_key TEXT NOT NULL,
+  source_system TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  source_event_type TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  raw_payload JSONB
+);
+
+CREATE TABLE IF NOT EXISTS proposal_sets (
+  id SERIAL PRIMARY KEY,
+  proposal_date DATE NOT NULL,
+  tracked_link TEXT NOT NULL,
+  editable BOOLEAN NOT NULL DEFAULT true,
+  proposal_size INTEGER NOT NULL DEFAULT 10,
+  status TEXT NOT NULL DEFAULT 'draft',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS proposal_items (
+  id SERIAL PRIMARY KEY,
+  proposal_set_id INTEGER NOT NULL REFERENCES proposal_sets(id) ON DELETE CASCADE,
+  candidate_external_key TEXT NOT NULL,
+  rank_position INTEGER NOT NULL,
+  candidate_score NUMERIC NOT NULL,
+  rationale TEXT,
+  selected BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS message_drafts (
+  id SERIAL PRIMARY KEY,
+  proposal_set_id INTEGER REFERENCES proposal_sets(id) ON DELETE SET NULL,
+  candidate_external_key TEXT NOT NULL,
+  draft_type TEXT NOT NULL,
+  subject_line TEXT,
+  message_body TEXT NOT NULL,
+  tracked_link TEXT NOT NULL,
+  approval_required BOOLEAN NOT NULL DEFAULT true,
+  approval_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS approval_events (
+  id SERIAL PRIMARY KEY,
+  draft_id INTEGER REFERENCES message_drafts(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  actor TEXT,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS send_batches (
+  id SERIAL PRIMARY KEY,
+  batch_type TEXT NOT NULL,
+  proposal_set_id INTEGER REFERENCES proposal_sets(id) ON DELETE SET NULL,
+  batch_status TEXT NOT NULL DEFAULT 'pending_approval',
+  new_outbound_count INTEGER NOT NULL DEFAULT 0,
+  reply_count INTEGER NOT NULL DEFAULT 0,
+  counts_against_daily_cap BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS reply_events (
+  id SERIAL PRIMARY KEY,
+  candidate_external_key TEXT NOT NULL,
+  reply_source TEXT NOT NULL,
+  classification TEXT NOT NULL,
+  reply_summary TEXT,
+  requires_approval BOOLEAN NOT NULL DEFAULT true,
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS dnc_events (
+  id SERIAL PRIMARY KEY,
+  candidate_external_key TEXT NOT NULL,
+  signal TEXT NOT NULL,
+  severity TEXT NOT NULL DEFAULT 'hard_stop',
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS daily_digests (
+  id SERIAL PRIMARY KEY,
+  digest_date DATE NOT NULL,
+  run_id INTEGER REFERENCES affiliate_runs(id) ON DELETE SET NULL,
+  digest_markdown TEXT NOT NULL,
+  provider_health TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/seren/serenbucks-affiliate-outreach/skill.spec.yaml
+++ b/seren/serenbucks-affiliate-outreach/skill.spec.yaml
@@ -1,0 +1,177 @@
+skill: serenbucks-affiliate-outreach
+description: Review-first outreach skill for the default SerenBucks affiliate campaign. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest.
+triggers:
+  - grow SerenBucks affiliate signups
+  - draft SerenBucks affiliate outreach
+  - review the daily affiliate digest
+  - sync affiliate candidates from Gmail or Outlook
+  - reconcile affiliate replies and unsubscribe events
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  command:
+    type: string
+    description: Top-level skill command.
+    enum:
+      - bootstrap
+      - run
+      - status
+      - sync
+      - draft
+      - reconcile
+      - digest
+    default: run
+  json_output:
+    type: boolean
+    description: Return machine-readable output when true.
+    default: false
+  proposal_size:
+    type: integer
+    description: Number of ranked candidates to surface for operator review.
+    min: 1
+    max: 10
+    default: 10
+  new_outbound_daily_cap:
+    type: integer
+    description: Maximum number of new outbound messages allowed per day.
+    min: 1
+    max: 10
+    default: 10
+  strict_mode:
+    type: boolean
+    description: Fail closed when bootstrap or required campaign context fails.
+    default: true
+  tracked_link:
+    type: string
+    description: Canonical tracked link for the default SerenBucks affiliate campaign.
+    default: https://seren.ai/serenbucks?ref=default
+secrets:
+  - SEREN_API_KEY
+connectors:
+  affiliates:
+    kind: seren_publisher
+    publisher: seren-affiliates
+  storage:
+    kind: seren_publisher
+    publisher: serendb
+  gmail:
+    kind: seren_publisher
+    publisher: gmail
+  outlook:
+    kind: seren_publisher
+    publisher: outlook
+  model:
+    kind: seren_publisher
+    publisher: seren-models
+state:
+  runs:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: affiliate_runs
+  candidates:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: candidate_profiles
+  proposals:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: proposal_sets
+  drafts:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: message_drafts
+  approvals:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: approval_events
+  digests:
+    kind: serendb
+    database: serenbucks_affiliate_outreach
+    table: daily_digests
+policies:
+  dry_run_default: true
+  idempotency_required: true
+workflow:
+  steps:
+    - id: normalize_request
+      use: transform.normalize_request
+      with:
+        command: "{command}"
+        json_output: "{json_output}"
+    - id: bootstrap_auth_and_db
+      use: transform.bootstrap_auth_and_db
+      with:
+        strict_mode: "{strict_mode}"
+        from_step: normalize_request
+    - id: bootstrap_affiliate_context
+      use: connector.affiliates.get
+      with:
+        tracked_link: "{tracked_link}"
+        from_step: bootstrap_auth_and_db
+    - id: sync_candidates_from_sent_history
+      use: transform.sync_candidates_from_sent_history
+      with:
+        from_step: bootstrap_affiliate_context
+    - id: sync_candidates_from_address_books
+      use: transform.sync_candidates_from_address_books
+      with:
+        from_step: sync_candidates_from_sent_history
+    - id: persist_candidates
+      use: connector.storage.upsert
+      with:
+        tables:
+          - candidate_profiles
+          - candidate_source_events
+        from_step: sync_candidates_from_address_books
+    - id: rank_candidate_universe
+      use: transform.rank_candidate_universe
+      with:
+        proposal_size: "{proposal_size}"
+        from_step: persist_candidates
+    - id: build_editable_top10
+      use: transform.build_editable_top10
+      with:
+        proposal_size: "{proposal_size}"
+        from_step: rank_candidate_universe
+    - id: draft_batches
+      use: transform.draft_review_batches
+      with:
+        new_outbound_daily_cap: "{new_outbound_daily_cap}"
+        from_step: build_editable_top10
+    - id: reconcile_signals
+      use: transform.reconcile_affiliate_and_reply_signals
+      with:
+        from_step: draft_batches
+    - id: persist_run_state
+      use: connector.storage.upsert
+      with:
+        tables:
+          - affiliate_runs
+          - proposal_sets
+          - message_drafts
+          - approval_events
+          - daily_digests
+          - dnc_events
+        from_step: reconcile_signals
+    - id: render_digest
+      use: transform.render_manual_daily_digest
+      with:
+        json_output: "{json_output}"
+        from_step: persist_run_state
+tests:
+  quick:
+    - validates_daily_cap_never_exceeds_ten
+    - defaults_to_single_tracked_link
+    - requires_manual_review_for_new_outbound_and_replies
+  smoke:
+    - bootstraps_affiliate_context_before_candidate_sync
+    - persists_candidates_before_ranking
+    - renders_manual_digest_from_fixture
+publish:
+  org: seren
+  slug: serenbucks-affiliate-outreach
+metadata:
+  category: growth
+  product_role: primary
+  family: affiliate-v1

--- a/seren/serenbucks-affiliate-outreach/tests/fixtures/connector_failure.json
+++ b/seren/serenbucks-affiliate-outreach/tests/fixtures/connector_failure.json
@@ -1,0 +1,9 @@
+{
+  "status": "error",
+  "skill": "serenbucks-affiliate-outreach",
+  "error_code": "affiliate_bootstrap_failed",
+  "connector": "affiliates",
+  "retry_count": 3,
+  "fail_closed": true,
+  "message": "Default affiliate campaign context could not be bootstrapped after three immediate attempts."
+}

--- a/seren/serenbucks-affiliate-outreach/tests/fixtures/dry_run_guard.json
+++ b/seren/serenbucks-affiliate-outreach/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,7 @@
+{
+  "status": "ok",
+  "skill": "serenbucks-affiliate-outreach",
+  "dry_run": true,
+  "blocked_action": "send_without_approval",
+  "approval_required": true
+}

--- a/seren/serenbucks-affiliate-outreach/tests/fixtures/happy_path.json
+++ b/seren/serenbucks-affiliate-outreach/tests/fixtures/happy_path.json
@@ -1,0 +1,30 @@
+{
+  "status": "ok",
+  "skill": "serenbucks-affiliate-outreach",
+  "workflow_step_count": 12,
+  "dry_run": true,
+  "campaign": {
+    "campaign_id": "serenbucks-default",
+    "tracked_link": "https://seren.ai/serenbucks?ref=default",
+    "source_of_truth": "seren-affiliates"
+  },
+  "bootstrap": {
+    "auth_path": "seren_desktop",
+    "affiliate_context_ready": true
+  },
+  "proposal": {
+    "editable": true,
+    "size": 10
+  },
+  "approval": {
+    "new_outbound_required": true,
+    "replies_required": true
+  },
+  "limits": {
+    "new_outbound_daily_cap": 10,
+    "replies_count_against_daily_cap": false
+  },
+  "crm": {
+    "source_of_truth": "skill_owned_serendb"
+  }
+}

--- a/seren/serenbucks-affiliate-outreach/tests/fixtures/policy_violation.json
+++ b/seren/serenbucks-affiliate-outreach/tests/fixtures/policy_violation.json
@@ -1,0 +1,9 @@
+{
+  "status": "error",
+  "skill": "serenbucks-affiliate-outreach",
+  "error_code": "dnc_blocked",
+  "signal": "unsubscribe",
+  "hard_stop": true,
+  "blocked_action": "draft_send",
+  "message": "Candidate was moved to hard DNC after an unsubscribe signal."
+}

--- a/seren/serenbucks-affiliate-outreach/tests/test_smoke.py
+++ b/seren/serenbucks-affiliate-outreach/tests/test_smoke.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "serenbucks-affiliate-outreach"
+    assert payload["campaign"]["campaign_id"] == "serenbucks-default"
+    assert payload["proposal"]["editable"] is True
+    assert payload["limits"]["new_outbound_daily_cap"] == 10
+    assert payload["limits"]["replies_count_against_daily_cap"] is False
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "affiliate_bootstrap_failed"
+    assert payload["retry_count"] == 3
+    assert payload["fail_closed"] is True
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "dnc_blocked"
+    assert payload["signal"] == "unsubscribe"
+    assert payload["hard_stop"] is True
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "send_without_approval"
+    assert payload["approval_required"] is True


### PR DESCRIPTION
## Summary
- publish the new `seren/serenbucks-affiliate-outreach` skill
- add the v1 review-first operating contract, schema, references, and runtime stubs
- include smoke fixtures for bootstrap, DNC, and approval-cap invariants

## Verification
- `API_KEY=test-desktop-auth python3 seren/serenbucks-affiliate-outreach/scripts/agent.py --config seren/serenbucks-affiliate-outreach/config.example.json --command run`
- `/Users/taariqlewis/Projects/Seren_Projects/seren-skills/.test-venv/bin/python -m pytest seren/serenbucks-affiliate-outreach/tests/test_smoke.py`