### PR TITLE
feat(affiliates): publish seren-affiliate skill v1

### DIFF
--- a/affiliates/seren/.env.example
+++ b/affiliates/seren/.env.example
@@ -1,0 +1,16 @@
+# Seren Affiliate skill environment template
+
+# Required — Seren platform API key (used by affiliates, seren-db, gmail,
+# microsoft-outlook, and seren-models publishers).
+SEREN_API_KEY=
+
+# Optional — HMAC key for the Phase 2 unsubscribe link tokens.
+# Leave unset until the seren-affiliates backend adds
+# GET /affiliates/unsubscribe/{token}. In Phase 1 the link is non-functional
+# (documented placeholder); the operator handles opt-outs via `command: block`.
+REFERRAL_TOKEN_SECRET=
+
+# Optional — overrides the Seren Desktop-injected API_KEY path.
+# Leave unset in local development unless you are explicitly testing the
+# seren_api_key auth path.
+API_KEY=

--- a/affiliates/seren/.gitignore
+++ b/affiliates/seren/.gitignore
@@ -1,0 +1,10 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+config.json
+state/
+.DS_Store

--- a/affiliates/seren/README.md
+++ b/affiliates/seren/README.md
@@ -1,0 +1,67 @@
+# seren-affiliate
+
+Lean partner-link distribution skill for the [seren-affiliates](https://github.com/serenorg/seren-affiliates) program portfolio. Generated from [`seren-skillforge/examples/seren-affiliate`](https://github.com/serenorg/seren-skillforge/tree/main/examples/seren-affiliate) and published here.
+
+## What it does
+
+For one publisher program per run, the skill:
+
+1. Bootstraps the operator's affiliate identity with `seren-affiliates` (registering on first run).
+2. Caches joined programs in `serendb` (database `seren_affiliate`).
+3. Ingests contacts from a pasted list or a Gmail / Outlook address book.
+4. Drafts a single pitch for the selected program via `seren-models`, gated by one operator approval.
+5. Sends through Gmail (preferred) or Microsoft Outlook, enforcing per-program dedupe, a global unsubscribe list, and a daily cap (default 10, hard-capped at 25).
+6. Reports local distribution metrics joined with live conversion and commission stats from `seren-affiliates`.
+
+## Placement
+
+Published at `seren-skills/affiliates/seren`. Complement to [`affiliates/seren-bucks`](../seren-bucks/SKILL.md) (campaign-specific review-first outreach). Shared `family: affiliate-v1` metadata.
+
+## Getting started
+
+```bash
+cp .env.example .env
+# Set SEREN_API_KEY in .env
+
+python3 scripts/agent.py --command bootstrap
+python3 scripts/agent.py --command status
+python3 scripts/agent.py --command run --config config.example.json
+```
+
+`config.example.json` is safe to copy to `config.json` and edit. Inputs are documented in [SKILL.md](SKILL.md).
+
+## Layout
+
+```
+SKILL.md                         Claude-facing skill documentation
+serendb_schema.sql               Database schema for the seren_affiliate db
+requirements.txt                 Pytest only; the runtime uses stdlib
+config.example.json              Example input config
+.env.example                     Required / optional env vars
+scripts/
+  agent.py                       Dispatcher for bootstrap/sync/run/draft/send/status/block
+  common.py                      Shared utilities, DEFAULT_CONFIG, placeholder contract
+  bootstrap.py                   Auth, profile register-or-fetch
+  sync.py                        Joined programs refresh + select_program
+  ingest.py                      Contact sourcing + provider resolve + eligibility + cap
+  draft.py                       LLM pitch drafting + approval gate
+  send.py                        Merge + per-contact send (Gmail preferred)
+  status.py                      Live stats fetch + report rendering
+  block.py                       Operator-managed unsubscribe
+references/
+  prompts/draft_pitch.md         seren-models prompt contract
+  state-machine.md               Step DAG and command subgraphs
+  provider-mappings.md           Publisher endpoints and paths
+tests/
+  test_smoke.py                  Invariants: dedupe, cap, approval gate, footer
+  fixtures/                      Happy-path, failure, dry-run-guard, policy-violation fixtures
+```
+
+## Rollout phases
+
+- **Phase 1 (shipped).** Operator-managed blocklist only. Unsubscribe link in the footer is a documented placeholder; operator removes recipients manually via `command: block`.
+- **Phase 2.** Requires a new `GET /affiliates/unsubscribe/{token}` route and `GET /affiliates/me/unsubscribes?since=...` list on the seren-affiliates backend. Once those ship, `sync` auto-mirrors remote unsubscribes into the local table.
+
+## Regenerating from the spec
+
+Edit `seren-skillforge/examples/seren-affiliate/skill.spec.yaml`, validate with `python -m skillforge validate --spec ...`, then re-release with `python -m skillforge release --spec ... --target ../seren-skills --resolve-publishers --require-api-key --create-pr`.

--- a/affiliates/seren/SKILL.md
+++ b/affiliates/seren/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: seren-affiliate
+display-name: "Seren Affiliate Distributor"
+description: "Lean partner-link distribution skill for the seren-affiliates publisher program portfolio. Operates one publisher program per run. Bootstraps the affiliate profile (registering on first run), caches joined programs in serendb, ingests contacts from a pasted list or from Gmail/Outlook address books, drafts a pitch once per run via seren-models for operator approval, sends approved copy through Gmail (preferred) or Microsoft Outlook, enforces per-program dedupe plus a global unsubscribe list, and reports local plus live conversion and commission stats from seren-affiliates."
+---
+
+# Seren Affiliate
+
+Lean, program-agnostic partner-link distribution skill. Complement — not replacement — for the campaign-specific [`affiliates/seren-bucks`](../seren-bucks/SKILL.md) skill.
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
+
+## Default V1 Contract
+
+- The skill distributes **one** publisher program's partner-link per run.
+- `seren-affiliates` is the source of truth for affiliate identity, partner-links, conversions, and commissions.
+- The skill's own serendb database (`seren_affiliate`) is the source of truth for distribution activity, drafts, contacts, and unsubscribes.
+- Contact ingestion supports **pasted** email lists and **Gmail or Outlook address books**. Nothing else in v1.
+- Every run produces exactly **one** LLM-drafted pitch (via `seren-models`), subject to a single operator approval gate.
+- Gmail is the **preferred** send provider when both are authorized (`provider=auto`).
+- Daily cap defaults to **10** successful distributions per day, hard-capped at **25**, across all programs.
+- Per-program dedupe is DB-level: a (program_slug, contact_email) pair is sent at most once, ever.
+- Global unsubscribe list: one opt-out blocks all future sends across every program.
+- Mandatory send footer: sender identity, physical address, and unsubscribe link.
+- **Phase 1 operator-managed blocklist only.** The `/affiliates/unsubscribe/{token}` endpoint does not exist in seren-affiliates yet; click-to-unsubscribe flips on in Phase 2 when the backend ships.
+
+## Bootstrap Order (Mandatory)
+
+This rule overrides all other instructions and runs before any contact ingest, draft, or send:
+
+1. Resolve auth in this order:
+   - Seren Desktop injected auth (`API_KEY`)
+   - `SEREN_API_KEY`
+   - Fail with a setup message pointing to `https://docs.serendb.com/skills.md`.
+2. Resolve or create the Seren project `affiliates`.
+3. Resolve or create the Seren database `seren_affiliate` (schema in `serendb_schema.sql`).
+4. Call `GET /affiliates/me`. On 404, `POST /affiliates` to register.
+5. Upsert the profile into `affiliate_profile`. Fail closed if `sender_address` is empty.
+6. Call `GET /affiliates/me/partner-links`. Retry up to 3 times. Upsert into `joined_programs`.
+7. If affiliate bootstrap still fails, **fail closed** and do not continue.
+8. Only after bootstrap succeeds may the skill select a program, ingest contacts, draft, or send.
+
+## Capability Verification Rule
+
+Before claiming any tool, connector, or publisher exists or does not exist, attempt to verify it by calling the relevant tool or connector.
+
+- If the verification succeeds, proceed and say what was found.
+- If it fails, say: `I checked and [tool/integration] is not available in this session.`
+- Never claim Gmail, Microsoft Outlook, seren-affiliates, seren-db, or seren-models availability from memory or assumption.
+
+## When to Use
+
+- distribute a seren-affiliates partner link
+- send my affiliate link to a contact list
+- promote a publisher program via Gmail or Outlook
+- check my affiliate distribution status
+- register as a seren-affiliates affiliate
+- unsubscribe a contact from my affiliate outreach
+
+## Commands
+
+All commands accept `json_output=true` for headless agent use.
+
+| Command     | Purpose |
+|-------------|---------|
+| `bootstrap` | Auth, serendb project/db, profile (register on 404), joined_programs cache. Stops there. |
+| `sync`      | Re-run bootstrap's profile and joined_programs refresh without continuing the pipeline. |
+| `status`    | Bootstrap plus `GET /affiliates/me/stats` and `/commissions` (optional `program_slug` filter). No send. |
+| `ingest`    | Bootstrap plus contact ingestion and eligibility filter. No draft, no send. |
+| `draft`     | Bootstrap plus contact ingestion plus one `seren-models` draft. Stores in `drafts`. No send. |
+| `send`      | Requires an existing `drafts` row. Runs the send path with the approval gate. |
+| `run`       | End-to-end default: bootstrap → draft → approve → send → report. |
+| `block`     | Operator-managed unsubscribe: appends `block_email` to `unsubscribes` (`source=operator_manual`). |
+
+## Inputs
+
+- `command` — one of the commands above. Default `run`.
+- `program_slug` — required for `draft`, `send`, `run`. Must match a row in `joined_programs`. If empty in interactive mode, the skill lists available programs and asks.
+- `provider` — `auto` (default, Gmail-first), `gmail`, or `outlook`.
+- `contacts_source` — `pasted` (default), `gmail_contacts`, or `outlook_contacts`.
+- `contacts` — for `pasted`: newline or comma delimited list, a CSV path, or a JSON array of `{email, name}`.
+- `voice_notes` — optional free-text hints for the drafter.
+- `approve_draft` — when `true`, skips the interactive approval gate. **Rejected unless `json_output=true` is also set** (prevents unattended sends from a human CLI).
+- `daily_cap` — 1–25. Default 10.
+- `json_output` — machine-readable output.
+- `strict_mode` — fail closed on bootstrap failures. Default `true`.
+- `block_email` — used only by `command: block`.
+
+## State (serendb database `seren_affiliate`)
+
+Schema in `serendb_schema.sql`. Tables:
+
+- `affiliate_profile` — cached `/affiliates/me`.
+- `joined_programs` — cached `/affiliates/me/partner-links`.
+- `contacts` — deduped address universe.
+- `distributions` — one row per successful send. `UNIQUE(program_slug, contact_email)` enforces per-program dedupe. Daily cap = `COUNT(*) WHERE sent_at::date = today`.
+- `unsubscribes` — global opt-out list.
+- `drafts` — per-run approved pitch.
+- `runs` — one row per invocation.
+
+## Compliance and Safety Rules
+
+- `policies.dry_run_default: true` — the skill previews every batch and refuses to send unless `approve_draft=true` (with `json_output=true`) or the interactive approval is recorded.
+- `policies.idempotency_required: true` — every distribution is keyed to a `run_id` plus `UNIQUE(program_slug, contact_email)`.
+- Mandatory footer placeholders in every drafted body: `{name}`, `{partner_link}`, `{sender_identity}`, `{sender_address}`, `{unsubscribe_link}`. A regex gate rejects drafts missing any of them.
+- `sender_address` is required before any send. The skill fails closed if `affiliate_profile.sender_address` is empty.
+- Hard-bounce on send auto-inserts into `unsubscribes` with `source=hard_bounce`.
+- PII posture: only `name` + `email` are pulled from provider address books. Never message bodies or threads. Email addresses never appear in stdout outside the final summary, and only in structured form under `json_output=true`.
+
+## Provider Selection
+
+- `provider=auto` → Gmail if Gmail publisher is authorized, else Microsoft Outlook, else fail closed.
+- `provider=gmail` or `provider=outlook` → explicit choice; fail closed if that one is not authorized.
+- Both publishers are authorized at the Seren platform level, not inside this skill. If neither is authorized, the skill instructs the operator to authorize one via the Seren platform.
+
+## Unsubscribe Handling (Phase 1 vs Phase 2)
+
+- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://api.seren.ai/affiliates/unsubscribe/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)`. The endpoint does **not** exist in the seren-affiliates backend yet. Until it ships, the operator handles unsubscribes manually via `command: block` with `block_email=<recipient>`.
+- **Phase 2.** Once the seren-affiliates backend adds `GET /affiliates/unsubscribe/{token}` and `GET /affiliates/me/unsubscribes?since=...`, the skill's `sync` step mirrors remote unsubscribes into the local `unsubscribes` table automatically.
+
+## Status and Stats
+
+`command: status` and the end-of-run report join local and live state:
+
+- Local (from serendb): counts by program — ingested, eligible, sent, skipped (dedupe), skipped (unsub), cap remaining.
+- Live (from seren-affiliates): clicks, conversions, pending and paid commissions, scoped by `program_slug`.
+
+## Related
+
+- Sibling skill — `affiliates/seren-bucks` — campaign-specific review-first outreach for a single Seren Bucks landing page.
+- `family: affiliate-v1` (shared with seren-bucks).

--- a/affiliates/seren/config.example.json
+++ b/affiliates/seren/config.example.json
@@ -1,0 +1,24 @@
+{
+  "connectors": [
+    "affiliates",
+    "gmail",
+    "model",
+    "outlook",
+    "storage"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "approve_draft": false,
+    "block_email": "",
+    "command": "run",
+    "contacts": "",
+    "contacts_source": "pasted",
+    "daily_cap": 10,
+    "json_output": false,
+    "program_slug": "",
+    "provider": "auto",
+    "strict_mode": true,
+    "voice_notes": ""
+  },
+  "skill": "seren-affiliate"
+}

--- a/affiliates/seren/references/prompts/draft_pitch.md
+++ b/affiliates/seren/references/prompts/draft_pitch.md
@@ -1,0 +1,58 @@
+# Draft Pitch Prompt — seren-affiliate
+
+This prompt is the single seren-models call per run at the `draft_pitch` step.
+Return a JSON object with exactly two keys: `subject` and `body_template`.
+`body_template` must contain these placeholder tokens, each at least once:
+`{name}`, `{partner_link}`, `{sender_identity}`, `{sender_address}`,
+`{unsubscribe_link}`. A regex gate rejects any output missing one of them.
+
+## System
+
+You draft one short outreach email for the operator to review before the skill
+sends it to a contact list. The operator is an affiliate enrolled in a
+publisher program on seren-affiliates and wants to share their personalized
+partner link with people who may find the program useful. You are not writing
+a marketing blast. You are drafting a thoughtful, specific note.
+
+Hard rules:
+
+- Subject line must be under 70 characters and free of emoji.
+- Body must be under 180 words.
+- Do not invent program features beyond what the program description states.
+- Do not make earnings claims on behalf of the recipient.
+- Do not promise discounts, bonuses, or exclusive deals unless the program
+  description explicitly includes them.
+- Body must end with a footer block that includes the sender identity line,
+  the sender's physical address, and the unsubscribe link — each on its own
+  line, after a horizontal separator.
+- Emit the five required placeholder tokens literally. Do not expand them.
+
+## User template
+
+```
+Program name: {{ program_name }}
+Program slug: {{ program_slug }}
+Program description:
+{{ program_description }}
+
+Operator voice notes (may be empty):
+{{ voice_notes }}
+
+Commission summary (advisory only, do not quote figures back at the recipient):
+{{ commission_summary_json }}
+```
+
+## Expected output shape
+
+```
+{
+  "subject": "Quick note on {{ program_name }} — thought of you",
+  "body_template": "Hi {name},\n\n<one-paragraph pitch>\n\n<one-paragraph call to action that includes {partner_link}>\n\n---\n{sender_identity}\n{sender_address}\nUnsubscribe: {unsubscribe_link}\n"
+}
+```
+
+## Footer contract
+
+`render_report` and the pre-send regex gate both enforce the footer contract.
+If any of the five placeholders is missing, the draft is rejected and the
+operator is told to re-run `draft` with tighter voice notes.

--- a/affiliates/seren/references/provider-mappings.md
+++ b/affiliates/seren/references/provider-mappings.md
@@ -1,0 +1,39 @@
+# Provider mappings
+
+The skill calls four connector publishers, each with fixed path assumptions.
+
+## affiliates — seren-affiliates
+
+| Step | Method | Path | Notes |
+|------|--------|------|-------|
+| sync_affiliate_profile | GET | /affiliates/me | 404 triggers POST /affiliates |
+| register_affiliate | POST | /affiliates | First-run only |
+| sync_joined_programs | GET | /affiliates/me/partner-links | 3 retries, fail closed |
+| select_program (re-fetch) | GET | /affiliates/me/partner-links/{slug} | Called right before merge_and_send to avoid stale URLs |
+| fetch_live_stats | GET | /affiliates/me/stats | Filter by program_slug |
+| fetch_live_commissions | GET | /affiliates/me/commissions | Filter by program_slug |
+| sync_remote_unsubscribes | GET | /affiliates/me/unsubscribes?since=... | Phase 2, backend dependency |
+
+Headers: `X-Seren-Agent-Id` (cached from first `/affiliates/me` response) + `Authorization: Bearer $SEREN_API_KEY`.
+
+## storage — seren-db
+
+Operations: `upsert` and `get` only. Database `seren_affiliate`.
+
+## gmail
+
+| Step | Method | Notes |
+|------|--------|-------|
+| ingest_contacts | gmail.contacts.list | Pagination; name+email only |
+| merge_and_send  | gmail.messages.send | Returns `message_id`; authoritative |
+
+## outlook — microsoft-outlook
+
+| Step | Method | Notes |
+|------|--------|-------|
+| ingest_contacts | outlook.contacts.list | Pagination; name+email only |
+| merge_and_send  | outlook.mail.send | Returns `message_id`; authoritative |
+
+## model — seren-models
+
+Single call at `draft_pitch`. Prompt reference: `references/prompts/draft_pitch.md`. Output is validated for the five required placeholder tokens before persistence.

--- a/affiliates/seren/references/state-machine.md
+++ b/affiliates/seren/references/state-machine.md
@@ -1,0 +1,90 @@
+# seren-affiliate state machine
+
+The skill operates one publisher program per run. State is owned by the
+serendb database `seren_affiliate`.
+
+## Run lifecycle
+
+```
+          ┌──────────────────────┐
+          │ normalize_request    │
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ bootstrap_auth_and_db│
+          └────────────┬─────────┘
+                       ▼ (3 retries, fail closed under strict_mode)
+          ┌──────────────────────┐
+          │ sync_affiliate_profile│ ← GET /affiliates/me, POST /affiliates on 404
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ sync_joined_programs │ ← GET /affiliates/me/partner-links
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ select_program       │ ← validates against joined_programs cache
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ resolve_provider     │ ← gmail-preferred auto, else --provider
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ ingest_contacts      │ ← pasted | gmail_contacts | outlook_contacts
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ filter_eligible      │ ← anti-join distributions + unsubscribes
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ enforce_daily_cap    │ ← COUNT distributions today; clip to cap
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ draft_pitch          │ ← one seren-models call per run
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ await_approval       │ ← blocking unless approve_draft + json_output
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ merge_and_send       │ ← per contact: provider.messages.send
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ persist_run_state    │ ← finalize runs row
+          └────────────┬─────────┘
+                       ▼
+          ┌──────────────────────┐
+          │ fetch_live_stats +   │ ← GET /affiliates/me/stats + /commissions
+          │ render_report        │
+          └──────────────────────┘
+```
+
+## Command subgraphs
+
+| Command    | Steps |
+|------------|-------|
+| bootstrap  | 1–4 (stops after sync_joined_programs) |
+| sync       | 1–2, 3–4, 5, render |
+| ingest     | 1–2, 7, persist contacts |
+| draft      | 1–10, persist_draft, render |
+| send       | 1–9 validation only, 11–13 execution, render (requires existing drafts row) |
+| run        | 1–15 end to end |
+| status     | 1–4, 14–15 (no send) |
+| block      | 1–2 + upsert into unsubscribes |
+
+## Failure modes
+
+- `auth_setup_required` — no Seren Desktop auth and no `SEREN_API_KEY` env var.
+- `affiliate_bootstrap_failed` — 3 consecutive failures on profile or programs sync.
+- `no_sender_address` — `affiliate_profile.sender_address` is empty. Bootstrap
+  fails closed and returns a setup instruction.
+- `no_provider_authorized` — neither gmail nor microsoft-outlook publisher is
+  authorized for the caller.
+- `approve_draft_without_json_output` — normalize_request rejects.
+- `daily_cap_exhausted` — sent count already at cap; the run terminates cleanly
+  with `sent_count=0` and a message.

--- a/affiliates/seren/requirements.txt
+++ b/affiliates/seren/requirements.txt
@@ -1,0 +1,5 @@
+# seren-affiliate uses only the Python standard library at runtime.
+# Publisher connectors (seren-affiliates, seren-db, gmail, microsoft-outlook,
+# seren-models) are invoked by the Seren runtime harness, not from these
+# scripts. Install pytest for the test suite.
+pytest>=8.0

--- a/affiliates/seren/scripts/agent.py
+++ b/affiliates/seren/scripts/agent.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Runtime stub for seren-affiliate.
+
+The live runtime harness executes the workflow DAG declared in skill.spec.yaml
+against Seren publisher connectors. This module is the reference and smoke
+test implementation: each workflow step is represented as a pure Python
+function that returns a structured dict. It is safe to invoke offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from block import block_email
+from bootstrap import bootstrap_auth_and_db, sync_affiliate_profile
+from common import (
+    DEFAULT_CONFIG,
+    daily_cap_from_input,
+    load_config,
+    new_run_id,
+    require_approve_draft_json_pairing,
+    utc_now,
+)
+from draft import await_approval, draft_pitch
+from ingest import enforce_daily_cap, filter_eligible, ingest_contacts, resolve_provider
+from send import merge_and_send
+from status import fetch_live_stats, render_report
+from sync import select_program, sync_joined_programs
+
+COMMAND_CHOICES = (
+    "bootstrap",
+    "run",
+    "status",
+    "sync",
+    "ingest",
+    "draft",
+    "send",
+    "block",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Seren Affiliate skill stub.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to the runtime config file.",
+    )
+    parser.add_argument(
+        "--command",
+        default=None,
+        choices=COMMAND_CHOICES,
+        help="Optional command override. Defaults to config.inputs.command.",
+    )
+    return parser.parse_args()
+
+
+def _bootstrap_stage(config: dict) -> dict:
+    auth_db = bootstrap_auth_and_db(config)
+    if auth_db["status"] != "ok":
+        return {"stage_status": "blocked", "auth_db": auth_db}
+    profile_result = sync_affiliate_profile(config)
+    if profile_result["status"] != "ok":
+        return {
+            "stage_status": "blocked",
+            "auth_db": auth_db,
+            "profile": profile_result,
+        }
+    programs_result = sync_joined_programs(config)
+    if programs_result["status"] != "ok":
+        return {
+            "stage_status": "blocked",
+            "auth_db": auth_db,
+            "profile": profile_result,
+            "programs": programs_result,
+        }
+    return {
+        "stage_status": "ok",
+        "auth_db": auth_db,
+        "profile": profile_result,
+        "programs": programs_result,
+    }
+
+
+def _bootstrap_only(config: dict, run_id: str) -> dict:
+    stage = _bootstrap_stage(config)
+    return {
+        "skill": "seren-affiliate",
+        "run_id": run_id,
+        "command": "bootstrap",
+        "run_status": "ok" if stage["stage_status"] == "ok" else "blocked",
+        "generated_at": utc_now(),
+        **{k: v for k, v in stage.items() if k != "stage_status"},
+    }
+
+
+def _status(config: dict, run_id: str) -> dict:
+    stage = _bootstrap_stage(config)
+    if stage["stage_status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": "status",
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            **{k: v for k, v in stage.items() if k != "stage_status"},
+        }
+    program_slug = str(config["inputs"].get("program_slug", "")).strip()
+    live = fetch_live_stats(config=config, program_slug=program_slug) if program_slug else None
+    return {
+        "skill": "seren-affiliate",
+        "run_id": run_id,
+        "command": "status",
+        "run_status": "ok",
+        "generated_at": utc_now(),
+        "auth_db": stage["auth_db"],
+        "profile": stage["profile"]["profile"],
+        "programs": stage["programs"]["programs"],
+        "live": live,
+    }
+
+
+def _block(config: dict, run_id: str) -> dict:
+    stage = _bootstrap_stage(config)
+    if stage["stage_status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": "block",
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            **{k: v for k, v in stage.items() if k != "stage_status"},
+        }
+    result = block_email(config)
+    return {
+        "skill": "seren-affiliate",
+        "run_id": run_id,
+        "command": "block",
+        "run_status": "ok" if result["status"] == "ok" else "blocked",
+        "generated_at": utc_now(),
+        "block_result": result,
+    }
+
+
+def _run_pipeline(config: dict, *, command: str, run_id: str) -> dict:
+    pairing_error = require_approve_draft_json_pairing(config)
+    if pairing_error is not None:
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            "error": pairing_error,
+        }
+
+    stage = _bootstrap_stage(config)
+    if stage["stage_status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            **{k: v for k, v in stage.items() if k != "stage_status"},
+        }
+
+    programs = stage["programs"]["programs"]
+    program_selection = select_program(config, programs)
+    if program_selection["status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            "profile": stage["profile"],
+            "programs": stage["programs"],
+            "program_selection": program_selection,
+        }
+    program = program_selection["program"]
+
+    provider = resolve_provider(config)
+    if provider["status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            "provider": provider,
+        }
+
+    ingest = ingest_contacts(config)
+    if ingest["status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            "ingest": ingest,
+        }
+
+    eligibility = filter_eligible(
+        contacts=ingest["contacts"],
+        program_slug=program["program_slug"],
+        already_sent_for_program=set(),
+        unsubscribes=set(),
+    )
+    cap = daily_cap_from_input(config)
+    cap_summary = enforce_daily_cap(
+        eligible=eligibility["eligible"],
+        cap=cap,
+        already_sent_today=0,
+    )
+
+    if command == "ingest":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "ok",
+            "generated_at": utc_now(),
+            "profile": stage["profile"]["profile"],
+            "program": program,
+            "ingest": ingest,
+            "eligibility": eligibility,
+            "cap_summary": cap_summary,
+        }
+
+    draft_result = draft_pitch(config=config, program=program, run_id=run_id)
+    if draft_result["status"] != "ok":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "blocked",
+            "generated_at": utc_now(),
+            "draft": draft_result,
+        }
+    draft = draft_result["draft"]
+
+    if command == "draft":
+        return {
+            "skill": "seren-affiliate",
+            "run_id": run_id,
+            "command": command,
+            "run_status": "ok",
+            "generated_at": utc_now(),
+            "profile": stage["profile"]["profile"],
+            "program": program,
+            "draft": draft,
+            "eligibility": eligibility,
+            "cap_summary": cap_summary,
+            "next_step": "Re-run `send` with approve_draft=true + json_output=true to dispatch.",
+        }
+
+    approval = await_approval(config=config, draft=draft)
+    send_result: dict | None = None
+    if approval["status"] == "approved":
+        send_result = merge_and_send(
+            config=config,
+            run_id=run_id,
+            profile=stage["profile"]["profile"],
+            program=program,
+            provider_used=provider["provider_used"],
+            draft=draft,
+            sendable=cap_summary["sendable"],
+            approval=approval,
+        )
+
+    live = fetch_live_stats(config=config, program_slug=program["program_slug"])
+    report = render_report(
+        config=config,
+        run_id=run_id,
+        command=command,
+        program=program,
+        profile=stage["profile"]["profile"],
+        provider_used=provider["provider_used"],
+        ingest_summary=ingest,
+        eligibility=eligibility,
+        cap_summary=cap_summary,
+        draft=draft,
+        approval=approval,
+        send_result=send_result,
+        live=live,
+    )
+
+    return {
+        "skill": "seren-affiliate",
+        "run_id": run_id,
+        "command": command,
+        "run_status": "ok",
+        "generated_at": utc_now(),
+        "profile": stage["profile"]["profile"],
+        "program": program,
+        "provider": provider,
+        "ingest": ingest,
+        "eligibility": eligibility,
+        "cap_summary": cap_summary,
+        "draft": draft,
+        "approval": approval,
+        "send": send_result,
+        "live": live,
+        "report": report,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    command = args.command or config["inputs"].get("command", DEFAULT_CONFIG["inputs"]["command"])
+    run_id = new_run_id(prefix=command)
+
+    if command == "bootstrap":
+        result = _bootstrap_only(config, run_id)
+    elif command == "status":
+        result = _status(config, run_id)
+    elif command == "block":
+        result = _block(config, run_id)
+    elif command == "sync":
+        result = _bootstrap_only(config, run_id)
+        result["command"] = "sync"
+    else:
+        result = _run_pipeline(config, command=command, run_id=run_id)
+
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/affiliates/seren/scripts/block.py
+++ b/affiliates/seren/scripts/block.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from common import is_valid_email, utc_now
+
+
+def block_email(config: dict) -> dict:
+    raw = str(config["inputs"].get("block_email", "")).strip().lower()
+    if not raw:
+        return {
+            "status": "error",
+            "error_code": "missing_block_email",
+            "message": "block command requires block_email input.",
+        }
+    if not is_valid_email(raw):
+        return {
+            "status": "error",
+            "error_code": "invalid_email",
+            "message": f"block_email '{raw}' is not a valid email address.",
+        }
+    return {
+        "status": "ok",
+        "unsubscribe": {
+            "email": raw,
+            "unsubscribed_at": utc_now(),
+            "source": "operator_manual",
+        },
+        "phase": "phase1_operator_blocklist_only",
+    }

--- a/affiliates/seren/scripts/bootstrap.py
+++ b/affiliates/seren/scripts/bootstrap.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from common import select_auth_path, utc_now
+
+
+def bootstrap_auth_and_db(config: dict) -> dict:
+    auth_path = select_auth_path(config)
+    if auth_path == "setup_required":
+        return {
+            "status": "error",
+            "error_code": "auth_setup_required",
+            "message": "No Seren Desktop auth or SEREN_API_KEY was found.",
+            "setup_url": config["auth"]["setup_url"],
+        }
+
+    return {
+        "status": "ok",
+        "auth_path": auth_path,
+        "database_status": "ready",
+        "database": config["database"],
+        "started_at": utc_now(),
+    }
+
+
+def sync_affiliate_profile(config: dict) -> dict:
+    simulate = config.get("simulate", {})
+    if bool(simulate.get("affiliate_bootstrap_failure")):
+        return {
+            "status": "error",
+            "error_code": "affiliate_bootstrap_failed",
+            "retry_count": 3,
+            "fail_closed": True,
+            "message": "GET /affiliates/me failed three consecutive attempts.",
+        }
+
+    registered = False
+    if bool(simulate.get("profile_missing")):
+        registered = True
+
+    sender_address = (
+        "" if bool(simulate.get("sender_address_missing")) else "1 Market Street, San Francisco CA"
+    )
+
+    profile = {
+        "agent_id": "agent-demo-0001",
+        "referral_code": "seren-demo",
+        "tier": "bronze",
+        "balance_cents": 0,
+        "display_name": "Seren Demo Affiliate",
+        "sender_address": sender_address,
+        "last_synced_at": utc_now(),
+    }
+
+    if not sender_address:
+        return {
+            "status": "error",
+            "error_code": "no_sender_address",
+            "message": (
+                "affiliate_profile.sender_address is empty. "
+                "Set it once before sending any distributions."
+            ),
+            "profile": profile,
+        }
+
+    return {
+        "status": "ok",
+        "registered_this_run": registered,
+        "profile": profile,
+        "source_of_truth": config["affiliate_source_of_truth"],
+    }

--- a/affiliates/seren/scripts/common.py
+++ b/affiliates/seren/scripts/common.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "dry_run": True,
+    "skill": "seren-affiliate",
+    "database": {
+        "project": "affiliates",
+        "name": "seren_affiliate",
+    },
+    "auth": {
+        "desktop_auth_first": True,
+        "api_key_env": "SEREN_API_KEY",
+        "setup_url": "https://docs.serendb.com/skills.md",
+        "referral_token_secret_env": "REFERRAL_TOKEN_SECRET",
+    },
+    "affiliate_source_of_truth": "seren-affiliates",
+    "providers": {
+        "preferred_order": ["gmail", "outlook"],
+    },
+    "contacts": {
+        "allowed_sources": ["pasted", "gmail_contacts", "outlook_contacts"],
+    },
+    "limits": {
+        "daily_cap_default": 10,
+        "daily_cap_max": 25,
+    },
+    "unsubscribe": {
+        "endpoint_base": "https://api.seren.ai/affiliates/unsubscribe",
+        "phase1_operator_blocklist_only": True,
+    },
+    "inputs": {
+        "command": "run",
+        "program_slug": "",
+        "provider": "auto",
+        "contacts_source": "pasted",
+        "contacts": "",
+        "voice_notes": "",
+        "approve_draft": False,
+        "daily_cap": 10,
+        "json_output": False,
+        "strict_mode": True,
+        "block_email": "",
+    },
+    "simulate": {
+        "affiliate_bootstrap_failure": False,
+        "profile_missing": False,
+        "sender_address_missing": False,
+        "no_provider_authorized": False,
+        "hard_bounce_email": "",
+    },
+}
+
+REQUIRED_PLACEHOLDERS = (
+    "{name}",
+    "{partner_link}",
+    "{sender_identity}",
+    "{sender_address}",
+    "{unsubscribe_link}",
+)
+
+EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def utc_now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def new_run_id(prefix: str = "run") -> str:
+    return f"{prefix}-{uuid.uuid4()}"
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config(config_path: str) -> dict[str, Any]:
+    path = Path(config_path)
+    if not path.exists():
+        return deepcopy(DEFAULT_CONFIG)
+    overlay = json.loads(path.read_text(encoding="utf-8"))
+    return deep_merge(DEFAULT_CONFIG, overlay)
+
+
+def select_auth_path(config: dict[str, Any]) -> str:
+    desktop_first = bool(config["auth"].get("desktop_auth_first", True))
+    if desktop_first and os.environ.get("API_KEY"):
+        return "seren_desktop"
+    if os.environ.get(config["auth"].get("api_key_env", "SEREN_API_KEY")):
+        return "seren_api_key"
+    return "setup_required"
+
+
+def daily_cap_from_input(config: dict[str, Any]) -> int:
+    raw = int(config["inputs"].get("daily_cap", config["limits"]["daily_cap_default"]))
+    hard_max = int(config["limits"]["daily_cap_max"])
+    return max(1, min(raw, hard_max))
+
+
+def is_valid_email(value: str) -> bool:
+    return bool(EMAIL_RE.match(value or ""))
+
+
+def hash_body(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def unsubscribe_token(
+    *,
+    email: str,
+    program_slug: str,
+    run_id: str,
+    secret: str | None,
+) -> str:
+    material = f"{email}|{program_slug}|{run_id}".encode("utf-8")
+    key = (secret or "development-only-token").encode("utf-8")
+    return hmac.new(key, material, hashlib.sha256).hexdigest()
+
+
+def unsubscribe_link(
+    *,
+    config: dict[str, Any],
+    email: str,
+    program_slug: str,
+    run_id: str,
+) -> str:
+    secret_env = config["auth"].get("referral_token_secret_env", "REFERRAL_TOKEN_SECRET")
+    token = unsubscribe_token(
+        email=email,
+        program_slug=program_slug,
+        run_id=run_id,
+        secret=os.environ.get(secret_env),
+    )
+    base = str(config["unsubscribe"]["endpoint_base"]).rstrip("/")
+    return f"{base}/{token}"
+
+
+def footer_missing_placeholders(body_template: str) -> list[str]:
+    return [token for token in REQUIRED_PLACEHOLDERS if token not in body_template]
+
+
+def require_approve_draft_json_pairing(config: dict[str, Any]) -> dict[str, Any] | None:
+    inputs = config["inputs"]
+    if bool(inputs.get("approve_draft")) and not bool(inputs.get("json_output")):
+        return {
+            "status": "error",
+            "error_code": "approve_draft_without_json_output",
+            "message": (
+                "approve_draft=true requires json_output=true so an unattended "
+                "human CLI cannot accidentally skip the approval gate."
+            ),
+        }
+    return None
+
+
+def parse_pasted_contacts(raw: str) -> list[dict[str, str]]:
+    contacts: list[dict[str, str]] = []
+    if not raw:
+        return contacts
+    text = raw.strip()
+    if text.startswith("["):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = []
+        for item in parsed:
+            if isinstance(item, dict) and is_valid_email(str(item.get("email", ""))):
+                contacts.append(
+                    {
+                        "email": str(item["email"]).strip().lower(),
+                        "display_name": str(item.get("name", "")).strip(),
+                    }
+                )
+        return contacts
+    for raw_line in re.split(r"[\n,]+", text):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if "<" in line and ">" in line:
+            name_part, email_part = line.rsplit("<", 1)
+            email = email_part.split(">", 1)[0].strip().lower()
+            name = name_part.strip().strip('"')
+        else:
+            email = line.strip().lower()
+            name = ""
+        if is_valid_email(email):
+            contacts.append({"email": email, "display_name": name})
+    return contacts

--- a/affiliates/seren/scripts/draft.py
+++ b/affiliates/seren/scripts/draft.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from common import footer_missing_placeholders, utc_now
+
+
+def _default_body_template(program_name: str) -> str:
+    return (
+        "Hi {name},\n\n"
+        f"I wanted to share {program_name}. The team has been shipping quality work and "
+        "I think the fit with what you're building is real.\n\n"
+        "If you'd like to take a look, my link is here: {partner_link}\n"
+        "Happy to answer any questions.\n\n"
+        "---\n"
+        "{sender_identity}\n"
+        "{sender_address}\n"
+        "Unsubscribe: {unsubscribe_link}\n"
+    )
+
+
+def draft_pitch(
+    *,
+    config: dict,
+    program: dict,
+    run_id: str,
+) -> dict:
+    voice_notes = str(config["inputs"].get("voice_notes", "")).strip()
+    subject = f"Thought of you for {program['program_name']}"
+    body = _default_body_template(program["program_name"])
+
+    missing = footer_missing_placeholders(body)
+    if missing:
+        return {
+            "status": "error",
+            "error_code": "draft_missing_placeholders",
+            "missing_placeholders": missing,
+            "message": (
+                "Draft output is missing required placeholder tokens. "
+                "Re-run draft with tighter voice notes."
+            ),
+        }
+
+    return {
+        "status": "ok",
+        "draft": {
+            "run_id": run_id,
+            "program_slug": program["program_slug"],
+            "subject": subject,
+            "body_template": body,
+            "model_used": "seren-models:claude-opus-4-6",
+            "approved_at": None,
+            "approved_by": None,
+        },
+        "voice_notes_length": len(voice_notes),
+        "drafted_at": utc_now(),
+    }
+
+
+def await_approval(*, config: dict, draft: dict) -> dict:
+    inputs = config["inputs"]
+    approve_draft = bool(inputs.get("approve_draft"))
+    json_output = bool(inputs.get("json_output"))
+
+    if approve_draft and not json_output:
+        return {
+            "status": "error",
+            "error_code": "approve_draft_without_json_output",
+            "message": (
+                "approve_draft=true requires json_output=true. "
+                "The approval gate cannot be auto-bypassed in human CLI mode."
+            ),
+        }
+
+    if approve_draft:
+        return {
+            "status": "approved",
+            "auto": True,
+            "approved_at": utc_now(),
+            "approved_by": "agent_auto_approval",
+            "draft_id": draft["run_id"],
+        }
+
+    return {
+        "status": "pending_approval",
+        "auto": False,
+        "message": (
+            "Review the draft subject, body, recipient count, and sample merge. "
+            "Re-run `send` with approve_draft=true (and json_output=true for agent mode) "
+            "once you're satisfied."
+        ),
+        "draft_id": draft["run_id"],
+    }

--- a/affiliates/seren/scripts/ingest.py
+++ b/affiliates/seren/scripts/ingest.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from common import is_valid_email, parse_pasted_contacts, utc_now
+
+SAMPLE_GMAIL_CONTACTS = [
+    {"email": "alice@example.com", "display_name": "Alice Chen"},
+    {"email": "bob@example.com", "display_name": "Bob Weaver"},
+    {"email": "carol@example.org", "display_name": "Carol Diaz"},
+]
+
+SAMPLE_OUTLOOK_CONTACTS = [
+    {"email": "dave@example.com", "display_name": "Dave Okafor"},
+    {"email": "eva@example.net", "display_name": "Eva Lindqvist"},
+]
+
+
+def _tagged(records: list[dict], source: str) -> list[dict]:
+    now = utc_now()
+    out = []
+    for record in records:
+        email = str(record.get("email", "")).strip().lower()
+        if not is_valid_email(email):
+            continue
+        out.append(
+            {
+                "email": email,
+                "display_name": str(record.get("display_name", "")).strip(),
+                "source_kind": source,
+                "first_seen_at": now,
+                "last_updated_at": now,
+            }
+        )
+    return out
+
+
+def ingest_contacts(config: dict) -> dict:
+    source = str(config["inputs"].get("contacts_source", "pasted"))
+    allowed = set(config["contacts"]["allowed_sources"])
+    if source not in allowed:
+        return {
+            "status": "error",
+            "error_code": "invalid_contacts_source",
+            "message": f"contacts_source '{source}' is not one of {sorted(allowed)}.",
+            "contacts": [],
+        }
+
+    if source == "pasted":
+        raw = str(config["inputs"].get("contacts", ""))
+        parsed = parse_pasted_contacts(raw)
+        return {
+            "status": "ok",
+            "source_kind": "pasted",
+            "count": len(parsed),
+            "contacts": _tagged(parsed, "pasted"),
+        }
+
+    if source == "gmail_contacts":
+        return {
+            "status": "ok",
+            "source_kind": "gmail_contacts",
+            "count": len(SAMPLE_GMAIL_CONTACTS),
+            "contacts": _tagged(SAMPLE_GMAIL_CONTACTS, "gmail_contacts"),
+        }
+
+    return {
+        "status": "ok",
+        "source_kind": "outlook_contacts",
+        "count": len(SAMPLE_OUTLOOK_CONTACTS),
+        "contacts": _tagged(SAMPLE_OUTLOOK_CONTACTS, "outlook_contacts"),
+    }
+
+
+def resolve_provider(config: dict) -> dict:
+    requested = str(config["inputs"].get("provider", "auto"))
+    simulate = config.get("simulate", {})
+
+    if bool(simulate.get("no_provider_authorized")):
+        return {
+            "status": "error",
+            "error_code": "no_provider_authorized",
+            "message": (
+                "Neither gmail nor microsoft-outlook publishers are authorized "
+                "for this caller. Authorize at the Seren platform level."
+            ),
+        }
+
+    preferred_order = config["providers"]["preferred_order"]
+    if requested == "auto":
+        chosen = preferred_order[0]
+    else:
+        chosen = requested
+
+    if chosen not in {"gmail", "outlook"}:
+        return {
+            "status": "error",
+            "error_code": "invalid_provider",
+            "message": f"provider '{chosen}' must be gmail, outlook, or auto.",
+        }
+
+    return {
+        "status": "ok",
+        "provider_used": chosen,
+        "resolution_mode": "auto" if requested == "auto" else "explicit",
+    }
+
+
+def filter_eligible(
+    *,
+    contacts: list[dict],
+    program_slug: str,
+    already_sent_for_program: set[str],
+    unsubscribes: set[str],
+) -> dict:
+    eligible: list[dict] = []
+    skipped_dedupe = 0
+    skipped_unsub = 0
+    for contact in contacts:
+        email = contact["email"]
+        if email in unsubscribes:
+            skipped_unsub += 1
+            continue
+        if email in already_sent_for_program:
+            skipped_dedupe += 1
+            continue
+        eligible.append(contact)
+    return {
+        "status": "ok",
+        "program_slug": program_slug,
+        "eligible_count": len(eligible),
+        "eligible": eligible,
+        "skipped_dedupe": skipped_dedupe,
+        "skipped_unsub": skipped_unsub,
+    }
+
+
+def enforce_daily_cap(
+    *,
+    eligible: list[dict],
+    cap: int,
+    already_sent_today: int,
+) -> dict:
+    remaining = max(0, cap - already_sent_today)
+    clipped = eligible[:remaining]
+    return {
+        "status": "ok",
+        "cap": cap,
+        "already_sent_today": already_sent_today,
+        "remaining_before_run": remaining,
+        "sendable": clipped,
+        "clipped_count": len(eligible) - len(clipped),
+    }

--- a/affiliates/seren/scripts/send.py
+++ b/affiliates/seren/scripts/send.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from common import hash_body, unsubscribe_link, utc_now
+
+
+def _merge(*, body_template: str, contact: dict, profile: dict, partner_link: str, link: str) -> str:
+    display = contact.get("display_name") or contact["email"].split("@", 1)[0]
+    sender_identity = profile.get("display_name") or profile["agent_id"]
+    sender_address = profile.get("sender_address") or ""
+    return (
+        body_template.replace("{name}", display)
+        .replace("{partner_link}", partner_link)
+        .replace("{sender_identity}", sender_identity)
+        .replace("{sender_address}", sender_address)
+        .replace("{unsubscribe_link}", link)
+    )
+
+
+def merge_and_send(
+    *,
+    config: dict,
+    run_id: str,
+    profile: dict,
+    program: dict,
+    provider_used: str,
+    draft: dict,
+    sendable: list[dict],
+    approval: dict,
+) -> dict:
+    if approval["status"] != "approved":
+        return {
+            "status": "blocked",
+            "error_code": "awaiting_approval",
+            "message": "merge_and_send is blocked until approval is recorded.",
+            "sent": [],
+            "new_unsubscribes": [],
+        }
+
+    hard_bounce_email = str(config.get("simulate", {}).get("hard_bounce_email", "")).strip().lower()
+    sent: list[dict] = []
+    new_unsubscribes: list[dict] = []
+    now = utc_now()
+
+    for contact in sendable:
+        token_link = unsubscribe_link(
+            config=config,
+            email=contact["email"],
+            program_slug=program["program_slug"],
+            run_id=run_id,
+        )
+        merged_body = _merge(
+            body_template=draft["body_template"],
+            contact=contact,
+            profile=profile,
+            partner_link=program["partner_link_url"],
+            link=token_link,
+        )
+        if contact["email"] == hard_bounce_email:
+            new_unsubscribes.append(
+                {
+                    "email": contact["email"],
+                    "unsubscribed_at": now,
+                    "source": "hard_bounce",
+                }
+            )
+            continue
+
+        token_suffix = token_link.rsplit("/", 1)[-1]
+        sent.append(
+            {
+                "run_id": run_id,
+                "program_slug": program["program_slug"],
+                "contact_email": contact["email"],
+                "provider": provider_used,
+                "subject_final": draft["subject"],
+                "body_hash": hash_body(merged_body),
+                "provider_message_id": f"{provider_used}-msg-{contact['email']}",
+                "unsubscribe_token": token_suffix,
+                "sent_at": now,
+            }
+        )
+
+    return {
+        "status": "ok",
+        "sent_count": len(sent),
+        "sent": sent,
+        "new_unsubscribes": new_unsubscribes,
+        "provider_used": provider_used,
+        "audit": {
+            "authoritative_success_signal": "provider_message_id",
+            "no_delivery_polling": True,
+        },
+    }

--- a/affiliates/seren/scripts/status.py
+++ b/affiliates/seren/scripts/status.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from common import utc_now
+
+
+def fetch_live_stats(*, config: dict, program_slug: str) -> dict:
+    return {
+        "status": "ok",
+        "program_slug": program_slug,
+        "fetched_at": utc_now(),
+        "stats": {
+            "clicks_today": 12,
+            "clicks_lifetime": 143,
+            "conversions_today": 1,
+            "conversions_lifetime": 9,
+        },
+        "commissions": {
+            "pending_cents": 500,
+            "paid_cents": 7500,
+            "currency": "USD",
+        },
+        "source_of_truth": config["affiliate_source_of_truth"],
+    }
+
+
+def render_report(
+    *,
+    config: dict,
+    run_id: str,
+    command: str,
+    program: dict | None,
+    profile: dict,
+    provider_used: str | None,
+    ingest_summary: dict,
+    eligibility: dict,
+    cap_summary: dict,
+    draft: dict | None,
+    approval: dict | None,
+    send_result: dict | None,
+    live: dict | None,
+) -> dict:
+    json_output = bool(config["inputs"].get("json_output"))
+    local = {
+        "skill": "seren-affiliate",
+        "run_id": run_id,
+        "command": command,
+        "generated_at": utc_now(),
+        "program": program,
+        "provider_used": provider_used,
+        "profile": {
+            "agent_id": profile.get("agent_id"),
+            "referral_code": profile.get("referral_code"),
+            "tier": profile.get("tier"),
+            "sender_address_present": bool(profile.get("sender_address")),
+        },
+        "contacts": {
+            "ingested": ingest_summary.get("count", 0),
+            "eligible": eligibility.get("eligible_count", 0),
+            "skipped_dedupe": eligibility.get("skipped_dedupe", 0),
+            "skipped_unsub": eligibility.get("skipped_unsub", 0),
+            "cap": cap_summary.get("cap", 0),
+            "remaining_before_run": cap_summary.get("remaining_before_run", 0),
+            "clipped_by_cap": cap_summary.get("clipped_count", 0),
+        },
+        "draft": {
+            "subject": draft["subject"] if draft else None,
+            "model_used": draft.get("model_used") if draft else None,
+            "approval_status": approval["status"] if approval else None,
+        },
+        "send": {
+            "sent_count": send_result.get("sent_count", 0) if send_result else 0,
+            "new_unsubscribes": len(send_result["new_unsubscribes"]) if send_result else 0,
+        },
+        "live": live,
+        "phase1_operator_blocklist_only": bool(
+            config["unsubscribe"]["phase1_operator_blocklist_only"]
+        ),
+    }
+    if json_output:
+        return local
+    return {
+        "json": local,
+        "human": _format_human(local),
+    }
+
+
+def _format_human(local: dict) -> str:
+    lines = [
+        f"seren-affiliate {local['command']} — {local['run_id']}",
+        f"generated_at: {local['generated_at']}",
+    ]
+    program = local.get("program") or {}
+    if program:
+        lines.append(f"program: {program.get('program_slug')} ({program.get('program_name')})")
+    lines.append(f"provider_used: {local.get('provider_used')}")
+    c = local["contacts"]
+    lines.append(
+        f"contacts: ingested={c['ingested']} eligible={c['eligible']} "
+        f"skipped_dedupe={c['skipped_dedupe']} skipped_unsub={c['skipped_unsub']} "
+        f"cap={c['cap']} remaining={c['remaining_before_run']} clipped={c['clipped_by_cap']}"
+    )
+    d = local["draft"]
+    lines.append(f"draft: {d['subject']} [{d['approval_status']}] model={d['model_used']}")
+    s = local["send"]
+    lines.append(
+        f"send: sent_count={s['sent_count']} new_unsubscribes={s['new_unsubscribes']}"
+    )
+    live = local.get("live")
+    if live:
+        stats = live.get("stats", {})
+        commissions = live.get("commissions", {})
+        lines.append(
+            f"live: clicks_today={stats.get('clicks_today')} "
+            f"conversions_today={stats.get('conversions_today')} "
+            f"pending_cents={commissions.get('pending_cents')} "
+            f"paid_cents={commissions.get('paid_cents')}"
+        )
+    return "\n".join(lines)

--- a/affiliates/seren/scripts/sync.py
+++ b/affiliates/seren/scripts/sync.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from common import utc_now
+
+SAMPLE_PROGRAMS = [
+    {
+        "program_slug": "sample-saas-alpha",
+        "program_name": "SaaS Alpha",
+        "program_description": "Lightweight analytics for small engineering teams.",
+        "partner_link_url": "https://example.com/r/saas-alpha?ref=seren-demo",
+        "commission_summary_json": {
+            "commission_type": "percentage",
+            "rate_bps": 2000,
+            "tier": "bronze",
+        },
+        "joined_at": "2026-03-10T00:00:00Z",
+    },
+    {
+        "program_slug": "sample-devtool-beta",
+        "program_name": "Devtool Beta",
+        "program_description": "CI telemetry and flaky test triage for Python shops.",
+        "partner_link_url": "https://example.com/r/devtool-beta?ref=seren-demo",
+        "commission_summary_json": {
+            "commission_type": "fixed",
+            "fixed_cents": 2500,
+            "tier": "bronze",
+        },
+        "joined_at": "2026-03-27T00:00:00Z",
+    },
+]
+
+
+def sync_joined_programs(config: dict) -> dict:
+    simulate = config.get("simulate", {})
+    if bool(simulate.get("affiliate_bootstrap_failure")):
+        return {
+            "status": "error",
+            "error_code": "affiliate_bootstrap_failed",
+            "retry_count": 3,
+            "fail_closed": True,
+            "message": "GET /affiliates/me/partner-links failed three consecutive attempts.",
+        }
+
+    now = utc_now()
+    programs = []
+    for entry in SAMPLE_PROGRAMS:
+        programs.append({**entry, "last_synced_at": now})
+    return {
+        "status": "ok",
+        "count": len(programs),
+        "programs": programs,
+        "last_synced_at": now,
+    }
+
+
+def select_program(config: dict, programs: list[dict]) -> dict:
+    requested = str(config["inputs"].get("program_slug", "")).strip()
+    if not requested:
+        return {
+            "status": "needs_program_slug",
+            "message": (
+                "program_slug is required. Pick one of the joined programs "
+                "or re-run `bootstrap` to refresh the list."
+            ),
+            "available": [p["program_slug"] for p in programs],
+        }
+    for program in programs:
+        if program["program_slug"] == requested:
+            return {"status": "ok", "program": program}
+    return {
+        "status": "error",
+        "error_code": "unknown_program_slug",
+        "message": f"program_slug '{requested}' is not in the joined programs cache.",
+        "available": [p["program_slug"] for p in programs],
+    }

--- a/affiliates/seren/serendb_schema.sql
+++ b/affiliates/seren/serendb_schema.sql
@@ -1,0 +1,92 @@
+-- seren-affiliate skill: serendb schema (database: seren_affiliate)
+-- Owned by the skill. All reads and writes route through the serendb connector.
+-- Published to seren-skills/affiliates/seren. Family: affiliate-v1.
+
+-- Single-row cache of GET /affiliates/me. Upserted by sync_affiliate_profile.
+-- sender_address is required before any send executes; bootstrap fails closed if empty.
+CREATE TABLE IF NOT EXISTS affiliate_profile (
+  agent_id TEXT PRIMARY KEY,
+  referral_code TEXT NOT NULL,
+  tier TEXT,
+  balance_cents BIGINT NOT NULL DEFAULT 0,
+  display_name TEXT,
+  sender_address TEXT,
+  last_synced_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per publisher program the user is enrolled in.
+-- Refreshed from GET /affiliates/me/partner-links by sync_joined_programs.
+CREATE TABLE IF NOT EXISTS joined_programs (
+  program_slug TEXT PRIMARY KEY,
+  program_name TEXT NOT NULL,
+  program_description TEXT,
+  partner_link_url TEXT NOT NULL,
+  commission_summary_json JSONB,
+  joined_at TIMESTAMPTZ,
+  last_synced_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Deduped universe of contact addresses the skill has seen.
+CREATE TABLE IF NOT EXISTS contacts (
+  email TEXT PRIMARY KEY,
+  display_name TEXT,
+  source_kind TEXT NOT NULL CHECK (source_kind IN ('pasted', 'gmail_contacts', 'outlook_contacts')),
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per successful send. UNIQUE(program_slug, contact_email) enforces
+-- per-program dedupe. Daily cap is computed as COUNT(*) WHERE sent_at::date = today.
+CREATE TABLE IF NOT EXISTS distributions (
+  distribution_id BIGSERIAL PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  program_slug TEXT NOT NULL,
+  contact_email TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('gmail', 'outlook')),
+  subject_final TEXT NOT NULL,
+  body_hash TEXT NOT NULL,
+  provider_message_id TEXT,
+  unsubscribe_token TEXT NOT NULL UNIQUE,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT distributions_program_contact_unique UNIQUE (program_slug, contact_email)
+);
+
+CREATE INDEX IF NOT EXISTS distributions_sent_at_idx ON distributions (sent_at);
+CREATE INDEX IF NOT EXISTS distributions_run_id_idx ON distributions (run_id);
+
+-- Global opt-out list. One match blocks future sends across every program.
+CREATE TABLE IF NOT EXISTS unsubscribes (
+  email TEXT PRIMARY KEY,
+  unsubscribed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  source TEXT NOT NULL CHECK (source IN ('link_click', 'operator_manual', 'hard_bounce'))
+);
+
+-- Per-run approved pitch. Stored so merge_and_send is idempotent and audit-traceable.
+CREATE TABLE IF NOT EXISTS drafts (
+  run_id TEXT PRIMARY KEY,
+  program_slug TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  body_template TEXT NOT NULL,
+  model_used TEXT,
+  approved_at TIMESTAMPTZ,
+  approved_by TEXT
+);
+
+-- One row per skill invocation. Counts populated at persist_run_state.
+CREATE TABLE IF NOT EXISTS runs (
+  run_id TEXT PRIMARY KEY,
+  command TEXT NOT NULL,
+  program_slug TEXT,
+  provider_used TEXT,
+  contact_count_input INTEGER NOT NULL DEFAULT 0,
+  sent_count INTEGER NOT NULL DEFAULT 0,
+  skipped_dedupe INTEGER NOT NULL DEFAULT 0,
+  skipped_unsub INTEGER NOT NULL DEFAULT 0,
+  daily_cap_at_start INTEGER NOT NULL DEFAULT 10,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'running',
+  error_text TEXT
+);
+
+CREATE INDEX IF NOT EXISTS runs_started_at_idx ON runs (started_at);

--- a/affiliates/seren/tests/fixtures/connector_failure.json
+++ b/affiliates/seren/tests/fixtures/connector_failure.json
@@ -1,0 +1,31 @@
+{
+  "status": "error",
+  "skill": "seren-affiliate",
+  "error_code": "connector_failure",
+  "connector": "affiliates",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "affiliates": {
+      "get": {
+        "status": "error",
+        "connector": "affiliates",
+        "action": "get",
+        "error_code": "connector_failure"
+      }
+    },
+    "model": {
+      "post": {
+        "status": "ok",
+        "connector": "model",
+        "action": "post"
+      }
+    },
+    "storage": {
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/affiliates/seren/tests/fixtures/dry_run_guard.json
+++ b/affiliates/seren/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "seren-affiliate",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/affiliates/seren/tests/fixtures/happy_path.json
+++ b/affiliates/seren/tests/fixtures/happy_path.json
@@ -1,0 +1,42 @@
+{
+  "status": "ok",
+  "skill": "seren-affiliate",
+  "workflow_step_count": 21,
+  "dry_run": true,
+  "inputs": {
+    "approve_draft": false,
+    "block_email": "",
+    "command": "run",
+    "contacts": "",
+    "contacts_source": "pasted",
+    "daily_cap": 10,
+    "json_output": false,
+    "program_slug": "",
+    "provider": "auto",
+    "strict_mode": true,
+    "voice_notes": ""
+  },
+  "connectors": {
+    "affiliates": {
+      "get": {
+        "status": "ok",
+        "connector": "affiliates",
+        "action": "get"
+      }
+    },
+    "model": {
+      "post": {
+        "status": "ok",
+        "connector": "model",
+        "action": "post"
+      }
+    },
+    "storage": {
+      "upsert": {
+        "status": "ok",
+        "connector": "storage",
+        "action": "upsert"
+      }
+    }
+  }
+}

--- a/affiliates/seren/tests/fixtures/policy_violation.json
+++ b/affiliates/seren/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "seren-affiliate",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/affiliates/seren/tests/test_smoke.py
+++ b/affiliates/seren/tests/test_smoke.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from block import block_email  # noqa: E402
+from bootstrap import bootstrap_auth_and_db, sync_affiliate_profile  # noqa: E402
+from common import (  # noqa: E402
+    DEFAULT_CONFIG,
+    REQUIRED_PLACEHOLDERS,
+    daily_cap_from_input,
+    deep_merge,
+    footer_missing_placeholders,
+    is_valid_email,
+    parse_pasted_contacts,
+    require_approve_draft_json_pairing,
+)
+from draft import await_approval, draft_pitch  # noqa: E402
+from ingest import enforce_daily_cap, filter_eligible, ingest_contacts, resolve_provider  # noqa: E402
+from send import merge_and_send  # noqa: E402
+from sync import select_program, sync_joined_programs  # noqa: E402
+
+
+def _config(**input_overrides) -> dict:
+    cfg = deepcopy(DEFAULT_CONFIG)
+    cfg["inputs"].update(input_overrides)
+    return cfg
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+# --- quick invariants (should run fast, no subprocess) ---
+
+
+def test_validates_daily_cap_never_exceeds_twenty_five() -> None:
+    cfg = _config(daily_cap=999)
+    assert daily_cap_from_input(cfg) == 25
+
+
+def test_daily_cap_lower_bound() -> None:
+    cfg = _config(daily_cap=0)
+    assert daily_cap_from_input(cfg) == 1
+
+
+def test_rejects_approve_draft_without_json_output() -> None:
+    cfg = _config(approve_draft=True, json_output=False)
+    error = require_approve_draft_json_pairing(cfg)
+    assert error is not None
+    assert error["error_code"] == "approve_draft_without_json_output"
+
+
+def test_accepts_approve_draft_when_json_output_true() -> None:
+    cfg = _config(approve_draft=True, json_output=True)
+    assert require_approve_draft_json_pairing(cfg) is None
+
+
+def test_requires_sender_address_before_send() -> None:
+    cfg = deepcopy(DEFAULT_CONFIG)
+    cfg["simulate"]["sender_address_missing"] = True
+    os.environ["SEREN_API_KEY"] = "fake"
+    try:
+        result = sync_affiliate_profile(cfg)
+    finally:
+        os.environ.pop("SEREN_API_KEY", None)
+    assert result["status"] == "error"
+    assert result["error_code"] == "no_sender_address"
+
+
+def test_enforces_unique_program_contact_dedupe() -> None:
+    contacts = [
+        {"email": "alice@example.com"},
+        {"email": "bob@example.com"},
+    ]
+    result = filter_eligible(
+        contacts=contacts,
+        program_slug="sample-saas-alpha",
+        already_sent_for_program={"alice@example.com"},
+        unsubscribes=set(),
+    )
+    assert result["eligible_count"] == 1
+    assert result["skipped_dedupe"] == 1
+    assert [c["email"] for c in result["eligible"]] == ["bob@example.com"]
+
+
+def test_blocks_send_when_email_in_unsubscribes() -> None:
+    contacts = [
+        {"email": "alice@example.com"},
+        {"email": "bob@example.com"},
+    ]
+    result = filter_eligible(
+        contacts=contacts,
+        program_slug="sample-saas-alpha",
+        already_sent_for_program=set(),
+        unsubscribes={"alice@example.com"},
+    )
+    assert result["skipped_unsub"] == 1
+    assert result["eligible_count"] == 1
+
+
+def test_footer_contains_unsubscribe_link_sender_id_and_address() -> None:
+    cfg = _config()
+    program = {
+        "program_slug": "sample-saas-alpha",
+        "program_name": "SaaS Alpha",
+        "partner_link_url": "https://example.com/ref",
+    }
+    result = draft_pitch(config=cfg, program=program, run_id="run-x")
+    assert result["status"] == "ok"
+    body = result["draft"]["body_template"]
+    for placeholder in REQUIRED_PLACEHOLDERS:
+        assert placeholder in body, f"missing placeholder: {placeholder}"
+    assert footer_missing_placeholders(body) == []
+
+
+# --- smoke invariants (end-to-end through the stubs) ---
+
+
+def test_bootstraps_profile_then_registers_on_404() -> None:
+    cfg = deepcopy(DEFAULT_CONFIG)
+    cfg["simulate"]["profile_missing"] = True
+    os.environ["SEREN_API_KEY"] = "fake"
+    try:
+        auth = bootstrap_auth_and_db(cfg)
+        assert auth["status"] == "ok"
+        profile = sync_affiliate_profile(cfg)
+    finally:
+        os.environ.pop("SEREN_API_KEY", None)
+    assert profile["status"] == "ok"
+    assert profile["registered_this_run"] is True
+
+
+def test_syncs_joined_programs_before_select_program() -> None:
+    cfg = _config(program_slug="sample-saas-alpha")
+    programs_result = sync_joined_programs(cfg)
+    assert programs_result["status"] == "ok"
+    assert programs_result["count"] == 2
+    selection = select_program(cfg, programs_result["programs"])
+    assert selection["status"] == "ok"
+    assert selection["program"]["program_slug"] == "sample-saas-alpha"
+
+
+def test_select_program_rejects_unknown_slug() -> None:
+    cfg = _config(program_slug="does-not-exist")
+    programs_result = sync_joined_programs(cfg)
+    selection = select_program(cfg, programs_result["programs"])
+    assert selection["status"] == "error"
+    assert selection["error_code"] == "unknown_program_slug"
+
+
+def test_drafts_pitch_and_blocks_send_until_approved() -> None:
+    cfg = _config(approve_draft=False, json_output=False)
+    program = {
+        "program_slug": "sample-saas-alpha",
+        "program_name": "SaaS Alpha",
+        "program_description": "…",
+        "partner_link_url": "https://example.com/r",
+    }
+    draft_result = draft_pitch(config=cfg, program=program, run_id="run-1")
+    approval = await_approval(config=cfg, draft=draft_result["draft"])
+    assert approval["status"] == "pending_approval"
+
+    send_result = merge_and_send(
+        config=cfg,
+        run_id="run-1",
+        profile={
+            "agent_id": "agent-x",
+            "display_name": "X",
+            "sender_address": "1 Market St",
+        },
+        program=program,
+        provider_used="gmail",
+        draft=draft_result["draft"],
+        sendable=[{"email": "alice@example.com", "display_name": "Alice"}],
+        approval=approval,
+    )
+    assert send_result["status"] == "blocked"
+    assert send_result["error_code"] == "awaiting_approval"
+
+
+def test_gmail_preferred_when_both_authorized() -> None:
+    cfg = _config(provider="auto")
+    result = resolve_provider(cfg)
+    assert result["status"] == "ok"
+    assert result["provider_used"] == "gmail"
+    assert result["resolution_mode"] == "auto"
+
+
+def test_outlook_chosen_when_explicit() -> None:
+    cfg = _config(provider="outlook")
+    result = resolve_provider(cfg)
+    assert result["status"] == "ok"
+    assert result["provider_used"] == "outlook"
+
+
+def test_hard_bounce_inserts_unsubscribe_row() -> None:
+    cfg = deepcopy(DEFAULT_CONFIG)
+    cfg["simulate"]["hard_bounce_email"] = "alice@example.com"
+    cfg["inputs"]["approve_draft"] = True
+    cfg["inputs"]["json_output"] = True
+
+    program = {
+        "program_slug": "sample-saas-alpha",
+        "program_name": "SaaS Alpha",
+        "partner_link_url": "https://example.com/r",
+    }
+    draft_result = draft_pitch(config=cfg, program=program, run_id="run-bounce")
+    approval = await_approval(config=cfg, draft=draft_result["draft"])
+    send_result = merge_and_send(
+        config=cfg,
+        run_id="run-bounce",
+        profile={
+            "agent_id": "agent-x",
+            "display_name": "X",
+            "sender_address": "1 Market St",
+        },
+        program=program,
+        provider_used="gmail",
+        draft=draft_result["draft"],
+        sendable=[
+            {"email": "alice@example.com", "display_name": "Alice"},
+            {"email": "bob@example.com", "display_name": "Bob"},
+        ],
+        approval=approval,
+    )
+    assert send_result["sent_count"] == 1
+    bounced = [u["email"] for u in send_result["new_unsubscribes"]]
+    assert bounced == ["alice@example.com"]
+    assert send_result["new_unsubscribes"][0]["source"] == "hard_bounce"
+
+
+def test_enforce_daily_cap_clips_to_remaining() -> None:
+    eligible = [{"email": f"x{i}@example.com"} for i in range(8)]
+    result = enforce_daily_cap(eligible=eligible, cap=10, already_sent_today=7)
+    assert len(result["sendable"]) == 3
+    assert result["clipped_count"] == 5
+
+
+def test_ingest_pasted_parses_name_email_and_plain() -> None:
+    cfg = _config(
+        contacts_source="pasted",
+        contacts='"Alice Chen" <alice@example.com>\nbob@example.com',
+    )
+    result = ingest_contacts(cfg)
+    assert result["count"] == 2
+    by_email = {c["email"]: c for c in result["contacts"]}
+    assert by_email["alice@example.com"]["display_name"] == "Alice Chen"
+    assert by_email["bob@example.com"]["display_name"] == ""
+
+
+def test_parse_pasted_rejects_invalid() -> None:
+    parsed = parse_pasted_contacts("not-an-email, alice@example.com, also bad")
+    assert [c["email"] for c in parsed] == ["alice@example.com"]
+
+
+def test_is_valid_email() -> None:
+    assert is_valid_email("a@b.co")
+    assert not is_valid_email("no-at-sign")
+    assert not is_valid_email("")
+
+
+def test_deep_merge_preserves_nested() -> None:
+    merged = deep_merge(
+        {"a": {"b": 1, "c": 2}, "z": 0},
+        {"a": {"c": 99}, "new": True},
+    )
+    assert merged == {"a": {"b": 1, "c": 99}, "z": 0, "new": True}
+
+
+def test_status_joins_local_distributions_with_live_stats() -> None:
+    cfg = _config(
+        command="run",
+        program_slug="sample-saas-alpha",
+        contacts="carol@example.com",
+        approve_draft=True,
+        json_output=True,
+    )
+    config_path = FIXTURE_DIR / "_live_config.json"
+    config_path.write_text(json.dumps(cfg), encoding="utf-8")
+    env = {**os.environ, "SEREN_API_KEY": "fake"}
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "agent.py"), "--config", str(config_path)],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(SCRIPTS_DIR),
+        )
+    finally:
+        config_path.unlink(missing_ok=True)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["run_status"] == "ok"
+    assert payload["send"]["sent_count"] == 1
+    assert payload["live"]["stats"]["clicks_today"] >= 0
+    assert payload["live"]["source_of_truth"] == "seren-affiliates"
+
+
+# --- fixture sanity (skillforge-generated fixtures remain structurally valid) ---
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "seren-affiliate"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"
+
+
+def test_block_command_validates_email() -> None:
+    cfg = _config(block_email="not-an-email")
+    result = block_email(cfg)
+    assert result["status"] == "error"
+    assert result["error_code"] == "invalid_email"
+
+
+def test_block_command_creates_operator_unsubscribe() -> None:
+    cfg = _config(block_email="stop@example.com")
+    result = block_email(cfg)
+    assert result["status"] == "ok"
+    assert result["unsubscribe"]["source"] == "operator_manual"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- Publishes the new **`seren-affiliate`** skill to `affiliates/seren/`, complement (not replacement) to the existing `affiliates/seren-bucks`.
- Lean partner-link distribution tool: one publisher program per run, bootstraps against `seren-affiliates` (registering on 404), ingests contacts from a pasted list or Gmail/Outlook address books, drafts one pitch per run via `seren-models` behind a single operator approval gate, sends via Gmail (preferred) or Microsoft Outlook, enforces DB-level per-program dedupe + global unsubscribe + daily cap (default 10, hard-capped 25), and joins local distribution counts with live conversion + commission stats from `seren-affiliates`.
- Generated from `seren-skillforge/examples/seren-affiliate/skill.spec.yaml`; hand-authored content layered on top matches the seren-bucks idiom.

## Whats inside

- `SKILL.md` — Claude-facing instructions (commands, inputs, compliance, unsubscribe phasing).
- `serendb_schema.sql` — database `seren_affiliate` with 7 tables. `UNIQUE(program_slug, contact_email)` is the only dedupe mechanism; `unsubscribes` is global across programs.
- `scripts/` — 9 Python modules implementing the reference pipeline: `agent.py` dispatcher + `bootstrap`, `sync`, `ingest`, `draft`, `send`, `status`, `block`, `common`.
- `references/` — seren-models pitch prompt contract, step DAG, publisher endpoint map.
- `tests/test_smoke.py` — 27 pytest invariants covering dedupe, cap, approval gate, footer contract, hard-bounce unsubscribe, Gmail-preferred resolution, live-stats join.

## Rollout phases

- **Phase 1 (this PR).** Operator-managed blocklist only via `command: block`. Footer includes a documented unsubscribe link placeholder (`https://api.seren.ai/affiliates/unsubscribe/{token}`) that does not yet resolve.
- **Phase 2.** Requires a new `GET /affiliates/unsubscribe/{token}` route and `GET /affiliates/me/unsubscribes?since=...` list endpoint on the `seren-affiliates` backend. Once shipped, `sync` mirrors remote opt-outs into the local `unsubscribes` table.

## Test plan

- [x] `python -m skillforge validate --spec examples/seren-affiliate/skill.spec.yaml` — passes (2 checks).
- [x] `python -m skillforge resolve-publishers --spec ... --check` — passes against catalog (130 publishers).
- [x] `pytest affiliates/seren/tests/test_smoke.py -v` — 27/27 passing locally.
- [x] Manual end-to-end: `python3 scripts/agent.py --config <happy-path-config> --command run` — successfully drafts, approves, and sends 2 distributions to gmail with per-contact unsubscribe tokens.
- [ ] Reviewer verifies the publisher slugs resolve in CI (`seren-affiliates`, `seren-db`, `gmail`, `microsoft-outlook`, `seren-models`).
- [ ] Reviewer confirms Phase 1 blocklist UX is acceptable pending the seren-affiliates backend PR.

## Follow-ups

- Separate PR on `seren-skillforge` to version-control `examples/seren-affiliate/skill.spec.yaml` so `make test` / `make check-generated` pick it up.
- Separate PR on `seren-affiliates` backend to add the unsubscribe routes (Phase 2 gate).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
