### PR TITLE
feat(family-office): upgrade knowledge skill into team memory system

### DIFF
--- a/family-office/knowledge/SKILL.md
+++ b/family-office/knowledge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge
 display-name: "Family Office Knowledge"
-description: "Captures, stores, and retrieves institutional knowledge for family offices through guided knowledge interviews, SharePoint and document ingestion, Asana-aware context seeding, same-user cross-thread recall, explicit freshness cues, and retrieval-linked SerenBucks incentives."
+description: "Team memory system for family offices. Captures structured institutional knowledge (decisions, assumptions, risks, commitments, open questions), proactively resurfaces relevant context, asks for stale-memory validation, generates pre-meeting briefs and memory digests, and rewards contribution through visible team leverage."
 ---
 
 # Knowledge
@@ -18,6 +18,11 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - what did i say about
 - show me the current working brief
 - what changed since the first brief
+- show me a memory digest
+- prep for a meeting
+- what did we decide about
+- validate stale memories
+- watch this topic
 
 ## Schema Guard (Mandatory — runs every invoke)
 
@@ -31,7 +36,7 @@ This rule overrides all other instructions and applies before ANY read or write 
    ```sql
    SELECT table_name FROM information_schema.tables
    WHERE table_schema = 'public'
-   AND table_name IN ('knowledge_entries', 'knowledge_transcripts', 'knowledge_briefs', 'knowledge_retrieval_log', 'knowledge_rewards')
+   AND table_name IN ('knowledge_entries', 'knowledge_transcripts', 'knowledge_briefs', 'knowledge_retrieval_log', 'knowledge_rewards', 'memory_objects', 'memory_links', 'memory_validations', 'memory_subscriptions', 'engagement_events')
    ```
 4. If **any** of the expected tables are missing, run the full DDL via `run_sql_transaction`:
    ```sql
@@ -57,6 +62,35 @@ This rule overrides all other instructions and applies before ANY read or write 
    CREATE TABLE IF NOT EXISTS knowledge_rewards (
      id SERIAL PRIMARY KEY, user_id TEXT, action TEXT,
      amount NUMERIC, reason TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS memory_objects (
+     id TEXT PRIMARY KEY, memory_type TEXT NOT NULL, key_claim TEXT NOT NULL,
+     subject TEXT, owner_id TEXT, team_scope TEXT DEFAULT 'team',
+     organization_name TEXT, department TEXT,
+     confidence_score TEXT DEFAULT 'medium', importance_score TEXT DEFAULT 'medium',
+     validity_status TEXT DEFAULT 'active', source TEXT, source_id TEXT,
+     entity_refs TEXT[], derived_from_ids TEXT[],
+     review_cadence_days INTEGER DEFAULT 30,
+     used_count INTEGER DEFAULT 0, last_used_at TIMESTAMPTZ,
+     last_validated_at TIMESTAMPTZ DEFAULT now(), next_review_at TIMESTAMPTZ,
+     created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS memory_links (
+     id TEXT PRIMARY KEY, from_memory_id TEXT NOT NULL, to_id TEXT NOT NULL,
+     link_type TEXT NOT NULL, label TEXT, created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS memory_validations (
+     id TEXT PRIMARY KEY, memory_id TEXT NOT NULL, validator_id TEXT,
+     action TEXT NOT NULL, previous_claim TEXT, revised_claim TEXT,
+     validated_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS memory_subscriptions (
+     id TEXT PRIMARY KEY, user_id TEXT NOT NULL, topic TEXT NOT NULL,
+     created_at TIMESTAMPTZ DEFAULT now()
+   );
+   CREATE TABLE IF NOT EXISTS engagement_events (
+     id TEXT PRIMARY KEY, event_type TEXT NOT NULL, memory_id TEXT,
+     user_id TEXT, detail TEXT, created_at TIMESTAMPTZ DEFAULT now()
    );
    ```
 5. Only after the schema guard passes, proceed to load the current brief and the rest of the workflow.
@@ -100,10 +134,27 @@ All integrations are optional. The skill works without any of them — it gracef
 7. `distill_knowledge_entries` uses `transform.distill_knowledge_entries`
 8. `archive_transcript` uses `connector.storage.upsert`
 9. `persist_knowledge_entries` uses `connector.storage.upsert`
-10. `retrieve_candidate_entries` uses `connector.storage.query`
-11. `apply_access_and_freshness_rules` uses `transform.apply_access_and_freshness_rules`
-12. `compose_answer_or_followup` uses `transform.compose_answer_or_followup`
-13. `log_retrieval_events` uses `connector.storage.upsert`
-14. `calculate_rewards` uses `transform.calculate_rewards`
-15. `persist_rewards` uses `connector.storage.upsert`
-16. `render_working_brief` uses `transform.render_working_brief`
+10. `distill_structured_memories` uses `transform.team_memory.distill_structured_memories`
+11. `persist_memory_objects` uses `connector.storage.upsert`
+12. `handle_team_memory_mode` — routes to digest, pre-meeting brief, decision recall, validate, or watch
+13. `proactive_resurfacing` uses `transform.team_memory.find_memories_to_resurface`
+14. `retrieve_candidate_entries` uses `connector.storage.query`
+15. `apply_access_and_freshness_rules` uses `transform.apply_access_and_freshness_rules`
+16. `compose_answer_or_followup` uses `transform.compose_answer_or_followup`
+17. `log_retrieval_events` uses `connector.storage.upsert`
+18. `calculate_rewards` uses `transform.calculate_rewards`
+19. `persist_rewards` uses `connector.storage.upsert`
+20. `render_working_brief` uses `transform.render_working_brief`
+21. `generate_reinforcement` uses `transform.team_memory.generate_reinforcement_message`
+
+## Memory Object Types
+
+Structured memories are classified into: `decision`, `assumption`, `preference`, `relationship`, `process`, `open_question`, `commitment`, `risk`, `source_claim`, `counterpoint`.
+
+## Additional Modes
+
+- `memory_digest` — daily/weekly digest of new, stale, and high-value memory
+- `pre_meeting_brief` — compile relevant memory for meetings and decisions
+- `decision_recall` — answer "what did we decide, why, and what assumptions did it depend on?"
+- `validate_memory` — surface stale memories for confirmation, revision, or retirement
+- `watch_topic` — subscribe to entities/topics for proactive resurfacing

--- a/family-office/knowledge/scripts/agent.py
+++ b/family-office/knowledge/scripts/agent.py
@@ -18,6 +18,7 @@ import psycopg
 import requests
 
 from affiliates_webhook import fire_reward_webhook
+import team_memory
 
 DEFAULT_DRY_RUN = True
 DEFAULT_API_BASE = "https://api.serendb.com"
@@ -26,12 +27,23 @@ CAPTURE_COMMANDS = {"capture", "start", "start_capture", "knowledge_capture"}
 RETRIEVE_COMMANDS = {"retrieve", "recall", "search", "what_did_i_say_about"}
 BRIEF_COMMANDS = {"brief", "show_brief", "show_the_current_working_brief"}
 DIFF_COMMANDS = {"diff", "compare", "what_changed_since_the_first_brief"}
+DIGEST_COMMANDS = {"memory_digest", "digest", "weekly_digest", "daily_digest"}
+PRE_MEETING_COMMANDS = {"pre_meeting_brief", "meeting_prep", "prep_meeting"}
+DECISION_RECALL_COMMANDS = {"decision_recall", "what_did_we_decide", "decision_history"}
+VALIDATE_COMMANDS = {"validate_memory", "validate", "confirm_memory", "review_stale"}
+WATCH_COMMANDS = {"watch_topic", "watch", "subscribe"}
 STORAGE_COLLECTIONS = {
     "briefs",
     "knowledge_entries",
     "retrieval_events",
     "reward_audits",
     "transcripts",
+    "memory_objects",
+    "memory_links",
+    "memory_validations",
+    "memory_subscriptions",
+    "memory_nudges",
+    "engagement_events",
 }
 
 
@@ -675,6 +687,16 @@ def normalize_request(config: dict[str, Any]) -> dict[str, Any]:
         mode = "brief"
     elif raw_command in DIFF_COMMANDS:
         mode = "diff"
+    elif raw_command in DIGEST_COMMANDS:
+        mode = "memory_digest"
+    elif raw_command in PRE_MEETING_COMMANDS:
+        mode = "pre_meeting_brief"
+    elif raw_command in DECISION_RECALL_COMMANDS:
+        mode = "decision_recall"
+    elif raw_command in VALIDATE_COMMANDS:
+        mode = "validate_memory"
+    elif raw_command in WATCH_COMMANDS:
+        mode = "watch_topic"
     else:
         mode = raw_command or "capture"
     query_text = str(inputs.get("query_text", "")).strip()
@@ -1062,6 +1084,42 @@ def run_once(config: dict[str, Any], dry_run: bool) -> dict[str, Any]:
         knowledge_entries = distill_knowledge_entries(config, request, transcript, sharepoint_context, asana_context, extracted_documents)
         transcript_write = archive_transcript(storage, request, transcript)
         knowledge_writes = persist_knowledge_entries(storage, knowledge_entries)
+
+        # --- Team Memory: distill structured memory objects from entries ---
+        memory_objects = team_memory.distill_structured_memories(knowledge_entries, request)
+        for mem in memory_objects:
+            storage.upsert("memory_objects", mem)
+
+        # --- Load existing memories for resurfacing/digest/validation ---
+        all_memories_response = storage.query("memory_objects", filters={"organization_name": request["organization_name"]})
+        all_memories = all_memories_response.get("records", [])
+
+        # --- Handle team memory modes ---
+        team_memory_result: dict[str, Any] = {}
+        if request["mode"] == "memory_digest":
+            team_memory_result = team_memory.generate_memory_digest(all_memories, request["current_date"])
+        elif request["mode"] == "pre_meeting_brief":
+            team_memory_result = team_memory.generate_pre_meeting_brief(all_memories, request["query_text"] or request["topic"], request["current_date"])
+        elif request["mode"] == "decision_recall":
+            decisions = [m for m in all_memories if m.get("memory_type") == "decision"]
+            resurfaced = team_memory.find_memories_to_resurface(decisions, request["query_text"] or request["topic"], request["current_date"], threshold=0.1)
+            team_memory_result = {"decisions": resurfaced, "total": len(resurfaced)}
+        elif request["mode"] == "validate_memory":
+            stale = team_memory.find_stale_memories(all_memories, request["current_date"])
+            team_memory_result = {"stale_memories": stale, "total": len(stale)}
+        elif request["mode"] == "watch_topic":
+            sub = {"id": f"sub-{str(uuid4())[:8]}", "user_id": request["requester_id"], "topic": request["query_text"] or request["topic"], "created_at": request["current_date"]}
+            storage.upsert("memory_subscriptions", sub)
+            team_memory_result = {"subscription": sub}
+
+        # --- Proactive resurfacing during retrieve mode ---
+        proactive_memories: list[dict[str, Any]] = []
+        if request["mode"] == "retrieve" and all_memories:
+            proactive_memories = team_memory.find_memories_to_resurface(all_memories, request["query_text"] or request["topic"], request["current_date"])
+            for mem in proactive_memories:
+                event = team_memory.build_engagement_event(event_type="reuse", memory_id=mem.get("id", ""), user_id=request["requester_id"], current_date=request["current_date"])
+                storage.upsert("engagement_events", event)
+
         candidate_entries = retrieve_candidate_entries(storage, request)
         if request["mode"] == "capture":
             candidate_entries = {"status": "ok", "records": knowledge_entries, "collection": "knowledge_entries", "connector": "storage", "action": "query"}
@@ -1077,6 +1135,13 @@ def run_once(config: dict[str, Any], dry_run: bool) -> dict[str, Any]:
         reward_audit = persist_rewards(storage, request, reward)
         working_brief = render_working_brief(storage, request, current_brief, sharepoint_context, asana_context, extracted_documents, filtered_results)
         brief_write = persist_working_brief_snapshot(storage, request, working_brief)
+
+        # --- Reinforcement messaging ---
+        reinforcement: str | None = None
+        engagement_events = storage.query("engagement_events").get("records", [])
+        if memory_objects:
+            reinforcement = team_memory.generate_reinforcement_message(engagement_events, memory_objects[0])
+
         return {
             "status": "ok",
             "skill": "knowledge",
@@ -1089,6 +1154,10 @@ def run_once(config: dict[str, Any], dry_run: bool) -> dict[str, Any]:
             "extracted_documents": extracted_documents,
             "transcript": transcript,
             "knowledge_entries": knowledge_entries,
+            "memory_objects": memory_objects,
+            "proactive_memories": proactive_memories,
+            "team_memory_result": team_memory_result,
+            "reinforcement": reinforcement,
             "transcript_write": transcript_write,
             "knowledge_writes": knowledge_writes,
             "retrieval_candidates": candidate_entries,

--- a/family-office/knowledge/scripts/team_memory.py
+++ b/family-office/knowledge/scripts/team_memory.py
@@ -1,0 +1,456 @@
+"""Team memory system for family-office knowledge skill.
+
+Structured memory objects, proactive resurfacing, stale-memory validation,
+decision recall, engagement tracking, and digest generation.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+# ---------------------------------------------------------------------------
+# Memory types
+# ---------------------------------------------------------------------------
+
+MEMORY_TYPES = {
+    "decision",
+    "assumption",
+    "preference",
+    "relationship",
+    "process",
+    "open_question",
+    "commitment",
+    "risk",
+    "source_claim",
+    "counterpoint",
+}
+
+VALID_LINK_TYPES = {"people", "entities", "teams", "documents", "meetings", "time_periods", "memories"}
+
+# Default review cadences by type (days)
+DEFAULT_REVIEW_CADENCE: dict[str, int] = {
+    "decision": 90,
+    "assumption": 30,
+    "preference": 180,
+    "relationship": 120,
+    "process": 60,
+    "open_question": 14,
+    "commitment": 30,
+    "risk": 14,
+    "source_claim": 60,
+    "counterpoint": 30,
+}
+
+STORAGE_COLLECTIONS_TEAM_MEMORY = {
+    "memory_objects",
+    "memory_links",
+    "memory_validations",
+    "memory_subscriptions",
+    "memory_nudges",
+    "engagement_events",
+}
+
+
+# ---------------------------------------------------------------------------
+# Memory object construction
+# ---------------------------------------------------------------------------
+
+
+def build_memory_object(
+    *,
+    memory_type: str,
+    key_claim: str,
+    subject: str = "",
+    owner_id: str = "",
+    team_scope: str = "team",
+    organization_name: str = "",
+    department: str = "",
+    confidence: str = "medium",
+    source: str = "",
+    source_id: str = "",
+    entity_refs: list[str] | None = None,
+    derived_from_ids: list[str] | None = None,
+    current_date: str = "",
+    review_cadence_days: int | None = None,
+) -> dict[str, Any]:
+    """Create a structured memory object."""
+    mtype = memory_type if memory_type in MEMORY_TYPES else "source_claim"
+    now = current_date or date.today().isoformat()
+    cadence = review_cadence_days if review_cadence_days is not None else DEFAULT_REVIEW_CADENCE.get(mtype, 30)
+    return {
+        "id": f"mem-{mtype[:4]}-{str(uuid4())[:8]}",
+        "memory_type": mtype,
+        "key_claim": key_claim,
+        "subject": subject,
+        "owner_id": owner_id,
+        "team_scope": team_scope,
+        "organization_name": organization_name,
+        "department": department,
+        "confidence_score": confidence,
+        "importance_score": "medium",
+        "validity_status": "active",
+        "source": source,
+        "source_id": source_id,
+        "entity_refs": entity_refs or [],
+        "derived_from_ids": derived_from_ids or [],
+        "created_at": now,
+        "updated_at": now,
+        "last_validated_at": now,
+        "next_review_at": now,  # placeholder — caller should compute
+        "review_cadence_days": cadence,
+        "used_count": 0,
+        "last_used_at": None,
+    }
+
+
+def build_memory_link(
+    *,
+    from_id: str,
+    to_id: str,
+    link_type: str,
+    label: str = "",
+    current_date: str = "",
+) -> dict[str, Any]:
+    """Create a link between a memory and an entity or another memory."""
+    return {
+        "id": f"link-{str(uuid4())[:8]}",
+        "from_memory_id": from_id,
+        "to_id": to_id,
+        "link_type": link_type if link_type in VALID_LINK_TYPES else "entities",
+        "label": label,
+        "created_at": current_date or date.today().isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Distillation: classify user text into memory types
+# ---------------------------------------------------------------------------
+
+_TYPE_SIGNALS: dict[str, list[str]] = {
+    "decision": ["decided", "agreed", "approved", "chose", "selected", "go with", "decision"],
+    "assumption": ["assuming", "assumption", "we believe", "expect that", "predicated on"],
+    "preference": ["prefer", "preference", "always want", "never want", "standard is"],
+    "commitment": ["committed", "promised", "obligation", "deadline", "must deliver", "owe"],
+    "risk": ["risk", "concern", "exposure", "downside", "watch out", "threat", "vulnerability"],
+    "open_question": ["question", "unclear", "unresolved", "need to find out", "tbd", "open item", "?"],
+    "process": ["process", "workflow", "procedure", "steps to", "protocol", "routine"],
+    "relationship": ["relationship", "partner", "advisor", "manager", "introduced by", "works with"],
+    "counterpoint": ["however", "counterpoint", "on the other hand", "disagree", "pushback", "caveat"],
+}
+
+
+def classify_memory_type(text: str) -> str:
+    """Infer the best memory type from text content using keyword signals."""
+    lower = text.lower()
+    best_type = "source_claim"
+    best_count = 0
+    for mtype, signals in _TYPE_SIGNALS.items():
+        count = sum(1 for s in signals if s in lower)
+        if count > best_count:
+            best_count = count
+            best_type = mtype
+    return best_type
+
+
+def distill_structured_memories(
+    entries: list[dict[str, Any]],
+    request: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Convert flat knowledge entries into structured memory objects.
+
+    Preserves backward compatibility — each entry gets wrapped as a memory
+    object with an inferred type, and the original entry fields are kept.
+    """
+    memories: list[dict[str, Any]] = []
+    for entry in entries:
+        text = entry.get("content", "") or entry.get("summary", "")
+        mtype = classify_memory_type(text)
+        mem = build_memory_object(
+            memory_type=mtype,
+            key_claim=entry.get("summary", text[:200]),
+            subject=entry.get("topic", request.get("topic", "")),
+            owner_id=entry.get("owner_id", request.get("requester_id", "")),
+            team_scope=entry.get("access_scope", request.get("access_scope", "team")),
+            organization_name=entry.get("organization_name", request.get("organization_name", "")),
+            department=entry.get("department", request.get("department", "")),
+            source=entry.get("source", ""),
+            source_id=entry.get("id", ""),
+            current_date=request.get("current_date", ""),
+        )
+        # Carry forward original entry fields for backward compat
+        mem["original_entry_id"] = entry.get("id", "")
+        mem["title"] = entry.get("title", "")
+        mem["content"] = text
+        memories.append(mem)
+    return memories
+
+
+# ---------------------------------------------------------------------------
+# Proactive resurfacing
+# ---------------------------------------------------------------------------
+
+
+def compute_resurfacing_score(
+    memory: dict[str, Any],
+    query_text: str,
+    current_date: str,
+) -> float:
+    """Score how relevant a memory is for proactive resurfacing.
+
+    Higher scores mean the memory should be surfaced. Range: 0.0-1.0.
+    """
+    score = 0.0
+    # Keyword overlap
+    query_terms = set(query_text.lower().split())
+    claim_terms = set(memory.get("key_claim", "").lower().split())
+    subject_terms = set(memory.get("subject", "").lower().split())
+    overlap = len(query_terms & (claim_terms | subject_terms))
+    if query_terms:
+        score += min(overlap / len(query_terms), 1.0) * 0.4
+
+    # Importance boost
+    importance = memory.get("importance_score", "medium")
+    if importance == "high":
+        score += 0.2
+    elif importance == "medium":
+        score += 0.1
+
+    # Staleness signal — stale memories with active status need attention
+    validity = memory.get("validity_status", "active")
+    if validity == "active":
+        try:
+            last_val = date.fromisoformat(str(memory.get("last_validated_at", current_date))[:10])
+            cadence = int(memory.get("review_cadence_days", 30))
+            cur = date.fromisoformat(current_date[:10])
+            days_since = (cur - last_val).days
+            if days_since > cadence:
+                score += 0.2  # overdue for validation
+        except (ValueError, TypeError):
+            pass
+
+    # Type boost — decisions and risks matter more
+    mtype = memory.get("memory_type", "")
+    if mtype in ("decision", "risk", "commitment"):
+        score += 0.1
+    elif mtype in ("open_question", "assumption"):
+        score += 0.05
+
+    # Usage — less-used memories may be forgotten and need resurfacing
+    used = int(memory.get("used_count", 0))
+    if used == 0:
+        score += 0.1
+
+    return min(score, 1.0)
+
+
+def find_memories_to_resurface(
+    memories: list[dict[str, Any]],
+    query_text: str,
+    current_date: str,
+    threshold: float = 0.3,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Find memories that should be proactively resurfaced for a given query."""
+    scored = []
+    for mem in memories:
+        if mem.get("validity_status") == "retired":
+            continue
+        s = compute_resurfacing_score(mem, query_text, current_date)
+        if s >= threshold:
+            scored.append((s, mem))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    results = []
+    for s, mem in scored[:limit]:
+        result = {**mem, "resurfacing_score": round(s, 3)}
+        results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Stale memory validation
+# ---------------------------------------------------------------------------
+
+
+def find_stale_memories(
+    memories: list[dict[str, Any]],
+    current_date: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Find active memories that are overdue for validation."""
+    stale: list[tuple[int, dict[str, Any]]] = []
+    for mem in memories:
+        if mem.get("validity_status") != "active":
+            continue
+        try:
+            last_val = date.fromisoformat(str(mem.get("last_validated_at", current_date))[:10])
+            cadence = int(mem.get("review_cadence_days", 30))
+            cur = date.fromisoformat(current_date[:10])
+            days_overdue = (cur - last_val).days - cadence
+            if days_overdue > 0:
+                stale.append((days_overdue, mem))
+        except (ValueError, TypeError):
+            continue
+    stale.sort(key=lambda x: x[0], reverse=True)
+    return [
+        {**mem, "days_overdue": days, "validation_prompt": _validation_prompt(mem)}
+        for days, mem in stale[:limit]
+    ]
+
+
+def _validation_prompt(memory: dict[str, Any]) -> str:
+    """Generate a validation question for a stale memory."""
+    mtype = memory.get("memory_type", "claim")
+    claim = memory.get("key_claim", "")[:100]
+    if mtype == "assumption":
+        return f"Is this assumption still valid? \"{claim}\""
+    if mtype == "decision":
+        return f"Does this decision still hold? \"{claim}\""
+    if mtype == "risk":
+        return f"Is this risk still relevant? \"{claim}\""
+    if mtype == "commitment":
+        return f"Has this commitment been fulfilled? \"{claim}\""
+    if mtype == "open_question":
+        return f"Has this been resolved? \"{claim}\""
+    return f"Is this still accurate? \"{claim}\""
+
+
+def validate_memory(
+    memory: dict[str, Any],
+    *,
+    confirmed: bool,
+    revised_claim: str = "",
+    validator_id: str = "",
+    current_date: str = "",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Apply a validation to a memory. Returns (updated_memory, validation_record)."""
+    now = current_date or date.today().isoformat()
+    validation = {
+        "id": f"val-{str(uuid4())[:8]}",
+        "memory_id": memory.get("id", ""),
+        "validator_id": validator_id,
+        "action": "confirmed" if confirmed else "revised" if revised_claim else "retired",
+        "previous_claim": memory.get("key_claim", ""),
+        "revised_claim": revised_claim if revised_claim else None,
+        "validated_at": now,
+    }
+    updated = {**memory}
+    updated["last_validated_at"] = now
+    updated["updated_at"] = now
+    if confirmed:
+        updated["validity_status"] = "active"
+    elif revised_claim:
+        updated["key_claim"] = revised_claim
+        updated["validity_status"] = "active"
+    else:
+        updated["validity_status"] = "retired"
+    return updated, validation
+
+
+# ---------------------------------------------------------------------------
+# Engagement events
+# ---------------------------------------------------------------------------
+
+
+def build_engagement_event(
+    *,
+    event_type: str,
+    memory_id: str = "",
+    user_id: str = "",
+    detail: str = "",
+    current_date: str = "",
+) -> dict[str, Any]:
+    """Track a memory engagement event (reuse, validation, nudge acted on, etc)."""
+    return {
+        "id": f"eng-{str(uuid4())[:8]}",
+        "event_type": event_type,
+        "memory_id": memory_id,
+        "user_id": user_id,
+        "detail": detail,
+        "created_at": current_date or datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def generate_reinforcement_message(
+    engagement_events: list[dict[str, Any]],
+    memory: dict[str, Any],
+) -> str | None:
+    """Generate a positive reinforcement message based on engagement data."""
+    reuse_count = sum(1 for e in engagement_events if e.get("memory_id") == memory.get("id") and e.get("event_type") == "reuse")
+    if reuse_count >= 3:
+        return f"Your note \"{memory.get('title', memory.get('key_claim', ''))[:50]}\" has been reused {reuse_count} times across team workflows."
+    validations = sum(1 for e in engagement_events if e.get("memory_id") == memory.get("id") and e.get("event_type") == "validation")
+    if validations >= 1:
+        mtype = memory.get("memory_type", "claim")
+        if mtype == "open_question":
+            return f"You resolved an open question that was blocking follow-up work."
+        if mtype == "assumption":
+            return f"You confirmed a stale assumption — future briefs will be more accurate."
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Digest and pre-meeting brief generation
+# ---------------------------------------------------------------------------
+
+
+def generate_memory_digest(
+    memories: list[dict[str, Any]],
+    current_date: str,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Generate a daily/weekly digest of memory state."""
+    stale = find_stale_memories(memories, current_date, limit=5)
+    recent = [m for m in memories if m.get("created_at", "") >= current_date[:7]]  # same month
+    high_importance = [m for m in memories if m.get("importance_score") == "high" and m.get("validity_status") == "active"]
+    open_questions = [m for m in memories if m.get("memory_type") == "open_question" and m.get("validity_status") == "active"]
+    risks = [m for m in memories if m.get("memory_type") == "risk" and m.get("validity_status") == "active"]
+    return {
+        "digest_date": current_date,
+        "total_memories": len(memories),
+        "active_memories": sum(1 for m in memories if m.get("validity_status") == "active"),
+        "stale_memories": stale,
+        "recent_additions": recent[:limit],
+        "high_importance": high_importance[:limit],
+        "open_questions": open_questions[:limit],
+        "active_risks": risks[:limit],
+    }
+
+
+def generate_pre_meeting_brief(
+    memories: list[dict[str, Any]],
+    meeting_topic: str,
+    current_date: str,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Compile relevant memories for a meeting or decision context."""
+    resurfaced = find_memories_to_resurface(memories, meeting_topic, current_date, threshold=0.2, limit=limit)
+    decisions = [m for m in resurfaced if m.get("memory_type") == "decision"]
+    assumptions = [m for m in resurfaced if m.get("memory_type") == "assumption"]
+    risks = [m for m in resurfaced if m.get("memory_type") == "risk"]
+    open_qs = [m for m in resurfaced if m.get("memory_type") == "open_question"]
+    commitments = [m for m in resurfaced if m.get("memory_type") == "commitment"]
+    stale_in_scope = [m for m in resurfaced if m.get("validity_status") == "active" and _is_stale(m, current_date)]
+    return {
+        "meeting_topic": meeting_topic,
+        "prepared_at": current_date,
+        "prior_decisions": decisions,
+        "active_assumptions": assumptions,
+        "active_risks": risks,
+        "open_questions": open_qs,
+        "commitments": commitments,
+        "stale_requiring_validation": stale_in_scope,
+        "all_relevant": resurfaced,
+        "total_surfaced": len(resurfaced),
+    }
+
+
+def _is_stale(memory: dict[str, Any], current_date: str) -> bool:
+    try:
+        last_val = date.fromisoformat(str(memory.get("last_validated_at", current_date))[:10])
+        cadence = int(memory.get("review_cadence_days", 30))
+        cur = date.fromisoformat(current_date[:10])
+        return (cur - last_val).days > cadence
+    except (ValueError, TypeError):
+        return False

--- a/family-office/knowledge/tests/test_team_memory.py
+++ b/family-office/knowledge/tests/test_team_memory.py
@@ -1,0 +1,284 @@
+"""Tests for team memory system (issue #371).
+
+Covers: structured memory distillation, proactive resurfacing, stale
+validation, new command modes, engagement events, and backward compatibility.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+SCRIPT_PATH = SCRIPT_DIR / "agent.py"
+TM_PATH = SCRIPT_DIR / "team_memory.py"
+
+
+def _load_team_memory():
+    spec = importlib.util.spec_from_file_location("team_memory", TM_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def tm():
+    return _load_team_memory()
+
+
+def _load_agent():
+    spec = importlib.util.spec_from_file_location("knowledge_agent", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def _base_config(command: str) -> dict:
+    return {
+        "current_date": "2026-04-04",
+        "dry_run": True,
+        "inputs": {
+            "access_scope": "team",
+            "asana_sync_enabled": True,
+            "command": command,
+            "department": "investments",
+            "interview_mode": "freeform",
+            "organization_name": "Rendero Trust",
+            "query_text": "tax strategy",
+            "requester_id": "user-123",
+            "reward_base_usd": 100,
+            "reward_per_retrieval_usd": 1,
+            "sharepoint_sync_enabled": True,
+            "top_k": 5,
+        },
+        "storage_records": {
+            "briefs": [],
+            "knowledge_entries": [],
+            "retrieval_events": [],
+            "reward_audits": [],
+            "transcripts": [],
+            "memory_objects": [],
+            "memory_links": [],
+            "memory_validations": [],
+            "memory_subscriptions": [],
+            "memory_nudges": [],
+            "engagement_events": [],
+        },
+        "sharepoint_context": [],
+        "asana_context": [],
+        "documents": [],
+        "interview_transcript": [],
+    }
+
+
+# --- Structured memory distillation ---
+
+
+class TestClassifyMemoryType:
+
+    def test_decision_detected(self, tm) -> None:
+        assert tm.classify_memory_type("We decided to go with the new fund structure") == "decision"
+
+    def test_assumption_detected(self, tm) -> None:
+        assert tm.classify_memory_type("Assuming the tax rate stays at 21%") == "assumption"
+
+    def test_risk_detected(self, tm) -> None:
+        assert tm.classify_memory_type("The main risk is currency exposure in the European portfolio") == "risk"
+
+    def test_open_question_detected(self, tm) -> None:
+        assert tm.classify_memory_type("Need to find out whether the LP has capacity?") == "open_question"
+
+    def test_commitment_detected(self, tm) -> None:
+        assert tm.classify_memory_type("We committed to delivering the report by Friday deadline") == "commitment"
+
+    def test_fallback_to_source_claim(self, tm) -> None:
+        assert tm.classify_memory_type("The portfolio returned 12% last year") == "source_claim"
+
+
+class TestDistillStructuredMemories:
+
+    def test_entries_become_memory_objects(self, tm) -> None:
+        entries = [
+            {"id": "e1", "summary": "We decided to use QSBS", "content": "We decided to use QSBS", "topic": "tax", "owner_id": "u1", "source": "interview"},
+            {"id": "e2", "summary": "Risk of audit exposure", "content": "Risk of audit exposure", "topic": "tax", "owner_id": "u1", "source": "sharepoint"},
+        ]
+        request = {"topic": "tax", "requester_id": "u1", "access_scope": "team", "organization_name": "Test", "department": "ops", "current_date": "2026-04-04"}
+        memories = tm.distill_structured_memories(entries, request)
+        assert len(memories) == 2
+        assert memories[0]["memory_type"] == "decision"
+        assert memories[1]["memory_type"] == "risk"
+        assert all("id" in m and "key_claim" in m and "validity_status" in m for m in memories)
+        # Backward compat: original entry fields preserved
+        assert memories[0]["original_entry_id"] == "e1"
+
+
+# --- Proactive resurfacing ---
+
+
+class TestResurfacing:
+
+    def test_relevant_memories_surface(self, tm) -> None:
+        memories = [
+            tm.build_memory_object(memory_type="decision", key_claim="Use QSBS for tax optimization", subject="tax strategy", current_date="2026-03-01"),
+            tm.build_memory_object(memory_type="risk", key_claim="Currency exposure in European bonds", subject="bonds", current_date="2026-03-01"),
+        ]
+        results = tm.find_memories_to_resurface(memories, "tax strategy planning", "2026-04-04", threshold=0.1)
+        assert len(results) >= 1
+        assert any("tax" in r.get("key_claim", "").lower() for r in results)
+
+    def test_retired_memories_excluded(self, tm) -> None:
+        mem = tm.build_memory_object(memory_type="decision", key_claim="Old decision", subject="tax", current_date="2026-01-01")
+        mem["validity_status"] = "retired"
+        results = tm.find_memories_to_resurface([mem], "tax", "2026-04-04")
+        assert len(results) == 0
+
+
+# --- Stale memory validation ---
+
+
+class TestStaleValidation:
+
+    def test_overdue_memories_found(self, tm) -> None:
+        mem = tm.build_memory_object(memory_type="assumption", key_claim="Tax rate stays at 21%", current_date="2026-01-01")
+        mem["review_cadence_days"] = 30
+        mem["last_validated_at"] = "2026-01-01"
+        stale = tm.find_stale_memories([mem], "2026-04-04")
+        assert len(stale) == 1
+        assert stale[0]["days_overdue"] > 60
+        assert "still valid" in stale[0]["validation_prompt"].lower()
+
+    def test_validate_confirm(self, tm) -> None:
+        mem = tm.build_memory_object(memory_type="assumption", key_claim="Rate is 21%", current_date="2026-01-01")
+        updated, validation = tm.validate_memory(mem, confirmed=True, validator_id="user-1", current_date="2026-04-04")
+        assert updated["validity_status"] == "active"
+        assert updated["last_validated_at"] == "2026-04-04"
+        assert validation["action"] == "confirmed"
+
+    def test_validate_revise(self, tm) -> None:
+        mem = tm.build_memory_object(memory_type="assumption", key_claim="Rate is 21%", current_date="2026-01-01")
+        updated, validation = tm.validate_memory(mem, confirmed=False, revised_claim="Rate is now 25%", current_date="2026-04-04")
+        assert updated["key_claim"] == "Rate is now 25%"
+        assert validation["action"] == "revised"
+
+    def test_validate_retire(self, tm) -> None:
+        mem = tm.build_memory_object(memory_type="assumption", key_claim="Old assumption", current_date="2026-01-01")
+        updated, validation = tm.validate_memory(mem, confirmed=False, current_date="2026-04-04")
+        assert updated["validity_status"] == "retired"
+        assert validation["action"] == "retired"
+
+
+# --- Digest and pre-meeting brief ---
+
+
+class TestDigestAndBrief:
+
+    def test_digest_includes_stale_and_open_questions(self, tm) -> None:
+        memories = [
+            tm.build_memory_object(memory_type="open_question", key_claim="LP capacity?", current_date="2026-04-01"),
+            tm.build_memory_object(memory_type="assumption", key_claim="Rate stays", current_date="2026-01-01"),
+        ]
+        memories[1]["last_validated_at"] = "2026-01-01"
+        memories[1]["review_cadence_days"] = 30
+        digest = tm.generate_memory_digest(memories, "2026-04-04")
+        assert digest["total_memories"] == 2
+        assert len(digest["open_questions"]) == 1
+        assert len(digest["stale_memories"]) == 1
+
+    def test_pre_meeting_brief_surfaces_decisions(self, tm) -> None:
+        memories = [
+            tm.build_memory_object(memory_type="decision", key_claim="Approved QSBS strategy for tax", subject="tax planning", current_date="2026-03-01"),
+            tm.build_memory_object(memory_type="risk", key_claim="Regulatory risk on new fund", subject="fund launch", current_date="2026-03-15"),
+        ]
+        brief = tm.generate_pre_meeting_brief(memories, "tax planning review", "2026-04-04")
+        assert brief["meeting_topic"] == "tax planning review"
+        assert len(brief["prior_decisions"]) >= 1
+
+
+# --- Agent integration: new modes produce output ---
+
+
+class TestAgentNewModes:
+
+    def test_capture_produces_memory_objects(self, monkeypatch) -> None:
+        agent = _load_agent()
+        monkeypatch.setattr(agent, "fire_reward_webhook", lambda **_: {"status": "skipped"})
+        config = _base_config("capture")
+        config["interview_transcript"] = [
+            {"speaker": "user", "text": "We decided to restructure the trust before Q4."},
+        ]
+        result = agent.run_once(config, dry_run=True)
+        assert result["status"] == "ok"
+        assert len(result["memory_objects"]) >= 1
+        assert result["memory_objects"][0]["memory_type"] == "decision"
+        # Backward compat: knowledge_entries still produced
+        assert len(result["knowledge_entries"]) >= 1
+
+    def test_memory_digest_mode(self, monkeypatch) -> None:
+        agent = _load_agent()
+        monkeypatch.setattr(agent, "fire_reward_webhook", lambda **_: {"status": "skipped"})
+        config = _base_config("memory_digest")
+        result = agent.run_once(config, dry_run=True)
+        assert result["normalized_request"]["mode"] == "memory_digest"
+        assert "total_memories" in result["team_memory_result"]
+
+    def test_validate_memory_mode(self, monkeypatch) -> None:
+        agent = _load_agent()
+        monkeypatch.setattr(agent, "fire_reward_webhook", lambda **_: {"status": "skipped"})
+        config = _base_config("validate_memory")
+        result = agent.run_once(config, dry_run=True)
+        assert result["normalized_request"]["mode"] == "validate_memory"
+        assert "stale_memories" in result["team_memory_result"]
+
+    def test_watch_topic_creates_subscription(self, monkeypatch) -> None:
+        agent = _load_agent()
+        monkeypatch.setattr(agent, "fire_reward_webhook", lambda **_: {"status": "skipped"})
+        config = _base_config("watch_topic")
+        result = agent.run_once(config, dry_run=True)
+        assert result["normalized_request"]["mode"] == "watch_topic"
+        assert "subscription" in result["team_memory_result"]
+        assert len(result["storage_state"]["memory_subscriptions"]) == 1
+
+
+# --- Backward compatibility ---
+
+
+class TestBackwardCompat:
+
+    def test_retrieve_still_works(self, monkeypatch) -> None:
+        agent = _load_agent()
+        monkeypatch.setattr(agent, "fire_reward_webhook", lambda **_: {"status": "sent", "transaction_id": "tx"})
+        config = _base_config("recall")
+        config["storage_records"]["knowledge_entries"] = [
+            {
+                "id": "entry-1", "organization_name": "Rendero Trust",
+                "department": "investments", "topic": "tax strategy",
+                "title": "QSBS planning", "summary": "Use QSBS.", "content": "Use QSBS.",
+                "owner_id": "user-999", "access_scope": "public",
+                "created_at": "2026-03-20", "updated_at": "2026-03-20", "stale_after_days": 30,
+            },
+        ]
+        result = agent.run_once(config, dry_run=True)
+        assert result["status"] == "ok"
+        assert result["normalized_request"]["mode"] == "retrieve"
+        assert len(result["retrieval_results"]["records"]) >= 1
+
+    def test_brief_still_works(self) -> None:
+        agent = _load_agent()
+        config = _base_config("show_brief")
+        config["storage_records"]["briefs"] = [
+            {"id": "b1", "organization_name": "Rendero Trust", "department": "investments",
+             "headline": "Pipeline", "summary": "Active deals.", "priorities": ["Close Fund IV"],
+             "risks": ["Timing"], "created_at": "2026-03-15", "updated_at": "2026-03-25"},
+        ]
+        result = agent.run_once(config, dry_run=True)
+        assert result["status"] == "ok"
+        assert result["normalized_request"]["mode"] == "brief"


### PR DESCRIPTION
## Summary

Transform `family-office/knowledge` from a passive capture-and-recall archive into an institutional memory system.

### New: team_memory.py module
- **10 structured memory types**: decision, assumption, preference, relationship, process, open_question, commitment, risk, source_claim, counterpoint
- **Memory type classification**: keyword-based inference from capture text
- **Proactive resurfacing**: scorer combining keyword overlap, importance, staleness, type, and usage
- **Stale memory validation**: detect overdue memories, generate validation prompts, support confirm/revise/retire
- **Pre-meeting briefs**: compile decisions, assumptions, risks, open questions for a topic
- **Memory digests**: summary of new, stale, high-importance, and open-question memory
- **Engagement tracking**: reuse events, validation events, reinforcement messages

### Agent integration
- Capture now produces `memory_objects` alongside flat entries (backward compatible)
- 5 new modes: `memory_digest`, `pre_meeting_brief`, `decision_recall`, `validate_memory`, `watch_topic`
- Proactive resurfacing during `retrieve` mode with engagement logging
- Reinforcement tied to real leverage (reuse count, validation impact), not vanity

### Schema guard
5 new tables: `memory_objects`, `memory_links`, `memory_validations`, `memory_subscriptions`, `engagement_events`

## Test plan

**21 new tests** (team_memory.py + agent integration):
- [x] Memory type classification (6 tests: decision, assumption, risk, open_question, commitment, fallback)
- [x] Structured distillation (entries become typed memory objects with backward-compat fields)
- [x] Proactive resurfacing (relevant memories surface, retired excluded)
- [x] Stale validation (overdue detection, confirm, revise, retire)
- [x] Digest and pre-meeting brief generation
- [x] Agent modes: capture produces memories, digest/validate/watch modes work
- [x] Backward compat: retrieve and brief modes unchanged

**5 existing smoke tests**: all pass unchanged

Closes #371

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com