### PR TITLE
fix(docs): retarget archived seren-desktop-issues repo to seren-desktop

### DIFF
--- a/coinbase/grid-trader/README.md
+++ b/coinbase/grid-trader/README.md
@@ -200,7 +200,7 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 
 ## Known Limitations
 
-- **No live ticker**: The `coinbase-trading` publisher does not yet expose `GET /products/{id}/ticker`. The bot uses the midpoint of `price_range` as the reference price. Request the endpoint be added via [serenorg/seren-desktop-issues](https://github.com/serenorg/seren-desktop-issues).
+- **No live ticker**: The `coinbase-trading` publisher does not yet expose `GET /products/{id}/ticker`. The bot uses the midpoint of `price_range` as the reference price. Request the endpoint be added via [serenorg/seren-desktop](https://github.com/serenorg/seren-desktop/issues).
 - **No cancel-all endpoint**: The publisher exposes `DELETE /orders/{order_id}` only. `stop` loops through active orders to cancel each individually.
 - **No order history API**: Fill detection is done by comparing `active_orders` in memory against live `GET /orders`. A restart clears in-memory state; re-running `start` re-places the full grid.
 
@@ -220,5 +220,5 @@ SerenDB persistence is best-effort; if unavailable, trading continues with local
 
 ## Support
 
-- Issues: [serenorg/seren-desktop-issues](https://github.com/serenorg/seren-desktop-issues)
+- Issues: [serenorg/seren-desktop](https://github.com/serenorg/seren-desktop/issues)
 - Docs: [docs.serendb.com](https://docs.serendb.com)

--- a/kraken/grid-trader/README.md
+++ b/kraken/grid-trader/README.md
@@ -312,7 +312,7 @@ tail -f logs/errors.jsonl
 
 - Seren Docs: https://docs.serendb.com
 - Kraken API: https://docs.kraken.com/api
-- Issues: https://github.com/serenorg/seren-desktop-issues
+- Issues: https://github.com/serenorg/seren-desktop/issues
 
 ## License
 

--- a/seren/job-seeker/README.md
+++ b/seren/job-seeker/README.md
@@ -178,7 +178,7 @@ Download your LinkedIn data export first (see Quick Start step 3).
 ## Support
 
 - Seren Docs: https://docs.serendb.com
-- Issues: https://github.com/serenorg/seren-desktop-issues
+- Issues: https://github.com/serenorg/seren-desktop/issues
 
 ## License
 

--- a/tests/test_no_archived_desktop_issues_repo.py
+++ b/tests/test_no_archived_desktop_issues_repo.py
@@ -1,0 +1,32 @@
+"""No skill doc may reference the archived serenorg/seren-desktop-issues repo.
+
+Fixes #370: the archived repo is read-only, so agents reading a skill doc
+that advertises it as the issue tracker will fail to file bugs there. The
+correct target is serenorg/seren-desktop/issues.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ARCHIVED = "seren-desktop-issues"
+
+# rerere cache mirrors past merge conflicts verbatim; it's git metadata,
+# not a source file, so skip it.
+SKIP_PREFIXES = (".git/",)
+
+
+def test_no_skill_doc_references_archived_desktop_issues_repo() -> None:
+    offenders: list[str] = []
+    for path in REPO_ROOT.rglob("*.md"):
+        rel = str(path.relative_to(REPO_ROOT))
+        if any(rel.startswith(p) for p in SKIP_PREFIXES):
+            continue
+        if ARCHIVED in path.read_text(encoding="utf-8", errors="ignore"):
+            offenders.append(rel)
+    assert not offenders, (
+        f"{len(offenders)} docs still reference the archived "
+        f"serenorg/{ARCHIVED} repo:\n"
+        + "\n".join(f"  - {p}" for p in sorted(offenders))
+    )


### PR DESCRIPTION
## Summary

- Retargets 4 references from archived `serenorg/seren-desktop-issues` to `serenorg/seren-desktop/issues` across:
  - `kraken/grid-trader/README.md`
  - `coinbase/grid-trader/README.md` (2 refs)
  - `seren/job-seeker/README.md`
- Adds `tests/test_no_archived_desktop_issues_repo.py` as a permanent guardrail.

Closes #370.

## Test plan

- [x] `pytest tests/test_no_archived_desktop_issues_repo.py` — 1 passed
- [x] Final grep for `seren-desktop-issues` returns only `.git/rr-cache/` hits (merge metadata, not source)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
