### PR TITLE
fix(affiliates): validate tracked_link post-merge (#404)

### DIFF
--- a/affiliates/seren/SKILL.md
+++ b/affiliates/seren/SKILL.md
@@ -105,6 +105,7 @@ Schema in `serendb_schema.sql`. Tables:
 - `policies.dry_run_default: true` — the skill previews every batch and refuses to send unless `approve_draft=true` (with `json_output=true`) or the interactive approval is recorded.
 - `policies.idempotency_required: true` — every distribution is keyed to a `run_id` plus `UNIQUE(program_slug, contact_email)`.
 - Mandatory footer placeholders in every drafted body: `{name}`, `{partner_link}`, `{sender_identity}`, `{sender_address}`, `{unsubscribe_link}`. A regex gate rejects drafts missing any of them.
+- Post-merge tracked-link validator (issue #404): after each per-contact merge, the skill asserts the bootstrapped `partner_link_url` substring is present in the merged body and **fails the send closed** (`validation_failed` / `tracked_link_missing`) if not. This is a defense-in-depth guard against a future LLM prompt change stripping the link or swapping a hallucinated URL.
 - `sender_address` is required before any send. The skill fails closed if `affiliate_profile.sender_address` is empty.
 - Hard-bounce on send auto-inserts into `unsubscribes` with `source=hard_bounce`.
 - PII posture: only `name` + `email` are pulled from provider address books. Never message bodies or threads. Email addresses never appear in stdout outside the final summary, and only in structured form under `json_output=true`.

--- a/affiliates/seren/scripts/send.py
+++ b/affiliates/seren/scripts/send.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from common import hash_body, unsubscribe_link, utc_now
+from validators import validate_tracked_link
 
 
 def _merge(*, body_template: str, contact: dict, profile: dict, partner_link: str, link: str) -> str:
@@ -56,6 +57,22 @@ def merge_and_send(
             partner_link=program["partner_link_url"],
             link=token_link,
         )
+        link_check = validate_tracked_link(
+            merged_body=merged_body,
+            tracked_link=program["partner_link_url"],
+        )
+        if link_check["status"] != "ok":
+            return {
+                "status": "validation_failed",
+                "error_code": link_check["error_code"],
+                "message": link_check["message"],
+                "failed_contact_email": contact["email"],
+                "expected_tracked_link": link_check.get("expected_tracked_link"),
+                "sent": sent,
+                "new_unsubscribes": new_unsubscribes,
+                "sent_count": len(sent),
+                "provider_used": provider_used,
+            }
         token_suffix = token_link.rsplit("/", 1)[-1]
         if contact["email"] == hard_bounce_email:
             new_unsubscribes.append(

--- a/affiliates/seren/scripts/validators.py
+++ b/affiliates/seren/scripts/validators.py
@@ -1,0 +1,42 @@
+"""Post-drafting validators for outbound affiliate messages.
+
+Issue #404 — defense-in-depth. Every merged outbound body must contain the
+exact `tracked_link` (partner_link_url) that was bootstrapped from
+seren-affiliates. A hallucinated URL, a stripped placeholder, or a stale code
+would otherwise reach the recipient undetected.
+"""
+
+from __future__ import annotations
+
+
+def validate_tracked_link(
+    *,
+    merged_body: str,
+    tracked_link: str,
+) -> dict:
+    """Assert the bootstrapped tracked_link substring is present in merged_body.
+
+    Returns {"status": "ok"} on success, or
+    {"status": "validation_failed", "error_code": "tracked_link_missing", ...}
+    so the send pipeline can fail-closed.
+    """
+    if not tracked_link:
+        return {
+            "status": "validation_failed",
+            "error_code": "tracked_link_empty",
+            "message": (
+                "Bootstrapped tracked_link is empty. Refusing to send a draft "
+                "whose partner_link cannot be verified."
+            ),
+        }
+    if tracked_link not in merged_body:
+        return {
+            "status": "validation_failed",
+            "error_code": "tracked_link_missing",
+            "message": (
+                "Merged draft body does not contain the bootstrapped "
+                "tracked_link. Fail-closed per #404."
+            ),
+            "expected_tracked_link": tracked_link,
+        }
+    return {"status": "ok"}

--- a/affiliates/seren/tests/test_smoke.py
+++ b/affiliates/seren/tests/test_smoke.py
@@ -31,6 +31,7 @@ from draft import await_approval, draft_pitch  # noqa: E402
 from ingest import enforce_daily_cap, filter_eligible, ingest_contacts, resolve_provider  # noqa: E402
 from send import merge_and_send  # noqa: E402
 from sync import select_program, sync_joined_programs  # noqa: E402
+from validators import validate_tracked_link  # noqa: E402
 
 
 def _config(**input_overrides) -> dict:
@@ -348,6 +349,68 @@ def test_block_command_creates_operator_unsubscribe() -> None:
     result = block_email(cfg)
     assert result["status"] == "ok"
     assert result["unsubscribe"]["source"] == "operator_manual"
+
+
+# --- Issue #404: tracked_link validator (defense-in-depth) ---
+
+
+def test_validate_tracked_link_accepts_body_containing_link() -> None:
+    result = validate_tracked_link(
+        merged_body="Hi Alice, here is the link: https://example.com/r/x?ref=demo\nThanks",
+        tracked_link="https://example.com/r/x?ref=demo",
+    )
+    assert result["status"] == "ok"
+
+
+def test_validate_tracked_link_rejects_body_missing_link() -> None:
+    result = validate_tracked_link(
+        merged_body="Hi Alice, here is the link: https://evil.example.com/hallucinated",
+        tracked_link="https://example.com/r/x?ref=demo",
+    )
+    assert result["status"] == "validation_failed"
+    assert result["error_code"] == "tracked_link_missing"
+    assert result["expected_tracked_link"] == "https://example.com/r/x?ref=demo"
+
+
+def test_merge_and_send_fails_closed_when_draft_drops_partner_link_placeholder() -> None:
+    cfg = deepcopy(DEFAULT_CONFIG)
+    cfg["inputs"]["approve_draft"] = True
+    cfg["inputs"]["json_output"] = True
+
+    program = {
+        "program_slug": "sample-saas-alpha",
+        "program_name": "SaaS Alpha",
+        "partner_link_url": "https://example.com/r/alpha?ref=demo",
+    }
+    draft_result = draft_pitch(config=cfg, program=program, run_id="run-404")
+    assert draft_result["status"] == "ok"
+
+    tampered_draft = dict(draft_result["draft"])
+    tampered_draft["body_template"] = (
+        "Hi {name},\n\nI wanted to share SaaS Alpha. "
+        "Here is a link: https://wrong.example.com/fake\n\n"
+        "---\n{sender_identity}\n{sender_address}\n"
+        "Unsubscribe: {unsubscribe_link}\n"
+    )
+    approval = await_approval(config=cfg, draft=tampered_draft)
+
+    send_result = merge_and_send(
+        config=cfg,
+        run_id="run-404",
+        profile={
+            "agent_id": "agent-x",
+            "display_name": "X",
+            "sender_address": "1 Market St",
+        },
+        program=program,
+        provider_used="gmail",
+        draft=tampered_draft,
+        sendable=[{"email": "alice@example.com", "display_name": "Alice"}],
+        approval=approval,
+    )
+    assert send_result["status"] == "validation_failed"
+    assert send_result["error_code"] == "tracked_link_missing"
+    assert send_result["sent_count"] == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `affiliates/seren/scripts/validators.py` with `validate_tracked_link` — asserts the bootstrapped `partner_link_url` substring is present in the merged outbound body.
- Wires it into `send.merge_and_send` as a post-merge gate: on mismatch, the entire batch fails closed with `status=validation_failed`, `error_code=tracked_link_missing`, `sent_count=0`.
- Documents the new rule in `affiliates/seren/SKILL.md` under Compliance and Safety Rules.
- 3 critical tests only (validator accept, validator reject, end-to-end fail-closed when a tampered draft drops the link).

Defense-in-depth: a hallucinated URL or stripped `{partner_link}` placeholder would otherwise reach a recipient undetected. This is the safety net #404 asked for.

Closes #404

## Test plan
- [x] `pytest affiliates/seren/tests/test_smoke.py -v` — 30 passed (27 existing + 3 new)
- [x] Existing send-path tests (`test_drafts_pitch_and_blocks_send_until_approved`, `test_hard_bounce_inserts_unsubscribe_row`) still pass — validator is transparent when the template is correct.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
