### PR TITLE
fix(affiliates): point unsubscribe flow at seren-affiliates-website

### DIFF
--- a/affiliates/seren/.env.example
+++ b/affiliates/seren/.env.example
@@ -4,10 +4,12 @@
 # microsoft-outlook, and seren-models publishers).
 SEREN_API_KEY=
 
-# Optional — HMAC key for the Phase 2 unsubscribe link tokens.
-# Leave unset until the seren-affiliates backend adds
-# GET /affiliates/unsubscribe/{token}. In Phase 1 the link is non-functional
-# (documented placeholder); the operator handles opt-outs via `command: block`.
+# Optional — HMAC key for the Phase 2 unsubscribe link tokens. Must match the
+# REFERRAL_TOKEN_SECRET configured on seren-affiliates-website so its
+# /unsubscribe/[agent_id]/[token] route can verify tokens minted by the skill.
+# Leave unset until that route ships (tracked in
+# serenorg/seren-affiliates-website#36). In Phase 1 the link is a documented
+# placeholder; the operator handles opt-outs via `command: block`.
 REFERRAL_TOKEN_SECRET=
 
 # Optional — overrides the Seren Desktop-injected API_KEY path.

--- a/affiliates/seren/README.md
+++ b/affiliates/seren/README.md
@@ -60,7 +60,7 @@ tests/
 ## Rollout phases
 
 - **Phase 1 (shipped).** Operator-managed blocklist only. Unsubscribe link in the footer is a documented placeholder; operator removes recipients manually via `command: block`.
-- **Phase 2.** Requires a new `GET /affiliates/unsubscribe/{token}` route and `GET /affiliates/me/unsubscribes?since=...` list on the seren-affiliates backend. Once those ship, `sync` auto-mirrors remote unsubscribes into the local table.
+- **Phase 2.** Requires a new public `GET /unsubscribe/[agent_id]/[token]` route and `GET /public/unsubscribes?agent_id=...&since=...` read API on `seren-affiliates-website` — tracked in serenorg/seren-affiliates-website#36. Once that ships, `sync` mirrors remote opt-outs into the local `unsubscribes` table by joining returned tokens against local `distributions` to resolve `token → email`. `seren-affiliates` (the backend) is intentionally **not** involved and stores no recipient PII.
 
 ## Regenerating from the spec
 

--- a/affiliates/seren/SKILL.md
+++ b/affiliates/seren/SKILL.md
@@ -24,7 +24,7 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - Per-program dedupe is DB-level: a (program_slug, contact_email) pair is sent at most once, ever.
 - Global unsubscribe list: one opt-out blocks all future sends across every program.
 - Mandatory send footer: sender identity, physical address, and unsubscribe link.
-- **Phase 1 operator-managed blocklist only.** The `/affiliates/unsubscribe/{token}` endpoint does not exist in seren-affiliates yet; click-to-unsubscribe flips on in Phase 2 when the backend ships.
+- **Phase 1 operator-managed blocklist only.** The public `/unsubscribe/{agent_id}/{token}` route on `seren-affiliates-website` does not exist yet; click-to-unsubscribe flips on in Phase 2 when that ships. `seren-affiliates` itself stores no recipient PII and needs no changes.
 
 ## Bootstrap Order (Mandatory)
 
@@ -117,8 +117,8 @@ Schema in `serendb_schema.sql`. Tables:
 
 ## Unsubscribe Handling (Phase 1 vs Phase 2)
 
-- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://api.seren.ai/affiliates/unsubscribe/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)`. The endpoint does **not** exist in the seren-affiliates backend yet. Until it ships, the operator handles unsubscribes manually via `command: block` with `block_email=<recipient>`.
-- **Phase 2.** Once the seren-affiliates backend adds `GET /affiliates/unsubscribe/{token}` and `GET /affiliates/me/unsubscribes?since=...`, the skill's `sync` step mirrors remote unsubscribes into the local `unsubscribes` table automatically.
+- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://affiliates.serendb.com/unsubscribe/{agent_id}/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)` and `agent_id` identifies the affiliate account. The route does **not** exist on `seren-affiliates-website` yet. Until it ships, the operator handles unsubscribes manually via `command: block` with `block_email=<recipient>`.
+- **Phase 2.** Once `seren-affiliates-website` adds `GET /unsubscribe/[agent_id]/[token]` and `GET /public/unsubscribes?agent_id=...&since=...`, the skill's `sync` step calls the public read API, joins returned tokens against the local `distributions` table to resolve `token → email`, and upserts into `unsubscribes` with `source=link_click`. `seren-affiliates` (the backend) is intentionally **not** involved — it stores no recipient PII by design.
 
 ## Status and Stats
 

--- a/affiliates/seren/references/provider-mappings.md
+++ b/affiliates/seren/references/provider-mappings.md
@@ -12,7 +12,6 @@ The skill calls four connector publishers, each with fixed path assumptions.
 | select_program (re-fetch) | GET | /affiliates/me/partner-links/{slug} | Called right before merge_and_send to avoid stale URLs |
 | fetch_live_stats | GET | /affiliates/me/stats | Filter by program_slug |
 | fetch_live_commissions | GET | /affiliates/me/commissions | Filter by program_slug |
-| sync_remote_unsubscribes | GET | /affiliates/me/unsubscribes?since=... | Phase 2, backend dependency |
 
 Headers: `X-Seren-Agent-Id` (cached from first `/affiliates/me` response) + `Authorization: Bearer $SEREN_API_KEY`.
 
@@ -37,3 +36,14 @@ Operations: `upsert` and `get` only. Database `seren_affiliate`.
 ## model — seren-models
 
 Single call at `draft_pitch`. Prompt reference: `references/prompts/draft_pitch.md`. Output is validated for the five required placeholder tokens before persistence.
+
+## website — seren-affiliates-website (Phase 2)
+
+Not a Seren publisher. Plain HTTPS from the skill.
+
+| Step | Method | Path | Notes |
+|------|--------|------|-------|
+| emit_unsubscribe_link | (client-side URL only) | /unsubscribe/{agent_id}/{token} | Embedded in every outbound body_template as `{unsubscribe_link}` |
+| sync_remote_unsubscribes | GET | /public/unsubscribes?agent_id=...&since=... | Phase 2 dependency (serenorg/seren-affiliates-website#36); returns paginated tokens the skill joins against local `distributions` to resolve token → email |
+
+Base URL: `https://affiliates.serendb.com` (configured at `config.unsubscribe.endpoint_base` and `config.unsubscribe.sync_api_base`). No recipient PII is ever sent to this host — only HMAC tokens and `agent_id`. `seren-affiliates` (the backend) is intentionally not involved.

--- a/affiliates/seren/scripts/common.py
+++ b/affiliates/seren/scripts/common.py
@@ -36,7 +36,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "daily_cap_max": 25,
     },
     "unsubscribe": {
-        "endpoint_base": "https://api.seren.ai/affiliates/unsubscribe",
+        "endpoint_base": "https://affiliates.serendb.com/unsubscribe",
+        "sync_api_base": "https://affiliates.serendb.com/public/unsubscribes",
         "phase1_operator_blocklist_only": True,
     },
     "inputs": {
@@ -139,6 +140,7 @@ def unsubscribe_link(
     email: str,
     program_slug: str,
     run_id: str,
+    agent_id: str,
 ) -> str:
     secret_env = config["auth"].get("referral_token_secret_env", "REFERRAL_TOKEN_SECRET")
     token = unsubscribe_token(
@@ -148,7 +150,7 @@ def unsubscribe_link(
         secret=os.environ.get(secret_env),
     )
     base = str(config["unsubscribe"]["endpoint_base"]).rstrip("/")
-    return f"{base}/{token}"
+    return f"{base}/{agent_id}/{token}"
 
 
 def footer_missing_placeholders(body_template: str) -> list[str]:

--- a/affiliates/seren/scripts/send.py
+++ b/affiliates/seren/scripts/send.py
@@ -47,6 +47,7 @@ def merge_and_send(
             email=contact["email"],
             program_slug=program["program_slug"],
             run_id=run_id,
+            agent_id=profile["agent_id"],
         )
         merged_body = _merge(
             body_template=draft["body_template"],
@@ -55,17 +56,17 @@ def merge_and_send(
             partner_link=program["partner_link_url"],
             link=token_link,
         )
+        token_suffix = token_link.rsplit("/", 1)[-1]
         if contact["email"] == hard_bounce_email:
             new_unsubscribes.append(
                 {
                     "email": contact["email"],
                     "unsubscribed_at": now,
                     "source": "hard_bounce",
+                    "unsubscribe_token": token_suffix,
                 }
             )
             continue
-
-        token_suffix = token_link.rsplit("/", 1)[-1]
         sent.append(
             {
                 "run_id": run_id,


### PR DESCRIPTION
## Summary

- Corrects the Phase 2 unsubscribe architecture. `seren-affiliates` is agent-to-agent and does not store recipient PII by design, so the original proposal (`serenorg/seren-affiliates#51`) that shoved email-adjacent storage into the backend was wrong.
- Phase 2 now targets `seren-affiliates-website` (Next.js on Cloudflare Pages), which already hosts the public marketing surface for `affiliates.serendb.com` and is the natural home for a public one-click unsubscribe route + its own KV/D1 opt-out store. Tracked as serenorg/seren-affiliates-website#36.
- Skill output changes: `{unsubscribe_link}` now emits `https://affiliates.serendb.com/unsubscribe/{agent_id}/{token}`. The `agent_id` in the path lets the website scope tokens per-affiliate for the public read API without ever seeing an email.

## Changes

- `scripts/common.py`: `unsubscribe_link()` takes `agent_id`, and `config.unsubscribe` grows a `sync_api_base` entry for the Phase 2 read API.
- `scripts/send.py`: passes `profile["agent_id"]` into the link builder. Also stamps `unsubscribe_token` onto hard-bounce rows so the same token can be reconciled later if a bounce eventually becomes a click.
- `SKILL.md`, `README.md`, `references/provider-mappings.md`: rewrite Phase 2 language to reference the website; add a new `website — seren-affiliates-website` section to the provider map; make the no-PII boundary explicit.
- `.env.example`: clarify that `REFERRAL_TOKEN_SECRET` must match the secret configured on the website.

## Test plan

- [x] `pytest tests/test_smoke.py -v` — all 27 invariants still pass after the kwarg addition and URL shape change.
- [ ] Reviewer confirms the URL shape works for Cloudflare Pages routing conventions (`/unsubscribe/[agent_id]/[token]` will map to `app/unsubscribe/[agent_id]/[token]/route.tsx`).
- [ ] Follow-up after serenorg/seren-affiliates-website#36 lands: wire `sync` to call the public read API and upsert returned tokens into `unsubscribes` (with `source=link_click`, joined against `distributions`).

## Context

- Original skill ship: serenorg/seren-skills#398 (merged 2026-04-14).
- Original backend proposal, closed as wrong: serenorg/seren-affiliates#51.
- New Phase 2 home: serenorg/seren-affiliates-website#36.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
