### PR TITLE
fix(serenbucks): document 3-tier unilevel model in outreach guidance

### DIFF
--- a/affiliates/seren-bucks/SKILL.md
+++ b/affiliates/seren-bucks/SKILL.md
@@ -12,6 +12,25 @@ Review-first growth skill for one default Seren Bucks affiliate campaign.
 
 Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
 
+## Affiliate Program Structure (Read Before Drafting)
+
+SerenBucks is a **3-tier unilevel** program. Outreach copy MUST reflect this:
+
+- **Tier 0** — the affiliate earns **20%** direct commission on their own referrals.
+- **Tier 1 override** — the affiliate's sponsor earns **5%** when a direct child refers.
+- **Tier 2 override** — the sponsor's sponsor earns **5%** when a grandchild refers.
+
+The bootstrapped `tracked_link` is the **operator's own `SRN_` recruitment link**. When
+a recipient signs up through that link, they become a Tier 1 downstream of the operator
+and receive **their own unique `SRN_` code** to share. Only the recipient's own code
+credits them with Tier 0 (20%) commission — forwarding the operator's link credits the
+operator, not the recipient.
+
+Never draft outreach that claims the recipient earns 20% on the link inside the email.
+Pull all outreach copy from `references/email-templates.md`, which documents the correct
+three-step recruitment flow (join → get own code → share own code) and the full tier
+disclosure.
+
 ## Default V1 Contract
 
 - The skill operates exactly one default affiliate campaign in v1.

--- a/affiliates/seren-bucks/config.example.json
+++ b/affiliates/seren-bucks/config.example.json
@@ -4,7 +4,7 @@
   "campaign": {
     "campaign_id": "seren-bucks-default",
     "campaign_name": "Seren Bucks Default Affiliate Campaign",
-    "tracked_link": "https://seren.ai/serenbucks?ref=default",
+    "tracked_link": "https://serendb.com?ref=default",
     "affiliate_source_of_truth": "seren-affiliates"
   },
   "database": {
@@ -44,7 +44,7 @@
     "proposal_size": 10,
     "new_outbound_daily_cap": 10,
     "strict_mode": true,
-    "tracked_link": "https://seren.ai/serenbucks?ref=default"
+    "tracked_link": "https://serendb.com?ref=default"
   },
   "connectors": [
     "affiliates",

--- a/affiliates/seren-bucks/references/email-templates.md
+++ b/affiliates/seren-bucks/references/email-templates.md
@@ -1,0 +1,81 @@
+# Seren Bucks V1 Outreach Email Templates
+
+Canonical copy for outreach drafts. Claude MUST pull from these templates
+when drafting new-outbound messages for the default SerenBucks campaign,
+rather than synthesizing commission language from scratch.
+
+## Program structure to disclose (non-negotiable)
+
+SerenBucks is a 3-tier unilevel affiliate program. Every outreach email
+MUST reflect the following flow without shortcuts:
+
+1. The recipient is being invited to **join** as an affiliate.
+2. The link in the email is the **sender's** `SRN_` recruitment link. It
+   attaches the recipient as a Tier 1 downstream **only after the
+   recipient signs up via the link**.
+3. Once signed up, the recipient receives **their own unique `SRN_`
+   code** and is the Tier 0 affiliate for anything *they* refer.
+4. Commission rates:
+   - **Tier 0 (recipient's own referrals):** 20% direct commission
+   - **Tier 1 override (paid to their sponsor, i.e. the sender):** 5%
+   - **Tier 2 override (paid to sponsor's sponsor):** 5%
+
+Never tell the recipient they earn 20% just by forwarding the sender's
+link. That credits the sender, not them.
+
+## Template: Recruitment outreach (default)
+
+Placeholders:
+
+- `{{recipient_first_name}}` — e.g. `Erik`
+- `{{sender_first_name}}` — e.g. `Taariq`
+- `{{sender_full_name}}` — e.g. `Taariq Lewis`
+- `{{sender_link}}` — sender's bootstrapped tracked link, e.g. `https://serendb.com?ref=SRN_TUQ4PQE2`
+- `{{personal_hook}}` — one-sentence personalized opener grounded in CRM signal
+
+Subject options:
+
+- `Join SerenBucks and earn 20% on your own referrals`
+- `SerenBucks affiliate invite — your own referral code inside`
+
+Body:
+
+```
+Hi {{recipient_first_name}},
+
+{{personal_hook}}
+
+We're opening up the SerenBucks Affiliate Program and I'd like to sponsor
+you in. Here's how it works:
+
+1. Join via my sponsor link below. You'll get your own unique SerenBucks
+   referral code (an SRN_ link of your very own).
+2. Share YOUR code with your network. You earn 20% commission on every
+   SerenDB signup and usage that comes through YOUR link.
+3. As your sponsor, I earn a 5% network override from your activity —
+   that's why I'm happy to bring you in. No cost to you.
+
+Join here (this enrolls you under me as sponsor):
+{{sender_link}}
+
+After signup you'll see your own code in the SerenBucks dashboard —
+that's the one you send to friends.
+
+Cheers,
+{{sender_full_name}}
+SerenDB
+```
+
+## What the draft MUST NOT say
+
+- "You earn 20% on this link" (the link is the sender's, not theirs).
+- "Just share this link to earn commissions" (same reason).
+- "No signup required" (signup is how they get their own `SRN_` code).
+
+## Validation checklist before approval
+
+- Body contains the sender's exact bootstrapped `tracked_link`.
+- Body contains the three-step flow (join → get own code → share own code).
+- Body discloses both the recipient's 20% and the sender's 5% override.
+- Subject and body do not claim the recipient earns from forwarding the
+  sender's link.

--- a/affiliates/seren-bucks/scripts/common.py
+++ b/affiliates/seren-bucks/scripts/common.py
@@ -13,7 +13,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "campaign": {
         "campaign_id": "seren-bucks-default",
         "campaign_name": "Seren Bucks Default Affiliate Campaign",
-        "tracked_link": "https://seren.ai/serenbucks?ref=default",
+        "tracked_link": "https://serendb.com?ref=default",
         "affiliate_source_of_truth": "seren-affiliates",
     },
     "database": {
@@ -53,7 +53,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "proposal_size": 10,
         "new_outbound_daily_cap": 10,
         "strict_mode": True,
-        "tracked_link": "https://seren.ai/serenbucks?ref=default",
+        "tracked_link": "https://serendb.com?ref=default",
     },
     "simulate": {
         "affiliate_bootstrap_failure": False,

--- a/affiliates/seren-bucks/skill.spec.yaml
+++ b/affiliates/seren-bucks/skill.spec.yaml
@@ -45,7 +45,7 @@ inputs:
   tracked_link:
     type: string
     description: Canonical tracked link for the default Seren Bucks affiliate campaign.
-    default: https://seren.ai/serenbucks?ref=default
+    default: https://serendb.com?ref=default
 secrets:
   - SEREN_API_KEY
 connectors:

--- a/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
+++ b/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
@@ -1,0 +1,63 @@
+"""Critical guardrails for SerenBucks outreach copy correctness.
+
+These tests cover the P0/P1 fixes tracked in #400-#404. They assert the
+skill's static guidance tells Claude how to describe the 3-tier unilevel
+program and uses the correct production tracked-link domain. Runtime
+email synthesis is Claude's job; these tests lock the contract that feeds
+it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+EMAIL_TEMPLATE = SKILL_ROOT / "references" / "email-templates.md"
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+COMMON_PY = SKILL_ROOT / "scripts" / "common.py"
+CONFIG_EXAMPLE = SKILL_ROOT / "config.example.json"
+SKILL_SPEC = SKILL_ROOT / "skill.spec.yaml"
+
+
+def test_email_template_documents_three_step_recruitment_flow() -> None:
+    """P0 #400: drafts must describe join -> get own code -> share own code."""
+    body = EMAIL_TEMPLATE.read_text(encoding="utf-8").lower()
+    assert "join" in body, "template must tell recipient to join first"
+    assert "your own" in body and "code" in body, (
+        "template must explain recipient gets their own SRN_ code after signup"
+    )
+    assert "share" in body, "template must tell recipient to share THEIR code"
+    assert "20%" in body, "template must state the 20% direct commission"
+    assert "5%" in body, "template must state the 5% override so sender's stake is honest"
+
+
+def test_skill_md_documents_three_tier_unilevel_structure() -> None:
+    """P0 #401: SKILL.md must ground Claude in tier 0/1/2 commission model."""
+    body = SKILL_MD.read_text(encoding="utf-8").lower()
+    for phrase in ("tier 0", "tier 1", "tier 2"):
+        assert phrase in body, f"SKILL.md missing '{phrase}' reference"
+    assert "20%" in body and "5%" in body, (
+        "SKILL.md must document 20% direct and 5% override rates"
+    )
+    assert "email-templates" in body, (
+        "SKILL.md must point Claude at references/email-templates.md"
+    )
+
+
+def test_default_tracked_link_uses_serendb_domain() -> None:
+    """P1 #403: all defaults must use serendb.com, not the obsolete seren.ai URL."""
+    offenders = []
+    for path in (COMMON_PY, CONFIG_EXAMPLE, SKILL_SPEC):
+        if "seren.ai/serenbucks" in path.read_text(encoding="utf-8"):
+            offenders.append(path.name)
+    assert not offenders, f"obsolete seren.ai/serenbucks domain in: {offenders}"
+
+    config = json.loads(CONFIG_EXAMPLE.read_text(encoding="utf-8"))
+    for link in (
+        config["campaign"]["tracked_link"],
+        config["inputs"]["tracked_link"],
+    ):
+        assert link.startswith("https://serendb.com"), (
+            f"default tracked_link must use serendb.com, got: {link}"
+        )


### PR DESCRIPTION
## Summary

- `seren-bucks` outreach claimed the recipient earned 20% while embedding the **sender's** `SRN_` recruitment link (live emails went out 2026-04-15). Adds SKILL.md commission-structure docs and a canonical recruitment email template in `references/` so Claude no longer synthesizes misleading copy.
- Moves stale `seren.ai/serenbucks` defaults to `serendb.com` across `common.py`, `config.example.json`, and `skill.spec.yaml`.
- Locks the fix in with three guardrail tests in `tests/test_commission_copy_guardrails.py`.

Closes #400, #401, #402, #403. Defense-in-depth validator (#404) will be a follow-up.

## Test plan

- [x] `pytest affiliates/seren-bucks/tests/` — 7 passed
- [x] `pytest tests/` — regressions limited to 2 pre-existing polymarket failures on `main` (unrelated)
- [ ] Functional Gmail dry-run: re-invoke `/seren-bucks` and confirm draft copy follows the 3-step recruitment flow and uses `https://serendb.com?ref=<SRN_>` link

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
