### PR TITLE
feat(index): add per-skill lastModified from git log (seren-desktop#1476)

### DIFF
--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -2,11 +2,41 @@
 // ABOUTME: Builds a skills index JSON from all SKILL.md files in the repo.
 // ABOUTME: Output is uploaded to Cloudflare R2 by the build-skills-index workflow.
 
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const RAW_BASE = "https://raw.githubusercontent.com/serenorg/seren-skills/main";
+
+/**
+ * Get the last-commit ISO timestamp for a file from Git history.
+ *
+ * mtime is unreliable in CI because Git checkouts reset all file mtimes to
+ * the checkout time, not the original commit time. Using `git log -1 --format=%cI`
+ * gives us the actual last-commit timestamp, which is what desktop clients
+ * need to detect stale installed skills without hitting the GitHub API
+ * (seren-desktop#1476).
+ *
+ * Falls back to file mtime if git is unavailable or the file is untracked.
+ */
+function lastCommitISO(filePath) {
+  try {
+    const out = execFileSync(
+      "git",
+      ["log", "-1", "--format=%cI", "--", filePath],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    ).trim();
+    if (out) return out;
+  } catch {
+    // Fall through to mtime fallback
+  }
+  try {
+    return statSync(filePath).mtime.toISOString();
+  } catch {
+    return undefined;
+  }
+}
 
 function walkDir(dir) {
   const results = [];
@@ -91,13 +121,20 @@ for (const skillPath of skillFiles) {
     tags: parseTags(fm),
     author: fm.author,
     version: fm.version,
+    // Last-commit ISO timestamp for the SKILL.md file. Desktop clients use
+    // this to detect stale installed skills without hitting GitHub's
+    // anonymous-rate-limited commits API. (seren-desktop#1476)
+    lastModified: lastCommitISO(skillPath),
   });
 }
 
 skills.sort((a, b) => a.name.localeCompare(b.name));
 
 const index = {
-  version: "1",
+  // Bumped from "1" to "2" — schema now includes per-skill `lastModified`.
+  // Desktop clients that don't know about lastModified will simply ignore
+  // the new field and continue using the GitHub fallback for staleness checks.
+  version: "2",
   updatedAt: new Date().toISOString(),
   skills,
   tree: tree.sort(),


### PR DESCRIPTION
## Summary

Companion PR to [serenorg/seren-desktop#1479](https://github.com/serenorg/seren-desktop/pull/1479) (Slice D of seren-desktop#1476).

The desktop client needs per-skill commit timestamps in the R2 index to detect stale installed skills without hammering the GitHub commits API. Without this field, an idle desktop with N installed upstream-managed skills makes N+1 GitHub requests per refresh and burns through the anonymous 60/hr rate limit easily.

## Changes

- New `lastCommitISO()` helper reads `git log -1 --format=%cI -- <path>` for each `SKILL.md`. Falls back to file `mtime` if git is unavailable or the file is untracked.
- Each skill entry now carries `lastModified: <ISO 8601 timestamp>`.
- Index `version` bumped from `"1"` to `"2"`.

## Why `git log` instead of `mtime`

File mtimes are reset on every Git checkout to the checkout time, not the original commit time, so they are useless in CI. `git log -1 --format=%cI` returns the actual last-commit timestamp from history.

## Backward compatibility

- Desktop versions that don't know about `lastModified` ignore the field and continue using the GitHub fallback path.
- The matching desktop change ([seren-desktop d7b9ba62](https://github.com/serenorg/seren-desktop/commit/d7b9ba62)) treats v1 and v2 indexes interchangeably — only v2 short-circuits the GitHub call.

## Verification

Ran locally against the current repo:

```
node scripts/build-index.mjs
version: 2
skills count: 74
skills with lastModified: 74
```

74/74 skills have a real ISO timestamp from `git log`.

## Next deploy

Once this merges, the existing `build-skills-index` workflow will publish the v2 index to R2 on its next run. No deploy steps needed beyond merge.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
