### PR TITLE
fix: harden alpaca persistence contract

### DIFF
--- a/alpaca/saas-short-trader/scripts/self_learning.py
+++ b/alpaca/saas-short-trader/scripts/self_learning.py
@@ -172,7 +172,7 @@ def upsert_feature_snapshots(conn: psycopg.Connection, mode: str = "paper-sim") 
               SELECT
                 cs.run_id,
                 sr.mode,
-                COALESCE(sr.metadata->>'run_type', 'scan') AS run_type,
+                COALESCE(sr.run_type, sr.metadata->>'run_type', 'scan') AS run_type,
                 cs.ticker,
                 COALESCE(cs.created_at, NOW()) AS as_of_ts,
                 jsonb_build_object(
@@ -245,7 +245,7 @@ def upsert_outcome_labels(conn: psycopg.Connection, mode: str = "paper-sim") -> 
               END AS realized_return
             FROM trading.learning_feature_snapshots fs
             LEFT JOIN trading.position_marks_daily pm
-              ON pm.source_run_id = fs.run_id
+              ON COALESCE(pm.scan_run_id, pm.source_run_id) = fs.run_id
              AND pm.ticker = fs.ticker
              AND pm.mode = fs.mode
             WHERE fs.mode = %s

--- a/alpaca/saas-short-trader/scripts/serendb_schema.sql
+++ b/alpaca/saas-short-trader/scripts/serendb_schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS trading.strategy_runs (
   run_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   strategy_name TEXT NOT NULL DEFAULT 'saas-short-trader',
   mode TEXT NOT NULL CHECK (mode IN ('paper', 'paper-sim', 'live')),
+  run_type TEXT,
   run_date DATE NOT NULL DEFAULT CURRENT_DATE,
   status TEXT NOT NULL DEFAULT 'completed',
   universe TEXT[] NOT NULL,
@@ -28,6 +29,7 @@ ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS config JSONB NOT NULL
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS error_code TEXT;
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS error_message TEXT;
+ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS run_type TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_strategy_runs_skill_mode_started
   ON trading.strategy_runs (skill_slug, mode, started_at DESC);
@@ -185,10 +187,13 @@ CREATE TABLE IF NOT EXISTS trading.position_marks_daily (
   unrealized_pnl NUMERIC(18, 6) NOT NULL DEFAULT 0,
   gross_exposure NUMERIC(18, 6),
   net_exposure NUMERIC(18, 6),
+  scan_run_id UUID REFERENCES trading.strategy_runs(run_id),
   source_run_id UUID REFERENCES trading.strategy_runs(run_id),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (as_of_date, mode, ticker)
 );
+
+ALTER TABLE trading.position_marks_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);
 
 CREATE INDEX IF NOT EXISTS idx_position_marks_mode_date ON trading.position_marks_daily(mode, as_of_date DESC);
 
@@ -202,10 +207,13 @@ CREATE TABLE IF NOT EXISTS trading.pnl_daily (
   net_exposure NUMERIC(18, 6),
   hit_rate NUMERIC(8, 4),
   max_drawdown NUMERIC(18, 6),
+  scan_run_id UUID REFERENCES trading.strategy_runs(run_id),
   source_run_id UUID REFERENCES trading.strategy_runs(run_id),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (as_of_date, mode)
 );
+
+ALTER TABLE trading.pnl_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);
 
 CREATE INDEX IF NOT EXISTS idx_pnl_daily_mode_date ON trading.pnl_daily(mode, as_of_date DESC);
 

--- a/alpaca/saas-short-trader/scripts/serendb_storage.py
+++ b/alpaca/saas-short-trader/scripts/serendb_storage.py
@@ -71,7 +71,7 @@ class SerenDBStorage:
                     WHERE strategy_name = 'saas-short-trader'
                       AND mode = %s
                       AND status = 'running'
-                      AND COALESCE(metadata->>'run_type', '') = %s
+                      AND COALESCE(run_type, metadata->>'run_type', '') = %s
                       AND created_at >= NOW() - (%s || ' hours')::interval
                     ORDER BY created_at DESC
                     LIMIT 1
@@ -92,6 +92,7 @@ class SerenDBStorage:
         metadata: Dict[str, Any],
     ) -> str:
         run_id = str(uuid4())
+        run_type = str(metadata.get("run_type") or "").strip() or None
         self.reporter.start_run(
             run_id,
             mode=mode,
@@ -103,10 +104,10 @@ class SerenDBStorage:
                 cur.execute(
                     """
                     INSERT INTO trading.strategy_runs
-                      (run_id, skill_slug, venue, strategy_name, mode, status, dry_run, started_at,
+                      (run_id, skill_slug, venue, strategy_name, mode, run_type, status, dry_run, started_at,
                        run_date, universe, max_names_scored, max_names_orders, min_conviction, config, summary, metadata)
                     VALUES
-                      (%s, %s, 'alpaca', %s, %s, %s, %s, NOW(),
+                      (%s, %s, 'alpaca', %s, %s, %s, %s, %s, NOW(),
                        CURRENT_DATE, %s::text[], %s, %s, %s, %s::jsonb, '{}'::jsonb, %s::jsonb)
                     """,
                     (
@@ -114,6 +115,7 @@ class SerenDBStorage:
                         SKILL_SLUG,
                         STRATEGY_NAME,
                         mode,
+                        run_type,
                         status,
                         mode != "live",
                         universe,
@@ -304,13 +306,21 @@ class SerenDBStorage:
                         )
             conn.commit()
 
-    def upsert_position_marks(self, as_of_date: date, mode: str, rows: List[Dict[str, Any]], source_run_id: str) -> None:
+    def upsert_position_marks(
+        self,
+        as_of_date: date,
+        mode: str,
+        rows: List[Dict[str, Any]],
+        source_run_id: str,
+        scan_run_id: Optional[str] = None,
+    ) -> None:
         self.reporter.record_position_marks(source_run_id, rows)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for r in rows:
                     side = self._position_side(r.get("net_exposure"))
                     status = "closed" if abs(float(r["qty"])) <= 1e-9 else "open"
+                    row_scan_run_id = str(r.get("scan_run_id") or scan_run_id or source_run_id)
                     period_start, _ = self._period_bounds(as_of_date)
                     metadata_json = json.dumps(
                         {
@@ -318,15 +328,16 @@ class SerenDBStorage:
                             "mode": mode,
                             "gross_exposure": r.get("gross_exposure"),
                             "net_exposure": r.get("net_exposure"),
+                            "scan_run_id": row_scan_run_id,
                         }
                     )
                     cur.execute(
                         """
                         INSERT INTO trading.position_marks_daily
                           (as_of_date, mode, ticker, qty, avg_entry_price, mark_price, market_value,
-                           realized_pnl, unrealized_pnl, gross_exposure, net_exposure, source_run_id)
+                           realized_pnl, unrealized_pnl, gross_exposure, net_exposure, scan_run_id, source_run_id)
                         VALUES
-                          (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                          (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         ON CONFLICT (as_of_date, mode, ticker) DO UPDATE
                         SET qty = EXCLUDED.qty,
                             avg_entry_price = EXCLUDED.avg_entry_price,
@@ -336,6 +347,7 @@ class SerenDBStorage:
                             unrealized_pnl = EXCLUDED.unrealized_pnl,
                             gross_exposure = EXCLUDED.gross_exposure,
                             net_exposure = EXCLUDED.net_exposure,
+                            scan_run_id = EXCLUDED.scan_run_id,
                             source_run_id = EXCLUDED.source_run_id
                         """,
                         (
@@ -350,6 +362,7 @@ class SerenDBStorage:
                             r.get("unrealized_pnl", 0.0),
                             r.get("gross_exposure"),
                             r.get("net_exposure"),
+                            row_scan_run_id,
                             source_run_id,
                         ),
                     )
@@ -432,6 +445,7 @@ class SerenDBStorage:
         hit_rate: float,
         max_drawdown: float,
         source_run_id: str,
+        scan_run_id: Optional[str] = None,
     ) -> None:
         self.reporter.record_pnl(
             source_run_id,
@@ -450,9 +464,9 @@ class SerenDBStorage:
                     """
                     INSERT INTO trading.pnl_daily
                       (as_of_date, mode, realized_pnl, unrealized_pnl, net_pnl, gross_exposure, net_exposure,
-                       hit_rate, max_drawdown, source_run_id)
+                       hit_rate, max_drawdown, scan_run_id, source_run_id)
                     VALUES
-                      (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                      (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (as_of_date, mode) DO UPDATE
                     SET realized_pnl = EXCLUDED.realized_pnl,
                         unrealized_pnl = EXCLUDED.unrealized_pnl,
@@ -461,6 +475,7 @@ class SerenDBStorage:
                         net_exposure = EXCLUDED.net_exposure,
                         hit_rate = EXCLUDED.hit_rate,
                         max_drawdown = EXCLUDED.max_drawdown,
+                        scan_run_id = EXCLUDED.scan_run_id,
                         source_run_id = EXCLUDED.source_run_id
                     """,
                     (
@@ -473,6 +488,7 @@ class SerenDBStorage:
                         net_exposure,
                         hit_rate,
                         max_drawdown,
+                        scan_run_id,
                         source_run_id,
                     ),
                 )
@@ -523,7 +539,7 @@ class SerenDBStorage:
                       ON sr.run_id = e.run_id
                     WHERE sr.strategy_name = 'saas-short-trader'
                       AND sr.mode = %s
-                      AND COALESCE(sr.metadata->>'run_type', '') = 'scan'
+                      AND COALESCE(sr.run_type, sr.metadata->>'run_type', '') = 'scan'
                       AND sr.status = 'completed'
                       AND e.side = 'SELL'
                       AND NOT EXISTS (

--- a/alpaca/saas-short-trader/scripts/strategy_engine.py
+++ b/alpaca/saas-short-trader/scripts/strategy_engine.py
@@ -541,7 +541,13 @@ class StrategyEngine:
 
             sim = self.simulate(selected, orders)
             marks = self.build_marks_from_orders(orders, sim["mark_map"], run_id)
-            self.storage.upsert_position_marks(date.today(), mode, marks, source_run_id=run_id)
+            self.storage.upsert_position_marks(
+                date.today(),
+                mode,
+                marks,
+                source_run_id=run_id,
+                scan_run_id=run_id,
+            )
 
             self.storage.upsert_pnl_daily(
                 as_of_date=date.today(),
@@ -552,6 +558,7 @@ class StrategyEngine:
                 net_exposure=-sim["gross_exposure"],
                 hit_rate=sim["hit_rate_5d"],
                 max_drawdown=sim["max_drawdown"],
+                scan_run_id=run_id,
                 source_run_id=run_id,
             )
             # Keep reporting rows aligned across paper/paper-sim/live.
@@ -565,6 +572,7 @@ class StrategyEngine:
                     net_exposure=-sim["gross_exposure"],
                     hit_rate=sim["hit_rate_5d"],
                     max_drawdown=sim["max_drawdown"],
+                    scan_run_id=run_id,
                     source_run_id=run_id,
                 )
             self.storage.upsert_pnl_daily(
@@ -576,6 +584,7 @@ class StrategyEngine:
                 net_exposure=0.0,
                 hit_rate=0.0,
                 max_drawdown=sim["max_drawdown"],
+                scan_run_id=run_id,
                 source_run_id=run_id,
             )
 
@@ -723,6 +732,7 @@ class StrategyEngine:
                     marks.append(
                         {
                             "ticker": ticker,
+                            "scan_run_id": order.get("run_id"),
                             "qty": 0.0,
                             "avg_entry_price": entry,
                             "mark_price": mark,
@@ -742,6 +752,7 @@ class StrategyEngine:
                 marks.append(
                     {
                         "ticker": ticker,
+                        "scan_run_id": order.get("run_id"),
                         "qty": qty,
                         "avg_entry_price": entry,
                         "mark_price": mark,
@@ -756,6 +767,12 @@ class StrategyEngine:
             if close_events:
                 self.storage.insert_order_events(run_id, mode, close_events)
             self.storage.upsert_position_marks(date.today(), mode, marks, source_run_id=run_id)
+            scan_run_ids = {
+                str(order.get("run_id") or "").strip()
+                for order in latest_orders
+                if str(order.get("run_id") or "").strip()
+            }
+            pnl_scan_run_id = next(iter(scan_run_ids)) if len(scan_run_ids) == 1 else None
             total_net = total_realized + total_unrealized
             hit_rate = wins / max(1, len(latest_orders))
             max_drawdown = self.compute_drawdown(mode, total_net)
@@ -768,6 +785,7 @@ class StrategyEngine:
                 net_exposure=-gross,
                 hit_rate=hit_rate,
                 max_drawdown=max_drawdown,
+                scan_run_id=pnl_scan_run_id,
                 source_run_id=run_id,
             )
             self.storage.update_run_status(

--- a/alpaca/sass-short-trader-delta-neutral/scripts/self_learning.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/self_learning.py
@@ -172,7 +172,7 @@ def upsert_feature_snapshots(conn: psycopg.Connection, mode: str = "paper-sim") 
               SELECT
                 cs.run_id,
                 sr.mode,
-                COALESCE(sr.metadata->>'run_type', 'scan') AS run_type,
+                COALESCE(sr.run_type, sr.metadata->>'run_type', 'scan') AS run_type,
                 cs.ticker,
                 COALESCE(cs.created_at, NOW()) AS as_of_ts,
                 jsonb_build_object(
@@ -245,7 +245,7 @@ def upsert_outcome_labels(conn: psycopg.Connection, mode: str = "paper-sim") -> 
               END AS realized_return
             FROM trading.learning_feature_snapshots fs
             LEFT JOIN trading.position_marks_daily pm
-              ON pm.source_run_id = fs.run_id
+              ON COALESCE(pm.scan_run_id, pm.source_run_id) = fs.run_id
              AND pm.ticker = fs.ticker
              AND pm.mode = fs.mode
             WHERE fs.mode = %s

--- a/alpaca/sass-short-trader-delta-neutral/scripts/serendb_schema.sql
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/serendb_schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS trading.strategy_runs (
   run_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   strategy_name TEXT NOT NULL DEFAULT 'sass-short-trader-delta-neutral',
   mode TEXT NOT NULL CHECK (mode IN ('paper', 'paper-sim', 'live')),
+  run_type TEXT,
   run_date DATE NOT NULL DEFAULT CURRENT_DATE,
   status TEXT NOT NULL DEFAULT 'completed',
   universe TEXT[] NOT NULL,
@@ -28,6 +29,7 @@ ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS config JSONB NOT NULL
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS error_code TEXT;
 ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS error_message TEXT;
+ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS run_type TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_strategy_runs_skill_mode_started
   ON trading.strategy_runs (skill_slug, mode, started_at DESC);
@@ -185,10 +187,13 @@ CREATE TABLE IF NOT EXISTS trading.position_marks_daily (
   unrealized_pnl NUMERIC(18, 6) NOT NULL DEFAULT 0,
   gross_exposure NUMERIC(18, 6),
   net_exposure NUMERIC(18, 6),
+  scan_run_id UUID REFERENCES trading.strategy_runs(run_id),
   source_run_id UUID REFERENCES trading.strategy_runs(run_id),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (as_of_date, mode, ticker)
 );
+
+ALTER TABLE trading.position_marks_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);
 
 CREATE INDEX IF NOT EXISTS idx_position_marks_mode_date ON trading.position_marks_daily(mode, as_of_date DESC);
 
@@ -202,10 +207,13 @@ CREATE TABLE IF NOT EXISTS trading.pnl_daily (
   net_exposure NUMERIC(18, 6),
   hit_rate NUMERIC(8, 4),
   max_drawdown NUMERIC(18, 6),
+  scan_run_id UUID REFERENCES trading.strategy_runs(run_id),
   source_run_id UUID REFERENCES trading.strategy_runs(run_id),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (as_of_date, mode)
 );
+
+ALTER TABLE trading.pnl_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);
 
 CREATE INDEX IF NOT EXISTS idx_pnl_daily_mode_date ON trading.pnl_daily(mode, as_of_date DESC);
 

--- a/alpaca/sass-short-trader-delta-neutral/scripts/serendb_storage.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/serendb_storage.py
@@ -71,7 +71,7 @@ class SerenDBStorage:
                     WHERE strategy_name = 'sass-short-trader-delta-neutral'
                       AND mode = %s
                       AND status = 'running'
-                      AND COALESCE(metadata->>'run_type', '') = %s
+                      AND COALESCE(run_type, metadata->>'run_type', '') = %s
                       AND created_at >= NOW() - (%s || ' hours')::interval
                     ORDER BY created_at DESC
                     LIMIT 1
@@ -92,6 +92,7 @@ class SerenDBStorage:
         metadata: Dict[str, Any],
     ) -> str:
         run_id = str(uuid4())
+        run_type = str(metadata.get("run_type") or "").strip() or None
         self.reporter.start_run(
             run_id,
             mode=mode,
@@ -103,10 +104,10 @@ class SerenDBStorage:
                 cur.execute(
                     """
                     INSERT INTO trading.strategy_runs
-                      (run_id, skill_slug, venue, strategy_name, mode, status, dry_run, started_at,
+                      (run_id, skill_slug, venue, strategy_name, mode, run_type, status, dry_run, started_at,
                        run_date, universe, max_names_scored, max_names_orders, min_conviction, config, summary, metadata)
                     VALUES
-                      (%s, %s, 'alpaca', %s, %s, %s, %s, NOW(),
+                      (%s, %s, 'alpaca', %s, %s, %s, %s, %s, NOW(),
                        CURRENT_DATE, %s::text[], %s, %s, %s, %s::jsonb, '{}'::jsonb, %s::jsonb)
                     """,
                     (
@@ -114,6 +115,7 @@ class SerenDBStorage:
                         SKILL_SLUG,
                         STRATEGY_NAME,
                         mode,
+                        run_type,
                         status,
                         mode != "live",
                         universe,
@@ -304,13 +306,21 @@ class SerenDBStorage:
                         )
             conn.commit()
 
-    def upsert_position_marks(self, as_of_date: date, mode: str, rows: List[Dict[str, Any]], source_run_id: str) -> None:
+    def upsert_position_marks(
+        self,
+        as_of_date: date,
+        mode: str,
+        rows: List[Dict[str, Any]],
+        source_run_id: str,
+        scan_run_id: Optional[str] = None,
+    ) -> None:
         self.reporter.record_position_marks(source_run_id, rows)
         with self.connect() as conn:
             with conn.cursor() as cur:
                 for r in rows:
                     side = self._position_side(r.get("net_exposure"))
                     status = "closed" if abs(float(r["qty"])) <= 1e-9 else "open"
+                    row_scan_run_id = str(r.get("scan_run_id") or scan_run_id or source_run_id)
                     period_start, _ = self._period_bounds(as_of_date)
                     metadata_json = json.dumps(
                         {
@@ -318,15 +328,16 @@ class SerenDBStorage:
                             "mode": mode,
                             "gross_exposure": r.get("gross_exposure"),
                             "net_exposure": r.get("net_exposure"),
+                            "scan_run_id": row_scan_run_id,
                         }
                     )
                     cur.execute(
                         """
                         INSERT INTO trading.position_marks_daily
                           (as_of_date, mode, ticker, qty, avg_entry_price, mark_price, market_value,
-                           realized_pnl, unrealized_pnl, gross_exposure, net_exposure, source_run_id)
+                           realized_pnl, unrealized_pnl, gross_exposure, net_exposure, scan_run_id, source_run_id)
                         VALUES
-                          (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                          (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         ON CONFLICT (as_of_date, mode, ticker) DO UPDATE
                         SET qty = EXCLUDED.qty,
                             avg_entry_price = EXCLUDED.avg_entry_price,
@@ -336,6 +347,7 @@ class SerenDBStorage:
                             unrealized_pnl = EXCLUDED.unrealized_pnl,
                             gross_exposure = EXCLUDED.gross_exposure,
                             net_exposure = EXCLUDED.net_exposure,
+                            scan_run_id = EXCLUDED.scan_run_id,
                             source_run_id = EXCLUDED.source_run_id
                         """,
                         (
@@ -350,6 +362,7 @@ class SerenDBStorage:
                             r.get("unrealized_pnl", 0.0),
                             r.get("gross_exposure"),
                             r.get("net_exposure"),
+                            row_scan_run_id,
                             source_run_id,
                         ),
                     )
@@ -432,6 +445,7 @@ class SerenDBStorage:
         hit_rate: float,
         max_drawdown: float,
         source_run_id: str,
+        scan_run_id: Optional[str] = None,
     ) -> None:
         self.reporter.record_pnl(
             source_run_id,
@@ -450,9 +464,9 @@ class SerenDBStorage:
                     """
                     INSERT INTO trading.pnl_daily
                       (as_of_date, mode, realized_pnl, unrealized_pnl, net_pnl, gross_exposure, net_exposure,
-                       hit_rate, max_drawdown, source_run_id)
+                       hit_rate, max_drawdown, scan_run_id, source_run_id)
                     VALUES
-                      (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                      (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (as_of_date, mode) DO UPDATE
                     SET realized_pnl = EXCLUDED.realized_pnl,
                         unrealized_pnl = EXCLUDED.unrealized_pnl,
@@ -461,6 +475,7 @@ class SerenDBStorage:
                         net_exposure = EXCLUDED.net_exposure,
                         hit_rate = EXCLUDED.hit_rate,
                         max_drawdown = EXCLUDED.max_drawdown,
+                        scan_run_id = EXCLUDED.scan_run_id,
                         source_run_id = EXCLUDED.source_run_id
                     """,
                     (
@@ -473,6 +488,7 @@ class SerenDBStorage:
                         net_exposure,
                         hit_rate,
                         max_drawdown,
+                        scan_run_id,
                         source_run_id,
                     ),
                 )
@@ -524,7 +540,7 @@ class SerenDBStorage:
                       ON sr.run_id = e.run_id
                     WHERE sr.strategy_name = 'sass-short-trader-delta-neutral'
                       AND sr.mode = %s
-                      AND COALESCE(sr.metadata->>'run_type', '') = 'scan'
+                      AND COALESCE(sr.run_type, sr.metadata->>'run_type', '') = 'scan'
                       AND sr.status = 'completed'
                       AND e.side IN ('SELL', 'BUY')
                       AND NOT EXISTS (

--- a/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
+++ b/alpaca/sass-short-trader-delta-neutral/scripts/strategy_engine.py
@@ -568,7 +568,13 @@ class StrategyEngine:
 
             sim = self.simulate(selected, orders)
             marks = self.build_marks_from_orders(orders, sim["mark_map"], run_id)
-            self.storage.upsert_position_marks(date.today(), mode, marks, source_run_id=run_id)
+            self.storage.upsert_position_marks(
+                date.today(),
+                mode,
+                marks,
+                source_run_id=run_id,
+                scan_run_id=run_id,
+            )
 
             self.storage.upsert_pnl_daily(
                 as_of_date=date.today(),
@@ -579,6 +585,7 @@ class StrategyEngine:
                 net_exposure=sim["net_exposure"],
                 hit_rate=sim["hit_rate_5d"],
                 max_drawdown=sim["max_drawdown"],
+                scan_run_id=run_id,
                 source_run_id=run_id,
             )
             # Keep reporting rows aligned across paper/paper-sim/live.
@@ -592,6 +599,7 @@ class StrategyEngine:
                     net_exposure=sim["net_exposure"],
                     hit_rate=sim["hit_rate_5d"],
                     max_drawdown=sim["max_drawdown"],
+                    scan_run_id=run_id,
                     source_run_id=run_id,
                 )
             self.storage.upsert_pnl_daily(
@@ -603,6 +611,7 @@ class StrategyEngine:
                 net_exposure=0.0,
                 hit_rate=0.0,
                 max_drawdown=sim["max_drawdown"],
+                scan_run_id=run_id,
                 source_run_id=run_id,
             )
 
@@ -765,6 +774,7 @@ class StrategyEngine:
                     marks.append(
                         {
                             "ticker": ticker,
+                            "scan_run_id": order.get("run_id"),
                             "qty": 0.0,
                             "avg_entry_price": entry,
                             "mark_price": mark,
@@ -785,6 +795,7 @@ class StrategyEngine:
                 marks.append(
                     {
                         "ticker": ticker,
+                        "scan_run_id": order.get("run_id"),
                         "qty": qty,
                         "avg_entry_price": entry,
                         "mark_price": mark,
@@ -799,6 +810,12 @@ class StrategyEngine:
             if close_events:
                 self.storage.insert_order_events(run_id, mode, close_events)
             self.storage.upsert_position_marks(date.today(), mode, marks, source_run_id=run_id)
+            scan_run_ids = {
+                str(order.get("run_id") or "").strip()
+                for order in latest_orders
+                if str(order.get("run_id") or "").strip()
+            }
+            pnl_scan_run_id = next(iter(scan_run_ids)) if len(scan_run_ids) == 1 else None
             total_net = total_realized + total_unrealized
             hit_rate = wins / max(1, len(latest_orders))
             max_drawdown = self.compute_drawdown(mode, total_net)
@@ -811,6 +828,7 @@ class StrategyEngine:
                 net_exposure=net,
                 hit_rate=hit_rate,
                 max_drawdown=max_drawdown,
+                scan_run_id=pnl_scan_run_id,
                 source_run_id=run_id,
             )
             self.storage.update_run_status(

--- a/tests/test_alpaca_persistence_contract.py
+++ b/tests/test_alpaca_persistence_contract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIRS = [
+    "alpaca/saas-short-trader",
+    "alpaca/sass-short-trader-delta-neutral",
+]
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=SKILL_DIRS)
+def test_schema_has_explicit_run_type_and_scan_run_id(skill_dir: str) -> None:
+    sql = (REPO_ROOT / skill_dir / "scripts/serendb_schema.sql").read_text(encoding="utf-8")
+    assert "ALTER TABLE trading.strategy_runs ADD COLUMN IF NOT EXISTS run_type TEXT;" in sql
+    assert "ALTER TABLE trading.position_marks_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);" in sql
+    assert "ALTER TABLE trading.pnl_daily ADD COLUMN IF NOT EXISTS scan_run_id UUID REFERENCES trading.strategy_runs(run_id);" in sql
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=SKILL_DIRS)
+def test_storage_queries_fallback_to_explicit_run_type(skill_dir: str) -> None:
+    source = (REPO_ROOT / skill_dir / "scripts/serendb_storage.py").read_text(encoding="utf-8")
+    assert "COALESCE(run_type, metadata->>'run_type', '')" in source
+    assert "COALESCE(sr.run_type, sr.metadata->>'run_type', '') = 'scan'" in source
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=SKILL_DIRS)
+def test_learning_labels_join_via_scan_run_id_fallback(skill_dir: str) -> None:
+    source = (REPO_ROOT / skill_dir / "scripts/self_learning.py").read_text(encoding="utf-8")
+    assert "COALESCE(sr.run_type, sr.metadata->>'run_type', 'scan')" in source
+    assert "COALESCE(pm.scan_run_id, pm.source_run_id) = fs.run_id" in source


### PR DESCRIPTION
## Summary
- make `run_type` an explicit persisted field in Alpaca strategy runs while preserving metadata fallback
- persist `scan_run_id` for daily marks and pnl so monitor/learning flows can trace back to the originating scan
- update learning joins and selected-order queries to use the hardened contract in both Alpaca skills

## Testing
- python3 -m pytest --import-mode=importlib tests/test_alpaca_persistence_contract.py alpaca/saas-short-trader/tests/test_live_safety.py alpaca/sass-short-trader-delta-neutral/tests/test_live_safety.py

Closes #388
