### PR TITLE
feat: include displayName in skills index JSON

### DIFF
--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -84,6 +84,7 @@ for (const skillPath of skillFiles) {
   skills.push({
     slug,
     name: fm.name || skillName,
+    displayName: fm["display-name"] || undefined,
     description: fm.description || "",
     source: "serenorg",
     sourceUrl,


### PR DESCRIPTION
Extract display-name from frontmatter into index.json so Seren Desktop can show human-readable skill names.