### PR TITLE
fix(skill-creator): require display-name in frontmatter authoring guidance

### DIFF
--- a/seren/skill-creator/SKILL.md
+++ b/seren/skill-creator/SKILL.md
@@ -30,7 +30,7 @@ Core spec rules:
 
 - `SKILL.md` must include YAML frontmatter
 - required top-level fields: `name`, `description`
-- optional top-level fields: `license`, `compatibility`, `metadata`, `allowed-tools`
+- optional top-level fields (per the spec): `license`, `compatibility`, `metadata`, `allowed-tools`, `display-name`
 - `name` must:
   - be 1-64 chars
   - use lowercase letters, digits, and hyphens only
@@ -39,13 +39,16 @@ Core spec rules:
   - exactly match the parent directory name
 - if `metadata` is used, it must be a map of string keys to string values
 
+Note: `display-name` is spec-optional but **required in this repo** (see Seren Repo Conventions below).
+
 ## Seren Repo Conventions
 
 On top of the spec, this repo uses the following conventions:
 
-- frontmatter uses only `name` and `description` (everything else is derived)
+- frontmatter must include `name`, `display-name`, and `description`
+- `display-name` is **required** for publication — the R2 catalog indexer (`scripts/build-index.mjs`) and SerenDesktop both read this field to humanize the catalog entry. Without it, the UI falls back to the raw directory slug (see #373, seren-desktop#1469)
+- `display-name` convention: double-quoted, Title Case, include the org prefix (for example `"Apollo API"`, `"SerenDB"`, `"Attio CRM"`)
 - optional spec fields (`license`, `compatibility`, `allowed-tools`, `metadata`) are available when appropriate
-- use the first `# H1` in the body as the display name
 - keep runtime files in `scripts/`
 - keep `requirements.txt` / `package.json`, `config.example.json`, and `.env.example` at the skill root
 - keep local `config.json` untracked
@@ -76,6 +79,7 @@ Use this baseline template:
 ```yaml
 ---
 name: skill-name
+display-name: "Org Skill Name"
 description: Clear statement of what the skill does and when to use it
 # license: Apache-2.0
 # compatibility: "Requires git and jq"
@@ -86,6 +90,7 @@ description: Clear statement of what the skill does and when to use it
 Validation requirements:
 
 - `name` equals directory name exactly
+- `display-name` is present, double-quoted, and Title Case with org prefix
 - `description` is concrete and trigger-oriented
 - optional fields (if present) follow spec constraints
 - keep frontmatter fields minimal and relevant
@@ -111,6 +116,7 @@ Checklist:
 
 - frontmatter present and valid
 - `name` matches directory
+- `display-name` present (required for R2 catalog + SerenDesktop rendering; see `tests/test_skill_display_names.py`)
 - commands in docs point to real files
 - runtime files (if any) live under `scripts/`
 - no secrets committed
@@ -120,6 +126,7 @@ Checklist:
 ```markdown
 ---
 name: api-tester
+display-name: "Seren API Tester"
 description: Test REST endpoints and validate response contracts.
 ---
 

--- a/tests/test_skill_creator_requires_display_name.py
+++ b/tests/test_skill_creator_requires_display_name.py
@@ -1,0 +1,45 @@
+"""skill-creator must tell authors to set display-name in frontmatter.
+
+Fixes #412: skill-creator SKILL.md used to instruct authors to use only
+`name` + `description` and to derive the display name from the first H1.
+Every skill scaffolded from that guidance shipped without
+`display-name`, so the R2 catalog indexer fell back to raw slugs
+(root cause of #373's recurrence).
+
+This guardrail asserts the skill-creator authoring guidance actively
+prescribes `display-name` — in the conventions prose, the baseline
+template, the validation checklist, and the example skeleton.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_CREATOR = (
+    Path(__file__).resolve().parent.parent
+    / "seren"
+    / "skill-creator"
+    / "SKILL.md"
+)
+
+
+def test_skill_creator_requires_display_name_in_frontmatter() -> None:
+    body = SKILL_CREATOR.read_text(encoding="utf-8")
+    assert body.count("display-name") >= 4, (
+        "seren/skill-creator/SKILL.md should mention `display-name` in "
+        "(1) the conventions prose, (2) the baseline frontmatter template, "
+        "(3) the validation checklist, and (4) the example skeleton. "
+        f"Found {body.count('display-name')} mentions."
+    )
+    # The old guidance explicitly said to skip display-name; make sure that
+    # sentence is gone so authors don't follow it.
+    forbidden = "frontmatter uses only `name` and `description`"
+    assert forbidden not in body, (
+        f"skill-creator still contains the obsolete guidance: {forbidden!r}"
+    )
+    # The "use H1 as display name" line is also wrong — catalog reads frontmatter.
+    h1_phrase = "use the first `# H1` in the body as the display name"
+    assert h1_phrase not in body, (
+        f"skill-creator still tells authors to derive display name from H1: "
+        f"{h1_phrase!r}"
+    )


### PR DESCRIPTION
## Summary

Addresses the root cause of #373 recurring: `seren/skill-creator/SKILL.md` used to prescribe `name` + `description` only and to derive the display name from the first `# H1`. The R2 catalog indexer and SerenDesktop both read `frontmatter.display-name` — so every new skill scaffolded from the old guidance shipped without it.

- Conventions, spec rules, baseline template, validation checklist, and example skeleton all now require `display-name`.
- New guardrail: `tests/test_skill_creator_requires_display_name.py` fails if the doc regresses.

Closes #412.

## Test plan

- [x] `pytest tests/test_skill_creator_requires_display_name.py` — 1 passed
- [x] `pytest tests/test_skill_display_names.py` — still 1 passed (79 skills scanned, gdex/trading still exempted per #408)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
