### PR TITLE
fix: drop /call suffix from publisher URLs (resolves HTTP 403)

### DIFF
--- a/hyperliquid/5x-btc-usdc-withdraw/scripts/backtest.py
+++ b/hyperliquid/5x-btc-usdc-withdraw/scripts/backtest.py
@@ -25,7 +25,7 @@ MAINT_RATES = {5: 0.03, 10: 0.03, 20: 0.025, 25: 0.02, 50: 0.01}
 
 def _fetch_btc_prices(api_base: str, api_key: str, days: int = BACKTEST_DAYS) -> list[tuple[str, float]]:
     """Fetch daily BTC prices from CoinGecko via Seren publisher."""
-    url = f"{api_base}/publishers/{COINGECKO_PUBLISHER}/call"
+    url = f"{api_base}/publishers/{COINGECKO_PUBLISHER}"
     body = json.dumps({
         "method": "GET",
         "path": f"/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days={days}&interval=daily",

--- a/polymarket/p2p-hyperliquid-bitcoin-usdc-deposit/scripts/backtest.py
+++ b/polymarket/p2p-hyperliquid-bitcoin-usdc-deposit/scripts/backtest.py
@@ -25,7 +25,7 @@ MAINT_RATES = {5: 0.03, 10: 0.03, 20: 0.025, 25: 0.02, 50: 0.01}
 
 def _fetch_btc_prices(api_base: str, api_key: str, days: int = BACKTEST_DAYS) -> list[tuple[str, float]]:
     """Fetch daily BTC prices from CoinGecko via Seren publisher."""
-    url = f"{api_base}/publishers/{COINGECKO_PUBLISHER}/call"
+    url = f"{api_base}/publishers/{COINGECKO_PUBLISHER}"
     body = json.dumps({
         "method": "GET",
         "path": f"/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days={days}&interval=daily",

--- a/polymarket/p2p-leverage-bitcoin-usdc-deposit/scripts/agent.py
+++ b/polymarket/p2p-leverage-bitcoin-usdc-deposit/scripts/agent.py
@@ -130,7 +130,7 @@ def _fatal(msg: str, **kw: Any) -> None:
 def _rpc_call(api_base: str, api_key: str, publisher: str, method: str,
               params: list, timeout: int = 30) -> Any:
     """Call a Seren publisher with a JSON-RPC payload."""
-    url = f"{api_base}/publishers/{publisher}/call"
+    url = f"{api_base}/publishers/{publisher}"
     body = json.dumps({
         "jsonrpc": "2.0",
         "id": 1,


### PR DESCRIPTION
## Summary

- Removes the invalid `/call` suffix from publisher URL construction in three skills
- The Seren gateway x402 prepaid balance flow with Bearer auth works at `/publishers/{slug}`, not `/publishers/{slug}/call`
- The `/call` suffix caused HTTP 403 Forbidden on `coingecko-serenai`, `seren-base`, and `seren-polygon` publishers

Closes #377

## Files changed

- `hyperliquid/5x-btc-usdc-withdraw/scripts/backtest.py` - `_fetch_btc_prices()` coingecko-serenai
- `polymarket/p2p-hyperliquid-bitcoin-usdc-deposit/scripts/backtest.py` - `_fetch_btc_prices()` coingecko-serenai
- `polymarket/p2p-leverage-bitcoin-usdc-deposit/scripts/agent.py` - `_rpc_call()` seren-base, seren-polygon

## Test plan

- [ ] Run `hyperliquid/5x-btc-usdc-withdraw` backtest - should fetch BTC price data without 403
- [ ] Run `polymarket/p2p-hyperliquid-bitcoin-usdc-deposit` backtest - should fetch BTC price data without 403
- [ ] Run `polymarket/p2p-leverage-bitcoin-usdc-deposit` - should call seren-base and seren-polygon without 403

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
