### PR TITLE
fix(affiliates): remove stale Phase 1/Phase 2 language — unsubscribe is shipped (#419)

### DIFF
--- a/affiliates/seren/.env.example
+++ b/affiliates/seren/.env.example
@@ -4,12 +4,9 @@
 # microsoft-outlook, and seren-models publishers).
 SEREN_API_KEY=
 
-# Optional — HMAC key for the Phase 2 unsubscribe link tokens. Must match the
+# Optional — HMAC key for unsubscribe link tokens. Must match the
 # REFERRAL_TOKEN_SECRET configured on seren-affiliates-website so its
 # /unsubscribe/[agent_id]/[token] route can verify tokens minted by the skill.
-# Leave unset until that route ships (tracked in
-# serenorg/seren-affiliates-website#36). In Phase 1 the link is a documented
-# placeholder; the operator handles opt-outs via `command: block`.
 REFERRAL_TOKEN_SECRET=
 
 # Optional — overrides the Seren Desktop-injected API_KEY path.

--- a/affiliates/seren/README.md
+++ b/affiliates/seren/README.md
@@ -57,10 +57,9 @@ tests/
   fixtures/                      Happy-path, failure, dry-run-guard, policy-violation fixtures
 ```
 
-## Rollout phases
+## Unsubscribe
 
-- **Phase 1 (shipped).** Operator-managed blocklist only. Unsubscribe link in the footer is a documented placeholder; operator removes recipients manually via `command: block`.
-- **Phase 2.** Requires a new public `GET /unsubscribe/[agent_id]/[token]` route and `GET /public/unsubscribes?agent_id=...&since=...` read API on `seren-affiliates-website` — tracked in serenorg/seren-affiliates-website#36. Once that ships, `sync` mirrors remote opt-outs into the local `unsubscribes` table by joining returned tokens against local `distributions` to resolve `token → email`. `seren-affiliates` (the backend) is intentionally **not** involved and stores no recipient PII.
+One-click unsubscribe is live. Every outbound email links to `https://affiliates-ui.serendb.com/unsubscribe/{agent_id}/{token}` (hosted on `seren-affiliates-website`). The `sync` command calls the public read API to pull new opt-outs into the local `unsubscribes` table. Operators can also manually block addresses via `command: block`.
 
 ## Regenerating from the spec
 

--- a/affiliates/seren/SKILL.md
+++ b/affiliates/seren/SKILL.md
@@ -24,7 +24,7 @@ Skill instructions are preloaded in context when this skill is active. Do not pe
 - Per-program dedupe is DB-level: a (program_slug, contact_email) pair is sent at most once, ever.
 - Global unsubscribe list: one opt-out blocks all future sends across every program.
 - Mandatory send footer: sender identity, physical address, and unsubscribe link.
-- **Phase 1 operator-managed blocklist only.** The public `/unsubscribe/{agent_id}/{token}` route on `seren-affiliates-website` does not exist yet; click-to-unsubscribe flips on in Phase 2 when that ships. `seren-affiliates` itself stores no recipient PII and needs no changes.
+- **One-click unsubscribe is live.** Every outbound email includes a footer link to `https://affiliates-ui.serendb.com/unsubscribe/{agent_id}/{token}`. Recipients click once to opt out. Operators can also manually block addresses via `command: block`.
 
 ## Bootstrap Order (Mandatory)
 
@@ -116,10 +116,13 @@ Schema in `serendb_schema.sql`. Tables:
 - `provider=gmail` or `provider=outlook` → explicit choice; fail closed if that one is not authorized.
 - Both publishers are authorized at the Seren platform level, not inside this skill. If neither is authorized, the skill instructs the operator to authorize one via the Seren platform.
 
-## Unsubscribe Handling (Phase 1 vs Phase 2)
+## Unsubscribe Handling
 
-- **Phase 1 (today).** The drafted footer contains a `{unsubscribe_link}` that points at `https://affiliates-ui.serendb.com/unsubscribe/{agent_id}/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)` and `agent_id` identifies the affiliate account. The route is live on `seren-affiliates-website` — recipients get a one-click opt-out confirmation page. Operators can also record manual opt-outs via `command: block` with `block_email=<recipient>` when they learn about them out-of-band. (Note: `affiliates.serendb.com` is the Rust API surface and does **not** host this route; emitting there would 404.)
-- **Phase 2.** The skill's `sync` step calls the public read API at `https://affiliates-ui.serendb.com/public/unsubscribes?agent_id=...&since=...`, joins returned tokens against the local `distributions` table to resolve `token → email`, and upserts into `unsubscribes` with `source=link_click`. `seren-affiliates` (the backend) is intentionally **not** involved — it stores no recipient PII by design.
+Every outbound email contains a footer link: `https://affiliates-ui.serendb.com/unsubscribe/{agent_id}/{token}`, where `token` is an HMAC of `(email, program_slug, run_id)` and `agent_id` identifies the affiliate account.
+
+- **Recipient one-click opt-out.** Clicking the link renders a confirmation page on `seren-affiliates-website` and records the opt-out in Cloudflare KV, scoped to the affiliate's `agent_id`. No recipient PII leaves the skill — only the opaque HMAC token.
+- **Operator manual block.** `command: block` with `block_email=<recipient>` inserts directly into the local `unsubscribes` table (`source=operator_manual`).
+- **Sync.** The `sync` command calls `https://affiliates-ui.serendb.com/public/unsubscribes?agent_id=...&since=...`, joins returned tokens against the local `distributions` table to resolve `token → email`, and upserts into `unsubscribes` with `source=link_click`. `seren-affiliates` (the backend) is not involved — it stores no recipient PII by design.
 
 ## Status and Stats
 

--- a/affiliates/seren/references/provider-mappings.md
+++ b/affiliates/seren/references/provider-mappings.md
@@ -37,13 +37,13 @@ Operations: `upsert` and `get` only. Database `seren_affiliate`.
 
 Single call at `draft_pitch`. Prompt reference: `references/prompts/draft_pitch.md`. Output is validated for the five required placeholder tokens before persistence.
 
-## website — seren-affiliates-website (Phase 2)
+## website — seren-affiliates-website
 
 Not a Seren publisher. Plain HTTPS from the skill.
 
 | Step | Method | Path | Notes |
 |------|--------|------|-------|
 | emit_unsubscribe_link | (client-side URL only) | /unsubscribe/{agent_id}/{token} | Embedded in every outbound body_template as `{unsubscribe_link}` |
-| sync_remote_unsubscribes | GET | /public/unsubscribes?agent_id=...&since=... | Phase 2 dependency (serenorg/seren-affiliates-website#36); returns paginated tokens the skill joins against local `distributions` to resolve token → email |
+| sync_remote_unsubscribes | GET | /public/unsubscribes?agent_id=...&since=... | Returns paginated tokens the skill joins against local `distributions` to resolve token → email |
 
 Base URL: `https://affiliates-ui.serendb.com` (configured at `config.unsubscribe.endpoint_base` and `config.unsubscribe.sync_api_base`). No recipient PII is ever sent to this host — only HMAC tokens and `agent_id`. `seren-affiliates` (the backend) is intentionally not involved; `affiliates.serendb.com` is the Rust API surface and does not host the unsubscribe routes.

--- a/affiliates/seren/scripts/block.py
+++ b/affiliates/seren/scripts/block.py
@@ -24,5 +24,5 @@ def block_email(config: dict) -> dict:
             "unsubscribed_at": utc_now(),
             "source": "operator_manual",
         },
-        "phase": "phase1_operator_blocklist_only",
+        "phase": "operator_manual",
     }

--- a/affiliates/seren/scripts/common.py
+++ b/affiliates/seren/scripts/common.py
@@ -38,7 +38,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "unsubscribe": {
         "endpoint_base": "https://affiliates-ui.serendb.com/unsubscribe",
         "sync_api_base": "https://affiliates-ui.serendb.com/public/unsubscribes",
-        "phase1_operator_blocklist_only": True,
+        "unsubscribe_live": True,
     },
     "inputs": {
         "command": "run",

--- a/affiliates/seren/scripts/status.py
+++ b/affiliates/seren/scripts/status.py
@@ -72,9 +72,7 @@ def render_report(
             "new_unsubscribes": len(send_result["new_unsubscribes"]) if send_result else 0,
         },
         "live": live,
-        "phase1_operator_blocklist_only": bool(
-            config["unsubscribe"]["phase1_operator_blocklist_only"]
-        ),
+        "unsubscribe_live": True,
     }
     if json_output:
         return local


### PR DESCRIPTION
## Summary
- Both unsubscribe routes are live and deployed on seren-affiliates-website (confirmed: /unsubscribe returns 400 for invalid HMAC, /public/unsubscribes returns 200 with paginated JSON). Feature issue seren-affiliates-website#36 is closed.
- Removed all Phase 1/Phase 2 references from SKILL.md, README.md, .env.example, references/provider-mappings.md, and the Python config/status/block modules.
- Replaced the stale config key phase1_operator_blocklist_only with unsubscribe_live.

Closes #419

## Test plan
- [x] affiliates/seren/tests/test_smoke.py — 31 passed
- [x] affiliates/seren-bucks/tests/ — 8 passed

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com