### PR TITLE
fix(seren-bucks): remove SerenDB company attribution from affiliate sign-off (#417)

### DIFF
--- a/affiliates/seren-bucks/references/email-templates.md
+++ b/affiliates/seren-bucks/references/email-templates.md
@@ -63,7 +63,6 @@ that's the one you send to friends.
 
 Cheers,
 {{sender_full_name}}
-SerenDB
 ```
 
 ## What the draft MUST NOT say

--- a/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
+++ b/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
@@ -61,3 +61,22 @@ def test_default_tracked_link_uses_serendb_domain() -> None:
         assert link.startswith("https://serendb.com"), (
             f"default tracked_link must use serendb.com, got: {link}"
         )
+
+
+def test_signoff_does_not_attribute_sender_to_serendb() -> None:
+    """#417: the sender is an affiliate, not a SerenDB employee.
+    The sign-off must never carry a company attribution line."""
+    import re
+
+    body = EMAIL_TEMPLATE.read_text(encoding="utf-8")
+    signoff = re.search(
+        r"Cheers,\s*\n\s*\{\{sender_full_name\}\}\s*\n(.*?)```",
+        body,
+        re.DOTALL,
+    )
+    assert signoff, "cannot locate sign-off block in template"
+    after_name = signoff.group(1).strip()
+    assert after_name == "", (
+        f"sign-off has extra content after sender_full_name: {after_name!r}. "
+        "Affiliates must sign as themselves, not as SerenDB."
+    )


### PR DESCRIPTION
## Summary
- Removes the `SerenDB` organization line from the outreach template sign-off in `affiliates/seren-bucks/references/email-templates.md`. The sender is an affiliate, not a SerenDB employee.
- Adds one regression test `test_signoff_does_not_attribute_sender_to_serendb` that locks the sign-off to sender name only.

Closes #417

## Test plan
- [x] `pytest affiliates/seren-bucks/tests/test_commission_copy_guardrails.py -v` — 4 passed (3 existing + 1 new)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com