### PR TITLE
fix(affiliates): emit affiliates-ui.serendb.com on unsubscribe URLs (#415)

### DIFF
--- a/affiliates/seren/SKILL.md
+++ b/affiliates/seren/SKILL.md
@@ -118,8 +118,8 @@ Schema in `serendb_schema.sql`. Tables:
 
 ## Unsubscribe Handling (Phase 1 vs Phase 2)
 
-- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://affiliates.serendb.com/unsubscribe/{agent_id}/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)` and `agent_id` identifies the affiliate account. The route does **not** exist on `seren-affiliates-website` yet. Until it ships, the operator handles unsubscribes manually via `command: block` with `block_email=<recipient>`.
-- **Phase 2.** Once `seren-affiliates-website` adds `GET /unsubscribe/[agent_id]/[token]` and `GET /public/unsubscribes?agent_id=...&since=...`, the skill's `sync` step calls the public read API, joins returned tokens against the local `distributions` table to resolve `token → email`, and upserts into `unsubscribes` with `source=link_click`. `seren-affiliates` (the backend) is intentionally **not** involved — it stores no recipient PII by design.
+- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://affiliates-ui.serendb.com/unsubscribe/{agent_id}/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)` and `agent_id` identifies the affiliate account. The route is live on `seren-affiliates-website` — recipients get a one-click opt-out confirmation page. Operators can also record manual opt-outs via `command: block` with `block_email=<recipient>` when they learn about them out-of-band. (Note: `affiliates.serendb.com` is the Rust API surface and does **not** host this route; emitting there would 404.)
+- **Phase 2.** The skill's `sync` step calls the public read API at `https://affiliates-ui.serendb.com/public/unsubscribes?agent_id=...&since=...`, joins returned tokens against the local `distributions` table to resolve `token → email`, and upserts into `unsubscribes` with `source=link_click`. `seren-affiliates` (the backend) is intentionally **not** involved — it stores no recipient PII by design.
 
 ## Status and Stats
 

--- a/affiliates/seren/references/provider-mappings.md
+++ b/affiliates/seren/references/provider-mappings.md
@@ -46,4 +46,4 @@ Not a Seren publisher. Plain HTTPS from the skill.
 | emit_unsubscribe_link | (client-side URL only) | /unsubscribe/{agent_id}/{token} | Embedded in every outbound body_template as `{unsubscribe_link}` |
 | sync_remote_unsubscribes | GET | /public/unsubscribes?agent_id=...&since=... | Phase 2 dependency (serenorg/seren-affiliates-website#36); returns paginated tokens the skill joins against local `distributions` to resolve token → email |
 
-Base URL: `https://affiliates.serendb.com` (configured at `config.unsubscribe.endpoint_base` and `config.unsubscribe.sync_api_base`). No recipient PII is ever sent to this host — only HMAC tokens and `agent_id`. `seren-affiliates` (the backend) is intentionally not involved.
+Base URL: `https://affiliates-ui.serendb.com` (configured at `config.unsubscribe.endpoint_base` and `config.unsubscribe.sync_api_base`). No recipient PII is ever sent to this host — only HMAC tokens and `agent_id`. `seren-affiliates` (the backend) is intentionally not involved; `affiliates.serendb.com` is the Rust API surface and does not host the unsubscribe routes.

--- a/affiliates/seren/scripts/common.py
+++ b/affiliates/seren/scripts/common.py
@@ -36,8 +36,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "daily_cap_max": 25,
     },
     "unsubscribe": {
-        "endpoint_base": "https://affiliates.serendb.com/unsubscribe",
-        "sync_api_base": "https://affiliates.serendb.com/public/unsubscribes",
+        "endpoint_base": "https://affiliates-ui.serendb.com/unsubscribe",
+        "sync_api_base": "https://affiliates-ui.serendb.com/public/unsubscribes",
         "phase1_operator_blocklist_only": True,
     },
     "inputs": {

--- a/affiliates/seren/tests/test_smoke.py
+++ b/affiliates/seren/tests/test_smoke.py
@@ -26,6 +26,7 @@ from common import (  # noqa: E402
     is_valid_email,
     parse_pasted_contacts,
     require_approve_draft_json_pairing,
+    unsubscribe_link,
 )
 from draft import await_approval, draft_pitch  # noqa: E402
 from ingest import enforce_daily_cap, filter_eligible, ingest_contacts, resolve_provider  # noqa: E402
@@ -349,6 +350,20 @@ def test_block_command_creates_operator_unsubscribe() -> None:
     result = block_email(cfg)
     assert result["status"] == "ok"
     assert result["unsubscribe"]["source"] == "operator_manual"
+
+
+def test_unsubscribe_link_targets_affiliates_ui_host() -> None:
+    """Issue #415: emit affiliates-ui.serendb.com (Next.js) not
+    affiliates.serendb.com (Rust API, which 404s on /unsubscribe/*)."""
+    link = unsubscribe_link(
+        config=deepcopy(DEFAULT_CONFIG),
+        email="alice@example.com",
+        program_slug="sample-saas-alpha",
+        run_id="run-1",
+        agent_id="agent-demo-0001",
+    )
+    assert link.startswith("https://affiliates-ui.serendb.com/unsubscribe/"), link
+    assert "//affiliates.serendb.com/" not in link, link
 
 
 # --- Issue #404: tracked_link validator (defense-in-depth) ---


### PR DESCRIPTION
## Summary
- `affiliates/seren/scripts/common.py`: switch `endpoint_base` and `sync_api_base` from `affiliates.serendb.com` to `affiliates-ui.serendb.com`. The Rust API at `affiliates.serendb.com` has no unsubscribe routes; the Next.js routes are live on `affiliates-ui.serendb.com`.
- `affiliates/seren/SKILL.md`: flip Phase 1/Phase 2 language — unsubscribe is now live, not "not yet shipped".
- `affiliates/seren/references/provider-mappings.md`: update base URL with a note about why `affiliates.serendb.com` is not the right host.
- One critical regression test `test_unsubscribe_link_targets_affiliates_ui_host` that locks the hostname.

Closes #415

## Test plan
- [x] `pytest affiliates/seren/tests/test_smoke.py -v` — 31 passed (30 existing + 1 new lock test)
- [x] `curl -o /dev/null -s -w "%{http_code}" https://affiliates-ui.serendb.com/unsubscribe/agent-demo-0001/deadbeef` → 400 (route exists, correct rejection). The pre-fix URL on `affiliates.serendb.com` returned 404.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
