### PR TITLE
fix(affiliates): send identifying User-Agent on sync_remote_unsubscribes

### DIFF
--- a/affiliates/seren/scripts/sync.py
+++ b/affiliates/seren/scripts/sync.py
@@ -11,6 +11,11 @@ from common import utc_now
 EPOCH_WATERMARK = "1970-01-01T00:00:00Z"
 DEFAULT_HTTP_TIMEOUT_SECONDS = 10
 MAX_PAGES_PER_RUN = 50  # 50 * 500 = 25k opt-outs per run, plenty per affiliate
+# Cloudflare's WAF on affiliates-ui.serendb.com 403s the default urllib
+# User-Agent. Send a proper identifying UA so the public read API is reachable.
+DEFAULT_USER_AGENT = (
+    "seren-affiliate-skill/1 (+https://github.com/serenorg/seren-skills)"
+)
 
 SAMPLE_PROGRAMS = [
     {
@@ -64,7 +69,13 @@ def sync_joined_programs(config: dict) -> dict:
 
 
 def _default_http_get(url: str, *, timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS) -> dict:
-    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        },
+    )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 

--- a/affiliates/seren/tests/test_smoke.py
+++ b/affiliates/seren/tests/test_smoke.py
@@ -478,6 +478,35 @@ def test_sync_remote_unsubscribes_paginates_resolves_and_skips_unknown() -> None
     assert result["next_watermark"] == "2026-04-12T00:00:00Z"
 
 
+def test_default_http_get_sends_identifying_user_agent() -> None:
+    """Cloudflare WAF on affiliates-ui.serendb.com 403s the default urllib
+    User-Agent. Production e2e caught this. Lock the UA so it can't regress."""
+    import sync as sync_mod
+
+    captured: dict = {}
+
+    class FakeResp:
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def read(self): return b'{"unsubscribes":[],"next_cursor":null}'
+
+    def fake_urlopen(req, *, timeout):
+        captured["headers"] = dict(req.header_items())
+        return FakeResp()
+
+    real_urlopen = sync_mod.urllib.request.urlopen
+    sync_mod.urllib.request.urlopen = fake_urlopen
+    try:
+        sync_mod._default_http_get("https://example.invalid/x")
+    finally:
+        sync_mod.urllib.request.urlopen = real_urlopen
+
+    ua = captured["headers"].get("User-agent") or captured["headers"].get("User-Agent")
+    assert ua and "seren-affiliate-skill" in ua, (
+        f"default http_get must send an identifying User-Agent, got: {ua!r}"
+    )
+
+
 def test_sync_remote_unsubscribes_stale_on_api_down_does_not_raise() -> None:
     """Explicit design choice from #421: website outage must not block sends.
     stale=True, watermark unchanged, pipeline continues with persisted blocklist."""


### PR DESCRIPTION
## Summary
Caught during the live production e2e for #421 — Cloudflare's WAF on `affiliates-ui.serendb.com` 403s the default Python `urllib` User-Agent (`Python-urllib/3.14`), which meant the shipped `sync_remote_unsubscribes` would trip the stale-blocklist fallback on every real run. Unit tests passed because they used a fake `http_get`.

Sets a proper identifying UA in `_default_http_get` and locks it with a critical test.

Follows on from #421 / #422.

## Test plan
- [x] `pytest affiliates/seren/tests/test_smoke.py` — 36 passed (35 existing + 1 new UA lock test)
- [x] Live: same URL that previously returned 403 now returns 200 JSON with the UA set.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
