### PR TITLE
test: unstick two pre-existing test failures on main (#407)

### DIFF
--- a/polymarket/maker-rebate-bot/scripts/agent.py
+++ b/polymarket/maker-rebate-bot/scripts/agent.py
@@ -9,6 +9,14 @@ import math
 import os
 import sys
 import time
+
+# --- Force unbuffered stdout so piped/background output is visible immediately ---
+if not sys.stdout.isatty():
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+# --- End unbuffered stdout fix ---
+
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone

--- a/tests/test_market_selection_gates.py
+++ b/tests/test_market_selection_gates.py
@@ -107,11 +107,11 @@ def test_min_volume_filter_exists() -> None:
     assert "min_volume" in source, "agent.py missing min_volume config"
 
 
-def test_min_volume_default_is_1000() -> None:
+def test_min_volume_default_is_5000() -> None:
     source = _read(BOT_AGENT)
     match = re.search(r"['\"]min_volume['\"],\s*([\d.]+)", source)
     assert match, "Cannot find min_volume default in agent.py"
-    assert float(match.group(1)) == 1000.0
+    assert float(match.group(1)) == 5000.0
 
 
 def test_min_volume_in_config_example() -> None:


### PR DESCRIPTION
## Summary
- `tests/test_market_selection_gates.py::test_min_volume_default_is_1000` → renamed to `_is_5000` with the assertion updated to `5000.0`. PR #295 raised the `min_volume` floor from `$1,000` → `$5,000` in both `polymarket/bot/scripts/agent.py` and `config.example.json` — the test was never updated alongside it.
- `polymarket/maker-rebate-bot/scripts/agent.py` now includes the canonical unbuffered-stdout block (`PYTHONUNBUFFERED` + `sys.stdout.reconfigure(line_buffering=True)`) that `tests/test_unbuffered_output.py` enforces across every trading agent.

No behavior change for traders or ops — this just lands the two drift fixes so `main` has a green suite again.

Closes #407

## Test plan
- [x] `pytest tests/test_market_selection_gates.py tests/test_unbuffered_output.py -v` — 31 passed (was 2 failing before this PR)
- [x] Full suite: `pytest tests/ -q` — 381 passed
- [x] `py_compile polymarket/maker-rebate-bot/scripts/agent.py` clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
