### PR TITLE
feat: add display names to taariq-authored skills

### DIFF
--- a/affiliates/seren-bucks/SKILL.md
+++ b/affiliates/seren-bucks/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: seren-bucks
+display-name: "Seren Bucks Affiliate"
 description: "Review-first outreach skill for the default Seren Bucks affiliate campaign. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest."
 ---
 

--- a/alpaca/saas-short-trader/SKILL.md
+++ b/alpaca/saas-short-trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: saas-short-trader
+display-name: "Alpaca SaaS Short Trader"
 description: "Alpaca-branded SaaS short trader with MCP-native execution: scores AI disruption risk, builds capped short baskets, and tracks paper/live PnL in SerenDB."
 ---
 

--- a/alpaca/sass-short-trader-delta-neutral/SKILL.md
+++ b/alpaca/sass-short-trader-delta-neutral/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sass-short-trader-delta-neutral
+display-name: "Alpaca SaaS Short Trader DN"
 description: "Alpaca-branded SaaS delta-neutral trader with MCP-native execution: scores AI disruption risk, builds capped short baskets, adds a configurable long hedge leg, and tracks paper/live PnL in SerenDB."
 ---
 

--- a/attio/crm/SKILL.md
+++ b/attio/crm/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: crm
+display-name: "Attio CRM"
 description: "Connect to Attio CRM to manage contacts, companies, deals, lists, tasks, notes, meetings, and comments through AI agents. Search records, create entries, update pipelines, and manage your sales workflow."
 ---
 

--- a/benjamin-black-consulting/ai-governance-assessment/SKILL.md
+++ b/benjamin-black-consulting/ai-governance-assessment/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ai-governance-assessment
+display-name: "AI Governance Assessment"
 description: "Assess AI governance maturity for compliance/risk leaders: evaluates 8 domains against NIST AI RMF, EU AI Act, ISO 42001, and OCC SR 11-7 frameworks. Persists results to SerenDB for tracking and follow-up."
 ---
 

--- a/coinbase/smart-dca-bot/SKILL.md
+++ b/coinbase/smart-dca-bot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: smart-dca-bot
+display-name: "Coinbase Smart DCA Bot"
 description: "AI-optimized Coinbase Smart DCA bot with single-asset, portfolio, and opportunity-scanner modes using local direct execution and strict safety controls."
 ---
 

--- a/crypto-bullseye-zone/tax/SKILL.md
+++ b/crypto-bullseye-zone/tax/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tax
+display-name: "CryptoBullseye Tax"
 version: "2.0.0"
 description: "Use when a user has a Form 1099-DA from a crypto exchange and wants to review it, understand it, or check it for issues before filing Form 8949."
 ---

--- a/crypto-recovery/key-recovery-diagnosis/SKILL.md
+++ b/crypto-recovery/key-recovery-diagnosis/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: key-recovery-diagnosis
+display-name: "Crypto Key Recovery"
 description: "Diagnose crypto wallet access-loss scenarios, classify self-recovery feasibility, guide safe local recovery attempts for simple cases, and prepare sponsor handoff summaries for expert-only cases."
 ---
 

--- a/curve/curve-gauge-yield-trader/SKILL.md
+++ b/curve/curve-gauge-yield-trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: curve-gauge-yield-trader
+display-name: "Curve Gauge Yield Trader"
 description: "Multi-chain Curve gauge yield trading skill with paper-first defaults. Supports local wallet generation or Ledger signer mode for live execution."
 ---
 

--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: knowledge
+display-name: "Family Office Knowledge"
 description: "Captures, stores, and retrieves institutional knowledge for family offices through guided knowledge interviews, SharePoint and document ingestion, Asana-aware context seeding, same-user cross-thread recall, explicit freshness cues, and retrieval-linked SerenBucks incentives."
 ---
 

--- a/google/calendar/SKILL.md
+++ b/google/calendar/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-calendar
+display-name: "Google Calendar"
 description: "Create, read, update, and delete Google Calendar events. Supports free/busy queries, recurring events, multi-calendar management, and meeting scheduling with OAuth authentication."
 ---
 

--- a/google/contacts/SKILL.md
+++ b/google/contacts/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-contacts
+display-name: "Google Contacts"
 description: "Read and manage Google Contacts via the People API. Access contact information including names, emails, phone numbers, and organizations with OAuth authentication."
 ---
 

--- a/google/docs/SKILL.md
+++ b/google/docs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-docs
+display-name: "Google Docs"
 description: "Create, read, and update Google Docs documents. Supports document creation, content insertion, formatting, and batch updates with OAuth authentication."
 ---
 

--- a/google/drive/SKILL.md
+++ b/google/drive/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-drive
+display-name: "Google Drive"
 description: "Create, read, update, and manage files and folders in Google Drive. Upload documents, organize folder structures, search files, and manage sharing permissions with OAuth authentication."
 ---
 

--- a/google/meet/SKILL.md
+++ b/google/meet/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-meet
+display-name: "Google Meet"
 description: "Create and manage Google Meet meeting spaces. Generate meeting links, configure meeting settings, and manage active conferences with OAuth authentication."
 ---
 

--- a/google/sheets/SKILL.md
+++ b/google/sheets/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-sheets
+display-name: "Google Sheets"
 description: "Read and write Google Sheets data, create spreadsheets, manage worksheets, and apply formatting. Supports batch reads, cell updates, and formula operations with OAuth authentication."
 ---
 

--- a/google/trends/SKILL.md
+++ b/google/trends/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: google-trends
+display-name: "Google Trends"
 description: "Access real-time Google Trends data including interest over time, regional breakdowns, related topics and queries. Supports up to 5 keywords per search, geographic filtering, date ranges, and search property filters."
 ---
 

--- a/hyperliquid/5x-btc-usdc-withdraw/SKILL.md
+++ b/hyperliquid/5x-btc-usdc-withdraw/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: 5x-btc-usdc-withdraw
+display-name: "Hyperliquid 5x BTC Withdraw"
 description: "5x leveraged BTC-PERP on Hyperliquid with free USDC withdrawal. No KYC, no debt, self-custody. Dry-run includes 270-day liquidation risk backtest via CoinGecko."
 ---
 

--- a/kalshi/consensus-divergence-monitor/SKILL.md
+++ b/kalshi/consensus-divergence-monitor/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: consensus-divergence-monitor
+display-name: "Kalshi Divergence Monitor"
 description: "Monitor Kalshi cross-venue consensus breaks, rank the largest divergences, and summarize what changed since the previous scan."
 ---
 

--- a/kalshi/hybrid-signal-trader/SKILL.md
+++ b/kalshi/hybrid-signal-trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: hybrid-signal-trader
+display-name: "Kalshi Hybrid Signal Trader"
 description: "Score Kalshi contract opportunities with cross-venue divergence plus gap and coil support, then return dry-run trade intents with plain-language rationale."
 ---
 

--- a/kalshi/macro-signal-monitor/SKILL.md
+++ b/kalshi/macro-signal-monitor/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: macro-signal-monitor
+display-name: "Kalshi Macro Signal Monitor"
 description: "Monitor gap and coil alignment for Kalshi contracts, map macro support to candidate markets, and explain signal freshness or ambiguity."
 ---
 

--- a/kalshi/watchlist-explainer/SKILL.md
+++ b/kalshi/watchlist-explainer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: watchlist-explainer
+display-name: "Kalshi Watchlist Explainer"
 description: "Explain why a Kalshi contract is interesting but not yet tradable, with freshness caveats, near-miss logic, and plain-language watchlist guidance."
 ---
 

--- a/kraken/1099-da-tax-reconciler/SKILL.md
+++ b/kraken/1099-da-tax-reconciler/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: 1099-da-tax-reconciler
+display-name: "Kraken 1099-DA Tax"
 version: "2.0.0"
 description: "Use when a user has a Form 1099-DA from Kraken and wants to review it, verify it against raw transaction history, or check it for issues before filing Form 8949."
 ---

--- a/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
+++ b/kraken/carf-dac8-crypto-asset-reporting/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: carf-dac8-crypto-asset-reporting
+display-name: "Kraken CARF DAC8 Reporting"
 description: "Reconcile CARF/DAC8 exchange-reported crypto transactions against user records, including transfer tracking and optional 1099-DA bridge mode."
 ---
 

--- a/kraken/money-mode-router/SKILL.md
+++ b/kraken/money-mode-router/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: money-mode-router
+display-name: "Kraken Money Mode Router"
 description: "Kraken customer skill that converts user goals into a concrete Kraken action mode (payments, investing, trading, on-chain, automation) and persists each session to SerenDB"
 ---
 

--- a/kraken/ramp-leverage-bitcoin-polymarket-deposit/SKILL.md
+++ b/kraken/ramp-leverage-bitcoin-polymarket-deposit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ramp-leverage-bitcoin-polymarket-deposit
+display-name: "Kraken Leveraged BTC Deposit"
 description: "Deposit up to 5x leveraged cash into Polymarket using Kraken margin trading. Fiat onramp via Kraken Ramp API. Uses Kraken REST API directly — user supplies their own API keys."
 ---
 

--- a/kraken/smart-dca-bot/SKILL.md
+++ b/kraken/smart-dca-bot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: smart-dca-bot
+display-name: "Kraken Smart DCA Bot"
 description: "AI-optimized Kraken DCA bot with single-asset, portfolio, and scanner modes using local direct execution and strict safety controls."
 ---
 

--- a/ledger/ledger-signing/SKILL.md
+++ b/ledger/ledger-signing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ledger-signing
+display-name: "Ledger Signing"
 description: "Guide Ledger device owners through secure transaction and message signing with explicit support for clear signing and blind signing fallback flows."
 ---
 

--- a/linear/issue-tracking/SKILL.md
+++ b/linear/issue-tracking/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: issue-tracking
+display-name: "Linear Issue Tracking"
 description: "Connect to Linear to manage issues, projects, cycles, and team workflows through AI agents. Create and update issues, manage project roadmaps, track sprint cycles, and search across your workspace."
 ---
 

--- a/microsoft/sharepoint/SKILL.md
+++ b/microsoft/sharepoint/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: microsoft-sharepoint
+display-name: "Microsoft SharePoint"
 description: "Manage SharePoint sites, document libraries, files, folders, and lists via Microsoft Graph API. Browse sites, upload and download files, create folders, copy files, and search across sites with OAuth2 authentication."
 ---
 

--- a/polymarket/high-throughput-paired-basis-maker/SKILL.md
+++ b/polymarket/high-throughput-paired-basis-maker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: high-throughput-paired-basis-maker
+display-name: "High-Throughput Basis Maker"
 description: "Run a paired-market basis strategy on Polymarket with mandatory backtest-first gating before trade intents."
 ---
 

--- a/polymarket/liquidity-paired-basis-maker/SKILL.md
+++ b/polymarket/liquidity-paired-basis-maker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: liquidity-paired-basis-maker
+display-name: "Liquidity Basis Maker"
 description: "Run a liquidity-filtered paired-market basis strategy on Polymarket with mandatory backtest-first gating before trade intents."
 ---
 

--- a/polymarket/maker-rebate-bot/SKILL.md
+++ b/polymarket/maker-rebate-bot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: polymarket-maker-rebate-bot
+display-name: "Polymarket Maker Rebate Bot"
 description: "Provide two-sided liquidity on Polymarket with rebate-aware quoting, inventory controls, and dry-run-first execution for binary markets."
 ---
 

--- a/polymarket/p2p-hyperliquid-bitcoin-usdc-deposit/SKILL.md
+++ b/polymarket/p2p-hyperliquid-bitcoin-usdc-deposit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: p2p-hyperliquid-bitcoin-usdc-deposit
+display-name: "P2P Hyperliquid BTC Deposit"
 description: "Deposit cash into Polymarket with 5x Bitcoin leverage on Hyperliquid. No KYC, no debt, self-custody. Fiat onramp via ZKP2P peer-onramp. Dry-run includes 270-day liquidation risk backtest."
 ---
 

--- a/polymarket/p2p-leverage-bitcoin-usdc-deposit/SKILL.md
+++ b/polymarket/p2p-leverage-bitcoin-usdc-deposit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: p2p-leverage-bitcoin-usdc-deposit
+display-name: "P2P Leveraged BTC Deposit"
 description: "This skill will allow you to deposit 73% of your cash into Polymarket, on Base, with Bitcoin Leverage. Use any supported Payment app on Peer."
 ---
 

--- a/prophet/prophet-adversarial-auditor/SKILL.md
+++ b/prophet/prophet-adversarial-auditor/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prophet-adversarial-auditor
+display-name: "Prophet Adversarial Auditor"
 description: "Inspect Prophet market creation history for rejected submissions, replayable failures, suspicious patterns, and plausible economic loss scenarios with structured findings for operators."
 ---
 

--- a/prophet/prophet-growth-agent/SKILL.md
+++ b/prophet/prophet-growth-agent/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prophet-growth-agent
+display-name: "Prophet Growth Agent"
 description: "Reinforce repeat Prophet market creation with lightweight status checks, progress tracking, reminder copy, and re-engagement recommendations after first success."
 ---
 

--- a/prophet/prophet-market-seeder/SKILL.md
+++ b/prophet/prophet-market-seeder/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prophet-market-seeder
+display-name: "Prophet Market Seeder"
 description: "Take referred Prophet users from setup through bounded market creation with referral-aware auth checks, candidate scoring, filtered submission, and clear run reporting."
 ---
 

--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: bat-sales-coach
+display-name: "BAT Sales Coach"
 description: "Supportive sales-executive coaching skill that runs a Behavior-Attitude-Technique loop, journals completed sales work, tracks pipeline progress in SerenDB, reinforces momentum without pressure, and turns self-directed technique reviews into the next behavior plan."
 ---
 

--- a/seren/asana/SKILL.md
+++ b/seren/asana/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: asana
+display-name: "Asana"
 description: "Manage Asana tasks, projects, sections, goals, portfolios, tags, teams, and workspaces through AI agents. Create, update, and organize work items with OAuth token passthrough."
 ---
 

--- a/seren/customer-support-intake/SKILL.md
+++ b/seren/customer-support-intake/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: customer-support-intake
+display-name: "Customer Support Intake"
 description: "Secure customer support evidence collection for SerenDesktop incidents. Use when users report failures and need one-click collection of logs, diagnostics, chat history, and screenshots with consent checks, PII redaction, and storage in SerenDB."
 ---
 

--- a/seren/seren-scheduler/SKILL.md
+++ b/seren/seren-scheduler/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: seren-scheduler
+display-name: "Seren Scheduler"
 description: "Create and manage scheduled HTTP jobs with the seren-cron publisher. Use when users want to create recurring webhook runs, list and inspect existing schedules, update jobs, pause or resume execution, organize jobs into groups, or review run history."
 ---
 

--- a/sidepit/auction-trader/SKILL.md
+++ b/sidepit/auction-trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: auction-trader
+display-name: "Sidepit Auction Trader"
 description: "AI agent trading skill for Sidepit's 1-second discrete auction exchange — submit orders, subscribe to market data, manage positions, and persist all auction activity to SerenDB via NNG/protobuf API."
 ---
 

--- a/spectra/spectra-pt-yield-trader/SKILL.md
+++ b/spectra/spectra-pt-yield-trader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: spectra-pt-yield-trader
+display-name: "Spectra PT Yield Trader"
 description: "Plan and evaluate Spectra PT yield trades using the Spectra MCP server across 10 chains. Use when you need fixed-yield opportunity scans, PT quoting, portfolio simulation, and risk-gated execution handoff."
 ---
 

--- a/wellsfargo/bank-statement-processing/SKILL.md
+++ b/wellsfargo/bank-statement-processing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: bank-statement-processing
+display-name: "Wells Fargo Bank Statements"
 description: "Wells Fargo bank statement retrieval skill for Seren Desktop: runtime-authenticated PDF download, transaction parsing, and masked SerenDB sync."
 ---
 

--- a/wellsfargo/budget-tracker/SKILL.md
+++ b/wellsfargo/budget-tracker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: budget-tracker
+display-name: "Wells Fargo Budget Tracker"
 description: "Compare actual Wells Fargo spending against user-defined monthly budgets per category, calculate variance, and track budget adherence over time."
 ---
 

--- a/wellsfargo/cash-flow-statement/SKILL.md
+++ b/wellsfargo/cash-flow-statement/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: cash-flow-statement
+display-name: "Wells Fargo Cash Flow"
 description: "Generate operating, investing, and financing cash flow statements from Wells Fargo transaction data stored in SerenDB."
 ---
 

--- a/wellsfargo/income-statement/SKILL.md
+++ b/wellsfargo/income-statement/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: income-statement
+display-name: "Wells Fargo Income Statement"
 description: "Generate categorized income statements from Wells Fargo transaction data stored in SerenDB by the bank-statement-processing skill."
 ---
 

--- a/wellsfargo/net-worth-tracker/SKILL.md
+++ b/wellsfargo/net-worth-tracker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: net-worth-tracker
+display-name: "Wells Fargo Net Worth"
 description: "Track account balances from Wells Fargo statement data with optional manual asset and liability entries to produce a simplified balance sheet and net worth trajectory over time."
 ---
 

--- a/wellsfargo/recurring-transactions/SKILL.md
+++ b/wellsfargo/recurring-transactions/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: recurring-transactions
+display-name: "Wells Fargo Recurring"
 description: "Detect and track recurring subscriptions, bills, and regular payments from Wells Fargo transaction data stored in SerenDB."
 ---
 

--- a/wellsfargo/tax-prep/SKILL.md
+++ b/wellsfargo/tax-prep/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tax-prep
+display-name: "Wells Fargo Tax Prep"
 description: "Map Wells Fargo transaction categories to IRS tax line items, calculate estimated quarterly payments, flag deductible expenses, and produce a tax-ready summary with totals per line item."
 ---
 

--- a/wellsfargo/vendor-analysis/SKILL.md
+++ b/wellsfargo/vendor-analysis/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: vendor-analysis
+display-name: "Wells Fargo Vendor Analysis"
 description: "Group Wells Fargo transactions by normalized vendor name, rank by total spend and frequency, detect spending trends, and produce top vendor reports with month-over-month deltas."
 ---
 

--- a/zkp2p/peer-to-peer-payments-exchange/SKILL.md
+++ b/zkp2p/peer-to-peer-payments-exchange/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: peer-to-peer-payments-exchange
+display-name: "ZKP2P Payments Exchange"
 description: "Route and execute peer-to-peer fiat-to-crypto payment and exchange flows on Peer (ZKP2P), including onramp, offramp, checkout, transfer, LP, vault, analytics, explorer, and activity monitoring paths."
 ---
 


### PR DESCRIPTION
## Summary
- add missing `display-name` frontmatter entries to Taariq-authored `SKILL.md` files that were missing them
- use short proper names intended to read clearly in the Seren Desktop UI
- set `affiliates/seren-bucks` to display as `Seren Bucks Affiliate`

## Verification
- `python3` validation script confirmed no Taariq-authored `SKILL.md` files remain without `display-name`
- spot-checked updated frontmatter for `affiliates/seren-bucks`, `alpaca/sass-short-trader-delta-neutral`, `kraken/ramp-leverage-bitcoin-polymarket-deposit`, and `family-office/knowledge`
- `git diff --stat` shows metadata-only changes: one added line per affected `SKILL.md`