### PR TITLE
feat(family-office): catalog rebuild — 55 leaves + 4 routers as proper 3-segment indexed skills

### DIFF
--- a/.github/workflows/family-office-rebuild.yml
+++ b/.github/workflows/family-office-rebuild.yml
@@ -1,0 +1,97 @@
+name: Enforce family-office catalog (rebuild)
+
+on:
+  pull_request:
+    paths:
+      - "family-office/**"
+      - "!family-office/knowledge/**"
+      - ".github/workflows/family-office-rebuild.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "family-office/**"
+      - "!family-office/knowledge/**"
+      - ".github/workflows/family-office-rebuild.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run critical smoke tests across all family-office leaves + routers
+        # --import-mode=importlib is required because every leaf has a
+        # scripts/agent.py and a tests/test_smoke.py; the default prepend
+        # mode would collide.
+        run: |
+          pytest family-office \
+            --ignore=family-office/knowledge \
+            --import-mode=importlib \
+            -q
+
+  forbid-publisher-root-skill-md:
+    # Regression guard against shipping a SKILL.md at the publisher root.
+    # The skill indexer at scripts/build-index.mjs requires 3-segment
+    # paths — a publisher-root SKILL.md is silently dropped and therefore
+    # pure repo pollution.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if family-office/SKILL.md exists
+        run: |
+          if [ -f "family-office/SKILL.md" ]; then
+            echo "::error::family-office/SKILL.md is a publisher-root file; indexer drops it. Move to family-office/<skill>/SKILL.md."
+            exit 1
+          fi
+
+  forbid-non-skill-folders:
+    # Every directory under family-office/ must contain a SKILL.md
+    # (making it an indexed skill) OR be the repo-level .pytest_cache.
+    # No _base/, no scripts/, no docs/ at the publisher level.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if any non-skill folder exists under family-office/
+        run: |
+          bad=$(find family-office -maxdepth 1 -mindepth 1 -type d \
+            -not -name knowledge \
+            -not -name '.*' \
+            | while read -r d; do
+                if [ ! -f "$d/SKILL.md" ]; then echo "$d"; fi
+              done)
+          if [ -n "$bad" ]; then
+            echo "::error::folders under family-office/ without SKILL.md (not indexed, not skills):"
+            echo "$bad"
+            exit 1
+          fi
+
+  indexer-smoke:
+    # Sanity: the repo's skill indexer picks up every new leaf + router.
+    # If it doesn't, the skills are invisible to SerenDesktop.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Ensure the indexer sees 55 leaves + 4 routers + 1 knowledge
+        run: |
+          COUNT=$(node scripts/build-index.mjs \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{console.log(JSON.parse(d).skills.filter(s=>s.slug.startsWith('family-office')).length)})")
+          if [ "$COUNT" != "60" ]; then
+            echo "::error::expected 60 family-office skills indexed, got $COUNT"
+            exit 1
+          fi

--- a/family-office/annual-budget-workbook/.env.example
+++ b/family-office/annual-budget-workbook/.env.example
@@ -1,0 +1,9 @@
+# Annual Budget Workbook — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/annual-budget-workbook/SKILL.md
+++ b/family-office/annual-budget-workbook/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: annual-budget-workbook
+display-name: "Annual Budget Workbook"
+description: "Produce an annual budget workbook for the family. Captures income sources, fixed expenses, variable expenses, savings targets, and charitable giving."
+---
+
+# Annual Budget Workbook
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- annual budget
+- family budget
+- create budget
+- budget workbook
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Annual Budget Workbook`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/annual-budget-workbook/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `budget_year` — Budget year?
+- `expected_income` — Expected income (range)?
+- `fixed_expenses` — Major fixed expense categories and amounts?
+- `variable_expenses` — Major variable expense categories?
+- `savings_target` — Savings target?
+- `charitable_giving_target` — Charitable giving target?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"annual-budget-workbook"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/annual-budget-workbook/requirements.txt
+++ b/family-office/annual-budget-workbook/requirements.txt
@@ -1,0 +1,4 @@
+# Annual Budget Workbook
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/annual-budget-workbook/scripts/agent.py
+++ b/family-office/annual-budget-workbook/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Annual Budget Workbook skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Annual Budget Workbook as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "annual-budget-workbook"
+SKILL_DISPLAY = "Annual Budget Workbook"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Annual Budget Workbook"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("budget_year", "Budget year?"),
+    ("expected_income", "Expected income (range)?"),
+    ("fixed_expenses", "Major fixed expense categories and amounts?"),
+    ("variable_expenses", "Major variable expense categories?"),
+    ("savings_target", "Savings target?"),
+    ("charitable_giving_target", "Charitable giving target?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/annual-budget-workbook/tests/test_smoke.py
+++ b/family-office/annual-budget-workbook/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Annual Budget Workbook skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/art-acquisition-due-diligence/.env.example
+++ b/family-office/art-acquisition-due-diligence/.env.example
@@ -1,0 +1,9 @@
+# Art Acquisition Due-Diligence Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/art-acquisition-due-diligence/SKILL.md
+++ b/family-office/art-acquisition-due-diligence/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: art-acquisition-due-diligence
+display-name: "Art Acquisition Due-Diligence Memo"
+description: "Produce a due diligence memo for an art acquisition — provenance, authentication, condition, insurance, storage, sale consideration."
+---
+
+# Art Acquisition Due-Diligence Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- art acquisition
+- art due diligence
+- buy painting
+- Warhol purchase
+- art DD
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Art Acquisition Due-Diligence Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/art-acquisition-due-diligence/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `artwork` — Artwork (artist, title, year)?
+- `asking_price` — Asking price?
+- `seller` — Seller (dealer / auction / private)?
+- `provenance_status` — Provenance status?
+- `authentication_source` — Authentication source (catalog raisonné / foundation)?
+- `condition_report` — Condition report summary?
+- `intended_location` — Intended display / storage location?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"art-acquisition-due-diligence"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/art-acquisition-due-diligence/requirements.txt
+++ b/family-office/art-acquisition-due-diligence/requirements.txt
@@ -1,0 +1,4 @@
+# Art Acquisition Due-Diligence Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/art-acquisition-due-diligence/scripts/agent.py
+++ b/family-office/art-acquisition-due-diligence/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Art Acquisition Due-Diligence Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Art Acquisition Due-Diligence Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "art-acquisition-due-diligence"
+SKILL_DISPLAY = "Art Acquisition Due-Diligence Memo"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Art Acquisition Due-Diligence Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("artwork", "Artwork (artist, title, year)?"),
+    ("asking_price", "Asking price?"),
+    ("seller", "Seller (dealer / auction / private)?"),
+    ("provenance_status", "Provenance status?"),
+    ("authentication_source", "Authentication source (catalog raisonné / foundation)?"),
+    ("condition_report", "Condition report summary?"),
+    ("intended_location", "Intended display / storage location?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/art-acquisition-due-diligence/tests/test_smoke.py
+++ b/family-office/art-acquisition-due-diligence/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Art Acquisition Due-Diligence Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/bookkeeping-bill-pay-setup-plan/.env.example
+++ b/family-office/bookkeeping-bill-pay-setup-plan/.env.example
@@ -1,0 +1,9 @@
+# Bookkeeping & Bill Pay Setup Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/bookkeeping-bill-pay-setup-plan/SKILL.md
+++ b/family-office/bookkeeping-bill-pay-setup-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: bookkeeping-bill-pay-setup-plan
+display-name: "Bookkeeping & Bill Pay Setup Plan"
+description: "Produce a setup plan for family-office bookkeeping and bill pay operations — software, approvers, reconciliation, internal controls."
+---
+
+# Bookkeeping & Bill Pay Setup Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- bookkeeping setup
+- bill pay plan
+- family office accounting
+- internal controls
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Bookkeeping & Bill Pay Setup Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/bookkeeping-bill-pay-setup-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `accounting_platform` — Accounting platform (Sage Intacct / QuickBooks / AtlasFive)?
+- `bill_pay_platform` — Bill pay platform?
+- `approval_thresholds` — Approval thresholds (principal / COO / staff)?
+- `reconciliation_cadence` — Reconciliation cadence?
+- `audit_trail_retention` — Audit trail retention period?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"bookkeeping-bill-pay-setup-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/bookkeeping-bill-pay-setup-plan/requirements.txt
+++ b/family-office/bookkeeping-bill-pay-setup-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Bookkeeping & Bill Pay Setup Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
+++ b/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Bookkeeping & Bill Pay Setup Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Bookkeeping & Bill Pay Setup Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "bookkeeping-bill-pay-setup-plan"
+SKILL_DISPLAY = "Bookkeeping & Bill Pay Setup Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Bookkeeping & Bill Pay Setup Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("accounting_platform", "Accounting platform (Sage Intacct / QuickBooks / AtlasFive)?"),
+    ("bill_pay_platform", "Bill pay platform?"),
+    ("approval_thresholds", "Approval thresholds (principal / COO / staff)?"),
+    ("reconciliation_cadence", "Reconciliation cadence?"),
+    ("audit_trail_retention", "Audit trail retention period?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/bookkeeping-bill-pay-setup-plan/tests/test_smoke.py
+++ b/family-office/bookkeeping-bill-pay-setup-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Bookkeeping & Bill Pay Setup Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/business-exit-strategy/.env.example
+++ b/family-office/business-exit-strategy/.env.example
@@ -1,0 +1,9 @@
+# Exit Tax Minimization Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/business-exit-strategy/SKILL.md
+++ b/family-office/business-exit-strategy/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: business-exit-strategy
+display-name: "Exit Tax Minimization Plan"
+description: "Produce an exit tax minimization plan for a principal selling an operating business. Captures business basis, expected proceeds, planning windows, and candidate structures (QSBS, charitable trusts, installment sales)."
+---
+
+# Exit Tax Minimization Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- business exit
+- sell business
+- minimize taxes before selling
+- exit planning
+- operating business sale
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Exit Tax Minimization Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/business-exit-strategy/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `business_name` — Business legal name?
+- `principal_basis` — Principal's basis in the business?
+- `expected_proceeds` — Expected sale proceeds?
+- `target_close_quarter` — Target close quarter (e.g. "2026-Q3")?
+- `state_of_residence` — Principal's state of residence?
+- `candidate_structures` — Candidate structures worth evaluating?
+- `cpa_firm` — CPA firm handling the return?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"business-exit-strategy"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/business-exit-strategy/requirements.txt
+++ b/family-office/business-exit-strategy/requirements.txt
@@ -1,0 +1,4 @@
+# Exit Tax Minimization Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/business-exit-strategy/scripts/agent.py
+++ b/family-office/business-exit-strategy/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Exit Tax Minimization Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Exit Tax Minimization Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "business-exit-strategy"
+SKILL_DISPLAY = "Exit Tax Minimization Plan"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Exit Tax Minimization Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("business_name", "Business legal name?"),
+    ("principal_basis", "Principal's basis in the business?"),
+    ("expected_proceeds", "Expected sale proceeds?"),
+    ("target_close_quarter", "Target close quarter (e.g. \"2026-Q3\")?"),
+    ("state_of_residence", "Principal's state of residence?"),
+    ("candidate_structures", "Candidate structures worth evaluating?"),
+    ("cpa_firm", "CPA firm handling the return?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/business-exit-strategy/tests/test_smoke.py
+++ b/family-office/business-exit-strategy/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Exit Tax Minimization Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/capital-allocation-router/DISPATCH.yml
+++ b/family-office/capital-allocation-router/DISPATCH.yml
@@ -1,0 +1,113 @@
+- skill: family-office-long-term-portfolio-strategy-plan
+  artifact: "Long-Term Portfolio Strategy Plan"
+  triggers:
+    - "long-term portfolio strategy"
+    - "investment policy statement"
+    - "portfolio plan"
+    - "long horizon allocation"
+- skill: family-office-target-asset-allocation-model
+  artifact: "Target Asset Allocation Model"
+  triggers:
+    - "asset allocation"
+    - "target allocation"
+    - "allocation model"
+    - "portfolio weights"
+- skill: family-office-portfolio-risk-register
+  artifact: "Portfolio Risk Register"
+  triggers:
+    - "portfolio risk"
+    - "risk register"
+    - "risk management memo"
+    - "portfolio risks"
+- skill: family-office-business-exit-strategy
+  artifact: "Exit Tax Minimization Plan"
+  triggers:
+    - "business exit"
+    - "sell business"
+    - "minimize taxes before selling"
+    - "exit planning"
+    - "operating business sale"
+- skill: family-office-new-business-diligence-memo
+  artifact: "New Business Diligence Memo"
+  triggers:
+    - "new business diligence"
+    - "acquire business"
+    - "evaluate new business"
+    - "business investment memo"
+- skill: family-office-investment-operations-review-checklist
+  artifact: "Investment Operations Review Checklist"
+  triggers:
+    - "investment operations review"
+    - "ops review"
+    - "custody check"
+    - "reconciliation review"
+- skill: family-office-client-sourced-deal-review-memo
+  artifact: "Client-Sourced Deal Review Memo"
+  triggers:
+    - "client sourced deal"
+    - "principal brought a deal"
+    - "friend referral investment"
+    - "review this deal"
+- skill: family-office-manager-dd-hedge-fund
+  artifact: "Hedge Fund Manager DD Memo"
+  triggers:
+    - "hedge fund manager DD"
+    - "hedge fund due diligence"
+    - "HF allocation memo"
+    - "evaluate hedge fund"
+- skill: family-office-manager-dd-private-equity
+  artifact: "Private Equity Manager DD Memo"
+  triggers:
+    - "private equity manager DD"
+    - "PE fund due diligence"
+    - "buyout fund memo"
+    - "PE allocation"
+- skill: family-office-manager-dd-private-debt
+  artifact: "Private Debt Manager DD Memo"
+  triggers:
+    - "private debt DD"
+    - "private credit manager"
+    - "direct lending fund"
+    - "private debt allocation"
+- skill: family-office-manager-dd-venture-capital
+  artifact: "Venture Capital Manager DD Memo"
+  triggers:
+    - "venture capital manager DD"
+    - "VC fund due diligence"
+    - "seed fund memo"
+    - "VC allocation"
+- skill: family-office-manager-dd-real-assets
+  artifact: "Real Assets Manager DD Memo"
+  triggers:
+    - "real assets manager DD"
+    - "infrastructure fund"
+    - "natural resources fund"
+    - "commodities allocation"
+- skill: family-office-manager-dd-real-estate
+  artifact: "Real Estate Manager DD Memo"
+  triggers:
+    - "real estate manager DD"
+    - "RE fund due diligence"
+    - "property fund memo"
+    - "real estate allocation"
+- skill: family-office-manager-dd-direct-co-investment
+  artifact: "Direct / Co-Investment DD Memo"
+  triggers:
+    - "direct investment DD"
+    - "co-investment memo"
+    - "SPV memo"
+    - "direct co-invest"
+- skill: family-office-manager-dd-esg-impact
+  artifact: "ESG / Impact Manager DD Memo"
+  triggers:
+    - "ESG manager DD"
+    - "impact fund due diligence"
+    - "impact investing memo"
+    - "ESG allocation"
+- skill: family-office-esg-impact-investing-mandate
+  artifact: "ESG / Impact Investing Mandate"
+  triggers:
+    - "ESG mandate"
+    - "impact mandate"
+    - "impact investing policy"
+    - "ESG investment policy"

--- a/family-office/capital-allocation-router/SKILL.md
+++ b/family-office/capital-allocation-router/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: capital-allocation-router
+display-name: "Family Office — Capital Allocation Router"
+description: "Pillar router for Capital Allocation. Classifies a natural-language advisor ask into the matching leaf skill inside the Capital Allocation pillar. Catalog rebuild tracked in issue #427."
+---
+
+# Family Office — Capital Allocation Router
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active.
+
+## When to Use
+
+Invoke when the advisor asks a natural-language question about **Capital Allocation**
+without naming a specific leaf skill. Representative phrases:
+
+- long-term portfolio strategy
+- investment policy statement
+- asset allocation
+- target allocation
+- portfolio risk
+- risk register
+- business exit
+- sell business
+- new business diligence
+- acquire business
+
+## Dispatch Table
+
+This router maps advisor prompts to the matching leaf skill inside the
+Capital Allocation pillar. The table is embedded here (authoring source of truth)
+and mirrored in `DISPATCH.yml` for programmatic consumers.
+
+| Leaf slug | Artifact | Example triggers |
+|---|---|---|
+| `family-office-long-term-portfolio-strategy-plan` | Long-Term Portfolio Strategy Plan | long-term portfolio strategy; investment policy statement; portfolio plan; long horizon allocation |
+| `family-office-target-asset-allocation-model` | Target Asset Allocation Model | asset allocation; target allocation; allocation model; portfolio weights |
+| `family-office-portfolio-risk-register` | Portfolio Risk Register | portfolio risk; risk register; risk management memo; portfolio risks |
+| `family-office-business-exit-strategy` | Exit Tax Minimization Plan | business exit; sell business; minimize taxes before selling; exit planning; operating business sale |
+| `family-office-new-business-diligence-memo` | New Business Diligence Memo | new business diligence; acquire business; evaluate new business; business investment memo |
+| `family-office-investment-operations-review-checklist` | Investment Operations Review Checklist | investment operations review; ops review; custody check; reconciliation review |
+| `family-office-client-sourced-deal-review-memo` | Client-Sourced Deal Review Memo | client sourced deal; principal brought a deal; friend referral investment; review this deal |
+| `family-office-manager-dd-hedge-fund` | Hedge Fund Manager DD Memo | hedge fund manager DD; hedge fund due diligence; HF allocation memo; evaluate hedge fund |
+| `family-office-manager-dd-private-equity` | Private Equity Manager DD Memo | private equity manager DD; PE fund due diligence; buyout fund memo; PE allocation |
+| `family-office-manager-dd-private-debt` | Private Debt Manager DD Memo | private debt DD; private credit manager; direct lending fund; private debt allocation |
+| `family-office-manager-dd-venture-capital` | Venture Capital Manager DD Memo | venture capital manager DD; VC fund due diligence; seed fund memo; VC allocation |
+| `family-office-manager-dd-real-assets` | Real Assets Manager DD Memo | real assets manager DD; infrastructure fund; natural resources fund; commodities allocation |
+| `family-office-manager-dd-real-estate` | Real Estate Manager DD Memo | real estate manager DD; RE fund due diligence; property fund memo; real estate allocation |
+| `family-office-manager-dd-direct-co-investment` | Direct / Co-Investment DD Memo | direct investment DD; co-investment memo; SPV memo; direct co-invest |
+| `family-office-manager-dd-esg-impact` | ESG / Impact Manager DD Memo | ESG manager DD; impact fund due diligence; impact investing memo; ESG allocation |
+| `family-office-esg-impact-investing-mandate` | ESG / Impact Investing Mandate | ESG mandate; impact mandate; impact investing policy; ESG investment policy |
+
+## Workflow
+
+1. The router reads the advisor's prompt.
+2. It matches trigger phrases to the leaf skill whose artifact best fits.
+3. It confirms the match with the advisor if confidence is borderline
+   ("Nearest skill is X — run it?").
+4. If no leaf matches, it returns a clear "not built in this iteration"
+   message and suggests logging the ask as an open question.
+
+## Non-goals for this iteration
+
+This router does not programmatically invoke the leaf skill's Python agent.
+Cross-skill invocation is handled by the Claude Code harness: the router's
+job is to name the right leaf so the harness invokes it. The programmatic
+orchestration pipeline ships under the execution-pipeline PR tracked in
+issue #427.
+
+## Composition
+
+If the advisor's ask implies more than one leaf artifact (example: "exit the
+business AND plan the philanthropic vehicle that catches the proceeds"), the
+router proposes a two-leaf sequence with a shared interview that minimizes
+duplicate questions.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/cashflow-forecast-worksheet/.env.example
+++ b/family-office/cashflow-forecast-worksheet/.env.example
@@ -1,0 +1,9 @@
+# Cashflow Forecast Worksheet — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/cashflow-forecast-worksheet/SKILL.md
+++ b/family-office/cashflow-forecast-worksheet/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cashflow-forecast-worksheet
+display-name: "Cashflow Forecast Worksheet"
+description: "Produce a 12-month rolling cashflow forecast. Captures inflows, outflows, timing, and cushion requirements."
+---
+
+# Cashflow Forecast Worksheet
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- cashflow forecast
+- cash management
+- 12-month cash plan
+- rolling cashflow
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Cashflow Forecast Worksheet`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/cashflow-forecast-worksheet/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `forecast_start_month` — Forecast start month (YYYY-MM)?
+- `recurring_inflows` — Recurring inflows (source, amount, cadence)?
+- `recurring_outflows` — Recurring outflows (category, amount, cadence)?
+- `lumpy_known_items` — Known lumpy inflows/outflows and timing?
+- `minimum_cushion` — Minimum liquidity cushion?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"cashflow-forecast-worksheet"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/cashflow-forecast-worksheet/requirements.txt
+++ b/family-office/cashflow-forecast-worksheet/requirements.txt
@@ -1,0 +1,4 @@
+# Cashflow Forecast Worksheet
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/cashflow-forecast-worksheet/scripts/agent.py
+++ b/family-office/cashflow-forecast-worksheet/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Cashflow Forecast Worksheet skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Cashflow Forecast Worksheet as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "cashflow-forecast-worksheet"
+SKILL_DISPLAY = "Cashflow Forecast Worksheet"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Cashflow Forecast Worksheet"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("forecast_start_month", "Forecast start month (YYYY-MM)?"),
+    ("recurring_inflows", "Recurring inflows (source, amount, cadence)?"),
+    ("recurring_outflows", "Recurring outflows (category, amount, cadence)?"),
+    ("lumpy_known_items", "Known lumpy inflows/outflows and timing?"),
+    ("minimum_cushion", "Minimum liquidity cushion?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/cashflow-forecast-worksheet/tests/test_smoke.py
+++ b/family-office/cashflow-forecast-worksheet/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Cashflow Forecast Worksheet skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/charitable-trust-selection-memo/.env.example
+++ b/family-office/charitable-trust-selection-memo/.env.example
@@ -1,0 +1,9 @@
+# Charitable Trust Selection Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/charitable-trust-selection-memo/SKILL.md
+++ b/family-office/charitable-trust-selection-memo/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: charitable-trust-selection-memo
+display-name: "Charitable Trust Selection Memo"
+description: "Produce a memo comparing charitable trust options — CRUT, CRAT, CLT, CLAT — for the family's giving goals."
+---
+
+# Charitable Trust Selection Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- charitable trust
+- CRUT CLT comparison
+- charitable remainder trust
+- charitable lead trust
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Charitable Trust Selection Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/charitable-trust-selection-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `goal` — Primary goal (income / tax / legacy)?
+- `funding_assets` — Assets to fund the trust?
+- `income_needs` — Income needs from the trust?
+- `term_vs_life` — Term vs life structure preference?
+- `beneficiaries` — Beneficiaries?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"charitable-trust-selection-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/charitable-trust-selection-memo/requirements.txt
+++ b/family-office/charitable-trust-selection-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Charitable Trust Selection Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/charitable-trust-selection-memo/scripts/agent.py
+++ b/family-office/charitable-trust-selection-memo/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Charitable Trust Selection Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Charitable Trust Selection Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "charitable-trust-selection-memo"
+SKILL_DISPLAY = "Charitable Trust Selection Memo"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Charitable Trust Selection Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("goal", "Primary goal (income / tax / legacy)?"),
+    ("funding_assets", "Assets to fund the trust?"),
+    ("income_needs", "Income needs from the trust?"),
+    ("term_vs_life", "Term vs life structure preference?"),
+    ("beneficiaries", "Beneficiaries?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/charitable-trust-selection-memo/tests/test_smoke.py
+++ b/family-office/charitable-trust-selection-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Charitable Trust Selection Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/client-sourced-deal-review-memo/.env.example
+++ b/family-office/client-sourced-deal-review-memo/.env.example
@@ -1,0 +1,9 @@
+# Client-Sourced Deal Review Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/client-sourced-deal-review-memo/SKILL.md
+++ b/family-office/client-sourced-deal-review-memo/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: client-sourced-deal-review-memo
+display-name: "Client-Sourced Deal Review Memo"
+description: "Produce a review memo for a deal the principal sourced themselves. Captures deal sponsor, structure, terms, conflicts, and recommendation."
+---
+
+# Client-Sourced Deal Review Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- client sourced deal
+- principal brought a deal
+- friend referral investment
+- review this deal
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Client-Sourced Deal Review Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/client-sourced-deal-review-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `deal_name` — Deal name?
+- `sponsor` — Deal sponsor?
+- `investment_amount` — Proposed investment amount?
+- `structure` — Deal structure (equity / debt / convertible)?
+- `key_terms` — Key terms (pref / cap / board / vesting)?
+- `conflicts` — Any conflicts of interest?
+- `recommendation_lean` — Lean recommendation (proceed / decline / pause)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"client-sourced-deal-review-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/client-sourced-deal-review-memo/requirements.txt
+++ b/family-office/client-sourced-deal-review-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Client-Sourced Deal Review Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/client-sourced-deal-review-memo/scripts/agent.py
+++ b/family-office/client-sourced-deal-review-memo/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Client-Sourced Deal Review Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Client-Sourced Deal Review Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "client-sourced-deal-review-memo"
+SKILL_DISPLAY = "Client-Sourced Deal Review Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Client-Sourced Deal Review Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("deal_name", "Deal name?"),
+    ("sponsor", "Deal sponsor?"),
+    ("investment_amount", "Proposed investment amount?"),
+    ("structure", "Deal structure (equity / debt / convertible)?"),
+    ("key_terms", "Key terms (pref / cap / board / vesting)?"),
+    ("conflicts", "Any conflicts of interest?"),
+    ("recommendation_lean", "Lean recommendation (proceed / decline / pause)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/client-sourced-deal-review-memo/tests/test_smoke.py
+++ b/family-office/client-sourced-deal-review-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Client-Sourced Deal Review Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/collectibles-acquisition-logistics/.env.example
+++ b/family-office/collectibles-acquisition-logistics/.env.example
@@ -1,0 +1,9 @@
+# Collectibles Acquisition & Logistics Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/collectibles-acquisition-logistics/SKILL.md
+++ b/family-office/collectibles-acquisition-logistics/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: collectibles-acquisition-logistics
+display-name: "Collectibles Acquisition & Logistics Plan"
+description: "Produce a plan for acquiring and moving a collectible asset (classic car, rare wine, timepiece, sports memorabilia). Example: antique Ferrari from Pebble Beach to Naples."
+---
+
+# Collectibles Acquisition & Logistics Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- collectibles logistics
+- classic car transport
+- rare wine acquisition
+- Ferrari transport
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Collectibles Acquisition & Logistics Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/collectibles-acquisition-logistics/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `category` — Collectible category?
+- `item` — Specific item?
+- `origin` — Origin location?
+- `destination` — Destination location?
+- `estimated_value` — Estimated value?
+- `transport_window` — Transport window (dates)?
+- `insurance_in_transit` — Insurance-in-transit requirement?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"collectibles-acquisition-logistics"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/collectibles-acquisition-logistics/requirements.txt
+++ b/family-office/collectibles-acquisition-logistics/requirements.txt
@@ -1,0 +1,4 @@
+# Collectibles Acquisition & Logistics Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/collectibles-acquisition-logistics/scripts/agent.py
+++ b/family-office/collectibles-acquisition-logistics/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Collectibles Acquisition & Logistics Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Collectibles Acquisition & Logistics Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "collectibles-acquisition-logistics"
+SKILL_DISPLAY = "Collectibles Acquisition & Logistics Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Collectibles Acquisition & Logistics Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("category", "Collectible category?"),
+    ("item", "Specific item?"),
+    ("origin", "Origin location?"),
+    ("destination", "Destination location?"),
+    ("estimated_value", "Estimated value?"),
+    ("transport_window", "Transport window (dates)?"),
+    ("insurance_in_transit", "Insurance-in-transit requirement?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/collectibles-acquisition-logistics/tests/test_smoke.py
+++ b/family-office/collectibles-acquisition-logistics/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Collectibles Acquisition & Logistics Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/community-engagement-plan/.env.example
+++ b/family-office/community-engagement-plan/.env.example
@@ -1,0 +1,9 @@
+# Community Engagement Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/community-engagement-plan/SKILL.md
+++ b/family-office/community-engagement-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: community-engagement-plan
+display-name: "Community Engagement Plan"
+description: "Produce a community engagement plan — relationships with civic, cultural, and nonprofit organizations; time commitments; reputational posture."
+---
+
+# Community Engagement Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- community engagement
+- civic involvement plan
+- nonprofit board service
+- public engagement plan
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Community Engagement Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/community-engagement-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `communities_of_interest` — Communities of interest?
+- `current_relationships` — Current relationships and roles?
+- `time_commitment_target` — Time commitment target?
+- `financial_support_target` — Financial support target?
+- `reputational_posture` — Reputational posture (public / private)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"community-engagement-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/community-engagement-plan/requirements.txt
+++ b/family-office/community-engagement-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Community Engagement Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/community-engagement-plan/scripts/agent.py
+++ b/family-office/community-engagement-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Community Engagement Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Community Engagement Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "community-engagement-plan"
+SKILL_DISPLAY = "Community Engagement Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Community Engagement Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("communities_of_interest", "Communities of interest?"),
+    ("current_relationships", "Current relationships and roles?"),
+    ("time_commitment_target", "Time commitment target?"),
+    ("financial_support_target", "Financial support target?"),
+    ("reputational_posture", "Reputational posture (public / private)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/community-engagement-plan/tests/test_smoke.py
+++ b/family-office/community-engagement-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Community Engagement Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/complexity-management-router/DISPATCH.yml
+++ b/family-office/complexity-management-router/DISPATCH.yml
@@ -1,0 +1,155 @@
+- skill: family-office-tax-strategy-memo
+  artifact: "Tax Strategy Memo"
+  triggers:
+    - "tax strategy"
+    - "tax planning memo"
+    - "year-end tax planning"
+    - "tax posture"
+- skill: family-office-cpa-tax-package-checklist
+  artifact: "CPA Tax Package Checklist"
+  triggers:
+    - "CPA checklist"
+    - "tax package checklist"
+    - "tax documents for CPA"
+    - "CPA document list"
+- skill: family-office-external-advisor-management-plan
+  artifact: "External Advisor Management Plan"
+  triggers:
+    - "external advisors"
+    - "manage outside advisors"
+    - "advisor roster"
+    - "legal and tax management plan"
+- skill: family-office-annual-budget-workbook
+  artifact: "Annual Budget Workbook"
+  triggers:
+    - "annual budget"
+    - "family budget"
+    - "create budget"
+    - "budget workbook"
+- skill: family-office-cashflow-forecast-worksheet
+  artifact: "Cashflow Forecast Worksheet"
+  triggers:
+    - "cashflow forecast"
+    - "cash management"
+    - "12-month cash plan"
+    - "rolling cashflow"
+- skill: family-office-expedited-funding-access-plan
+  artifact: "Expedited Funding Access Plan"
+  triggers:
+    - "expedited funding"
+    - "emergency liquidity"
+    - "large cash access"
+    - "SBLOC plan"
+- skill: family-office-bookkeeping-bill-pay-setup-plan
+  artifact: "Bookkeeping & Bill Pay Setup Plan"
+  triggers:
+    - "bookkeeping setup"
+    - "bill pay plan"
+    - "family office accounting"
+    - "internal controls"
+- skill: family-office-document-management-plan
+  artifact: "Document Management Plan"
+  triggers:
+    - "document management"
+    - "DMS plan"
+    - "folder taxonomy"
+    - "document retention"
+- skill: family-office-consolidated-reporting-spec
+  artifact: "Consolidated Reporting Specification"
+  triggers:
+    - "consolidated reporting"
+    - "reporting spec"
+    - "family-office reporting"
+    - "portfolio reporting requirements"
+- skill: family-office-insurance-coverage-review-worksheet
+  artifact: "Insurance Coverage Review Worksheet"
+  triggers:
+    - "insurance review"
+    - "coverage review"
+    - "policy audit"
+    - "insurance worksheet"
+- skill: family-office-insurance-procurement-framework
+  artifact: "Insurance Procurement Framework"
+  triggers:
+    - "insurance procurement"
+    - "buy insurance"
+    - "insurance RFP"
+    - "coverage procurement factors"
+- skill: family-office-real-estate-acquisition-plan
+  artifact: "Real Estate Acquisition Plan"
+  triggers:
+    - "real estate acquisition"
+    - "buy property plan"
+    - "RE acquisition"
+    - "property purchase plan"
+- skill: family-office-art-acquisition-due-diligence
+  artifact: "Art Acquisition Due-Diligence Memo"
+  triggers:
+    - "art acquisition"
+    - "art due diligence"
+    - "buy painting"
+    - "Warhol purchase"
+    - "art DD"
+- skill: family-office-leisure-asset-ownership-comparison
+  artifact: "Leisure Asset Ownership Comparison"
+  triggers:
+    - "jet vs NetJets"
+    - "leisure asset comparison"
+    - "fractional vs full ownership"
+    - "yacht ownership model"
+- skill: family-office-collectibles-acquisition-logistics
+  artifact: "Collectibles Acquisition & Logistics Plan"
+  triggers:
+    - "collectibles logistics"
+    - "classic car transport"
+    - "rare wine acquisition"
+    - "Ferrari transport"
+- skill: family-office-concierge-private-aviation-plan
+  artifact: "Private Aviation Coordination Plan"
+  triggers:
+    - "private aviation plan"
+    - "charter aircraft"
+    - "jet booking plan"
+    - "flight coordination"
+- skill: family-office-concierge-private-car-plan
+  artifact: "Private Car Coordination Plan"
+  triggers:
+    - "private car plan"
+    - "driver coordination"
+    - "chauffeur plan"
+    - "car service roster"
+- skill: family-office-concierge-travel-coordination-plan
+  artifact: "Travel Coordination Plan"
+  triggers:
+    - "travel coordination"
+    - "trip plan"
+    - "itinerary"
+    - "family trip logistics"
+- skill: family-office-concierge-personal-shopping-plan
+  artifact: "Personal Shopping Plan"
+  triggers:
+    - "personal shopping"
+    - "shopping plan"
+    - "gift shopping"
+    - "wardrobe plan"
+- skill: family-office-concierge-personal-protection-plan
+  artifact: "Personal Protection Plan"
+  triggers:
+    - "personal protection"
+    - "executive protection"
+    - "security plan"
+    - "physical security"
+- skill: family-office-password-management-setup-plan
+  artifact: "Password Management Setup Plan"
+  triggers:
+    - "password manager setup"
+    - "1Password plan"
+    - "credential vault"
+    - "family password setup"
+- skill: family-office-virtual-mailbox-setup-plan
+  artifact: "Virtual Mailbox Setup Plan"
+  triggers:
+    - "virtual mailbox"
+    - "mail scanning"
+    - "mail forwarding plan"
+    - "remote mail setup"

--- a/family-office/complexity-management-router/SKILL.md
+++ b/family-office/complexity-management-router/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: complexity-management-router
+display-name: "Family Office — Complexity Management Router"
+description: "Pillar router for Complexity Management. Classifies a natural-language advisor ask into the matching leaf skill inside the Complexity Management pillar. Catalog rebuild tracked in issue #427."
+---
+
+# Family Office — Complexity Management Router
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active.
+
+## When to Use
+
+Invoke when the advisor asks a natural-language question about **Complexity Management**
+without naming a specific leaf skill. Representative phrases:
+
+- tax strategy
+- tax planning memo
+- CPA checklist
+- tax package checklist
+- external advisors
+- manage outside advisors
+- annual budget
+- family budget
+- cashflow forecast
+- cash management
+
+## Dispatch Table
+
+This router maps advisor prompts to the matching leaf skill inside the
+Complexity Management pillar. The table is embedded here (authoring source of truth)
+and mirrored in `DISPATCH.yml` for programmatic consumers.
+
+| Leaf slug | Artifact | Example triggers |
+|---|---|---|
+| `family-office-tax-strategy-memo` | Tax Strategy Memo | tax strategy; tax planning memo; year-end tax planning; tax posture |
+| `family-office-cpa-tax-package-checklist` | CPA Tax Package Checklist | CPA checklist; tax package checklist; tax documents for CPA; CPA document list |
+| `family-office-external-advisor-management-plan` | External Advisor Management Plan | external advisors; manage outside advisors; advisor roster; legal and tax management plan |
+| `family-office-annual-budget-workbook` | Annual Budget Workbook | annual budget; family budget; create budget; budget workbook |
+| `family-office-cashflow-forecast-worksheet` | Cashflow Forecast Worksheet | cashflow forecast; cash management; 12-month cash plan; rolling cashflow |
+| `family-office-expedited-funding-access-plan` | Expedited Funding Access Plan | expedited funding; emergency liquidity; large cash access; SBLOC plan |
+| `family-office-bookkeeping-bill-pay-setup-plan` | Bookkeeping & Bill Pay Setup Plan | bookkeeping setup; bill pay plan; family office accounting; internal controls |
+| `family-office-document-management-plan` | Document Management Plan | document management; DMS plan; folder taxonomy; document retention |
+| `family-office-consolidated-reporting-spec` | Consolidated Reporting Specification | consolidated reporting; reporting spec; family-office reporting; portfolio reporting requirements |
+| `family-office-insurance-coverage-review-worksheet` | Insurance Coverage Review Worksheet | insurance review; coverage review; policy audit; insurance worksheet |
+| `family-office-insurance-procurement-framework` | Insurance Procurement Framework | insurance procurement; buy insurance; insurance RFP; coverage procurement factors |
+| `family-office-real-estate-acquisition-plan` | Real Estate Acquisition Plan | real estate acquisition; buy property plan; RE acquisition; property purchase plan |
+| `family-office-art-acquisition-due-diligence` | Art Acquisition Due-Diligence Memo | art acquisition; art due diligence; buy painting; Warhol purchase; art DD |
+| `family-office-leisure-asset-ownership-comparison` | Leisure Asset Ownership Comparison | jet vs NetJets; leisure asset comparison; fractional vs full ownership; yacht ownership model |
+| `family-office-collectibles-acquisition-logistics` | Collectibles Acquisition & Logistics Plan | collectibles logistics; classic car transport; rare wine acquisition; Ferrari transport |
+| `family-office-concierge-private-aviation-plan` | Private Aviation Coordination Plan | private aviation plan; charter aircraft; jet booking plan; flight coordination |
+| `family-office-concierge-private-car-plan` | Private Car Coordination Plan | private car plan; driver coordination; chauffeur plan; car service roster |
+| `family-office-concierge-travel-coordination-plan` | Travel Coordination Plan | travel coordination; trip plan; itinerary; family trip logistics |
+| `family-office-concierge-personal-shopping-plan` | Personal Shopping Plan | personal shopping; shopping plan; gift shopping; wardrobe plan |
+| `family-office-concierge-personal-protection-plan` | Personal Protection Plan | personal protection; executive protection; security plan; physical security |
+| `family-office-password-management-setup-plan` | Password Management Setup Plan | password manager setup; 1Password plan; credential vault; family password setup |
+| `family-office-virtual-mailbox-setup-plan` | Virtual Mailbox Setup Plan | virtual mailbox; mail scanning; mail forwarding plan; remote mail setup |
+
+## Workflow
+
+1. The router reads the advisor's prompt.
+2. It matches trigger phrases to the leaf skill whose artifact best fits.
+3. It confirms the match with the advisor if confidence is borderline
+   ("Nearest skill is X — run it?").
+4. If no leaf matches, it returns a clear "not built in this iteration"
+   message and suggests logging the ask as an open question.
+
+## Non-goals for this iteration
+
+This router does not programmatically invoke the leaf skill's Python agent.
+Cross-skill invocation is handled by the Claude Code harness: the router's
+job is to name the right leaf so the harness invokes it. The programmatic
+orchestration pipeline ships under the execution-pipeline PR tracked in
+issue #427.
+
+## Composition
+
+If the advisor's ask implies more than one leaf artifact (example: "exit the
+business AND plan the philanthropic vehicle that catches the proceeds"), the
+router proposes a two-leaf sequence with a shared interview that minimizes
+duplicate questions.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-personal-protection-plan/.env.example
+++ b/family-office/concierge-personal-protection-plan/.env.example
@@ -1,0 +1,9 @@
+# Personal Protection Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/concierge-personal-protection-plan/SKILL.md
+++ b/family-office/concierge-personal-protection-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: concierge-personal-protection-plan
+display-name: "Personal Protection Plan"
+description: "Produce a personal protection plan — threat profile, physical security, executive protection providers, travel security."
+---
+
+# Personal Protection Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- personal protection
+- executive protection
+- security plan
+- physical security
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Personal Protection Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/concierge-personal-protection-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `threat_profile` — Threat profile summary?
+- `covered_persons` — Persons in scope?
+- `geographies_of_concern` — Geographies of concern?
+- `provider_shortlist` — EP provider shortlist?
+- `residence_hardening_level` — Residence hardening level?
+- `travel_security_posture` — Travel security posture?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"concierge-personal-protection-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-personal-protection-plan/requirements.txt
+++ b/family-office/concierge-personal-protection-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Personal Protection Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/concierge-personal-protection-plan/scripts/agent.py
+++ b/family-office/concierge-personal-protection-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Personal Protection Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Personal Protection Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "concierge-personal-protection-plan"
+SKILL_DISPLAY = "Personal Protection Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Personal Protection Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("threat_profile", "Threat profile summary?"),
+    ("covered_persons", "Persons in scope?"),
+    ("geographies_of_concern", "Geographies of concern?"),
+    ("provider_shortlist", "EP provider shortlist?"),
+    ("residence_hardening_level", "Residence hardening level?"),
+    ("travel_security_posture", "Travel security posture?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/concierge-personal-protection-plan/tests/test_smoke.py
+++ b/family-office/concierge-personal-protection-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Personal Protection Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/concierge-personal-shopping-plan/.env.example
+++ b/family-office/concierge-personal-shopping-plan/.env.example
@@ -1,0 +1,9 @@
+# Personal Shopping Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/concierge-personal-shopping-plan/SKILL.md
+++ b/family-office/concierge-personal-shopping-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: concierge-personal-shopping-plan
+display-name: "Personal Shopping Plan"
+description: "Produce a personal shopping plan — occasion, budget, brand preferences, sizing, delivery, returns."
+---
+
+# Personal Shopping Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- personal shopping
+- shopping plan
+- gift shopping
+- wardrobe plan
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Personal Shopping Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/concierge-personal-shopping-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `occasion_or_purpose` — Occasion or purpose?
+- `budget_range` — Budget range?
+- `brand_preferences` — Brand preferences?
+- `sizing` — Sizing details?
+- `delivery_window` — Delivery window?
+- `returns_policy_requirements` — Returns policy requirements?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"concierge-personal-shopping-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-personal-shopping-plan/requirements.txt
+++ b/family-office/concierge-personal-shopping-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Personal Shopping Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/concierge-personal-shopping-plan/scripts/agent.py
+++ b/family-office/concierge-personal-shopping-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Personal Shopping Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Personal Shopping Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "concierge-personal-shopping-plan"
+SKILL_DISPLAY = "Personal Shopping Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Personal Shopping Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("occasion_or_purpose", "Occasion or purpose?"),
+    ("budget_range", "Budget range?"),
+    ("brand_preferences", "Brand preferences?"),
+    ("sizing", "Sizing details?"),
+    ("delivery_window", "Delivery window?"),
+    ("returns_policy_requirements", "Returns policy requirements?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/concierge-personal-shopping-plan/tests/test_smoke.py
+++ b/family-office/concierge-personal-shopping-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Personal Shopping Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/concierge-private-aviation-plan/.env.example
+++ b/family-office/concierge-private-aviation-plan/.env.example
@@ -1,0 +1,9 @@
+# Private Aviation Coordination Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/concierge-private-aviation-plan/SKILL.md
+++ b/family-office/concierge-private-aviation-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: concierge-private-aviation-plan
+display-name: "Private Aviation Coordination Plan"
+description: "Produce a private aviation coordination plan — operator roster, preferred aircraft, crew preferences, catering, ground transport."
+---
+
+# Private Aviation Coordination Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- private aviation plan
+- charter aircraft
+- jet booking plan
+- flight coordination
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Private Aviation Coordination Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/concierge-private-aviation-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `operators_in_use` — Operators in use?
+- `preferred_aircraft` — Preferred aircraft class?
+- `typical_routes` — Typical routes?
+- `crew_preferences` — Crew preferences?
+- `catering_preferences` — Catering preferences?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"concierge-private-aviation-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-private-aviation-plan/requirements.txt
+++ b/family-office/concierge-private-aviation-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Private Aviation Coordination Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/concierge-private-aviation-plan/scripts/agent.py
+++ b/family-office/concierge-private-aviation-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Private Aviation Coordination Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Private Aviation Coordination Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "concierge-private-aviation-plan"
+SKILL_DISPLAY = "Private Aviation Coordination Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Private Aviation Coordination Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("operators_in_use", "Operators in use?"),
+    ("preferred_aircraft", "Preferred aircraft class?"),
+    ("typical_routes", "Typical routes?"),
+    ("crew_preferences", "Crew preferences?"),
+    ("catering_preferences", "Catering preferences?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/concierge-private-aviation-plan/tests/test_smoke.py
+++ b/family-office/concierge-private-aviation-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Private Aviation Coordination Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/concierge-private-car-plan/.env.example
+++ b/family-office/concierge-private-car-plan/.env.example
@@ -1,0 +1,9 @@
+# Private Car Coordination Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/concierge-private-car-plan/SKILL.md
+++ b/family-office/concierge-private-car-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: concierge-private-car-plan
+display-name: "Private Car Coordination Plan"
+description: "Produce a private car coordination plan — operators, drivers, vehicles, standing reservations, billing."
+---
+
+# Private Car Coordination Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- private car plan
+- driver coordination
+- chauffeur plan
+- car service roster
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Private Car Coordination Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/concierge-private-car-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `operators_in_use` — Operators in use?
+- `preferred_drivers` — Preferred drivers?
+- `preferred_vehicles` — Preferred vehicles?
+- `standing_reservations` — Standing reservations (recurring needs)?
+- `billing_arrangement` — Billing arrangement?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"concierge-private-car-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-private-car-plan/requirements.txt
+++ b/family-office/concierge-private-car-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Private Car Coordination Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/concierge-private-car-plan/scripts/agent.py
+++ b/family-office/concierge-private-car-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Private Car Coordination Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Private Car Coordination Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "concierge-private-car-plan"
+SKILL_DISPLAY = "Private Car Coordination Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Private Car Coordination Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("operators_in_use", "Operators in use?"),
+    ("preferred_drivers", "Preferred drivers?"),
+    ("preferred_vehicles", "Preferred vehicles?"),
+    ("standing_reservations", "Standing reservations (recurring needs)?"),
+    ("billing_arrangement", "Billing arrangement?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/concierge-private-car-plan/tests/test_smoke.py
+++ b/family-office/concierge-private-car-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Private Car Coordination Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/concierge-travel-coordination-plan/.env.example
+++ b/family-office/concierge-travel-coordination-plan/.env.example
@@ -1,0 +1,9 @@
+# Travel Coordination Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/concierge-travel-coordination-plan/SKILL.md
+++ b/family-office/concierge-travel-coordination-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: concierge-travel-coordination-plan
+display-name: "Travel Coordination Plan"
+description: "Produce a travel coordination plan — itinerary, hotels, transfers, dining, contingency plans."
+---
+
+# Travel Coordination Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- travel coordination
+- trip plan
+- itinerary
+- family trip logistics
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Travel Coordination Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/concierge-travel-coordination-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `destination` — Destination(s)?
+- `travel_dates` — Travel dates?
+- `party_size` — Party size and composition?
+- `hotels_preferred` — Preferred hotels?
+- `dining_preferences` — Dining preferences?
+- `contingencies_to_plan` — Contingencies to plan for?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"concierge-travel-coordination-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/concierge-travel-coordination-plan/requirements.txt
+++ b/family-office/concierge-travel-coordination-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Travel Coordination Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/concierge-travel-coordination-plan/scripts/agent.py
+++ b/family-office/concierge-travel-coordination-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Travel Coordination Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Travel Coordination Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "concierge-travel-coordination-plan"
+SKILL_DISPLAY = "Travel Coordination Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Travel Coordination Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("destination", "Destination(s)?"),
+    ("travel_dates", "Travel dates?"),
+    ("party_size", "Party size and composition?"),
+    ("hotels_preferred", "Preferred hotels?"),
+    ("dining_preferences", "Dining preferences?"),
+    ("contingencies_to_plan", "Contingencies to plan for?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/concierge-travel-coordination-plan/tests/test_smoke.py
+++ b/family-office/concierge-travel-coordination-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Travel Coordination Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/consolidated-reporting-spec/.env.example
+++ b/family-office/consolidated-reporting-spec/.env.example
@@ -1,0 +1,9 @@
+# Consolidated Reporting Specification — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/consolidated-reporting-spec/SKILL.md
+++ b/family-office/consolidated-reporting-spec/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: consolidated-reporting-spec
+display-name: "Consolidated Reporting Specification"
+description: "Produce a specification for consolidated family-office reporting across entities, accounts, and asset classes."
+---
+
+# Consolidated Reporting Specification
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- consolidated reporting
+- reporting spec
+- family-office reporting
+- portfolio reporting requirements
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Consolidated Reporting Specification`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/consolidated-reporting-spec/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `reporting_platform` — Reporting platform (Addepar / Masttro / Eton / spreadsheet)?
+- `entities_to_consolidate` — Entities to consolidate?
+- `asset_classes_in_scope` — Asset classes in scope?
+- `reporting_cadence` — Reporting cadence?
+- `key_metrics` — Key metrics to surface?
+- `recipient_list` — Recipient list and their views?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"consolidated-reporting-spec"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/consolidated-reporting-spec/requirements.txt
+++ b/family-office/consolidated-reporting-spec/requirements.txt
@@ -1,0 +1,4 @@
+# Consolidated Reporting Specification
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/consolidated-reporting-spec/scripts/agent.py
+++ b/family-office/consolidated-reporting-spec/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Consolidated Reporting Specification skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Consolidated Reporting Specification as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "consolidated-reporting-spec"
+SKILL_DISPLAY = "Consolidated Reporting Specification"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Consolidated Reporting Specification"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("reporting_platform", "Reporting platform (Addepar / Masttro / Eton / spreadsheet)?"),
+    ("entities_to_consolidate", "Entities to consolidate?"),
+    ("asset_classes_in_scope", "Asset classes in scope?"),
+    ("reporting_cadence", "Reporting cadence?"),
+    ("key_metrics", "Key metrics to surface?"),
+    ("recipient_list", "Recipient list and their views?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/consolidated-reporting-spec/tests/test_smoke.py
+++ b/family-office/consolidated-reporting-spec/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Consolidated Reporting Specification skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/cpa-tax-package-checklist/.env.example
+++ b/family-office/cpa-tax-package-checklist/.env.example
@@ -1,0 +1,9 @@
+# CPA Tax Package Checklist — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/cpa-tax-package-checklist/SKILL.md
+++ b/family-office/cpa-tax-package-checklist/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cpa-tax-package-checklist
+display-name: "CPA Tax Package Checklist"
+description: "Produce a checklist of every document the CPA needs for tax return preparation. Tailored to the family's entities and income sources."
+---
+
+# CPA Tax Package Checklist
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- CPA checklist
+- tax package checklist
+- tax documents for CPA
+- CPA document list
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `CPA Tax Package Checklist`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/cpa-tax-package-checklist/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `tax_year` — Tax year?
+- `entities_in_scope` — Entities in scope (comma-separated legal names)?
+- `key_income_sources` — Key income sources?
+- `foreign_filings` — Foreign filings required (FBAR / 8938)?
+- `cpa_firm` — CPA firm?
+- `cpa_deadline` — CPA deadline for receipt (ISO date)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"cpa-tax-package-checklist"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/cpa-tax-package-checklist/requirements.txt
+++ b/family-office/cpa-tax-package-checklist/requirements.txt
@@ -1,0 +1,4 @@
+# CPA Tax Package Checklist
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/cpa-tax-package-checklist/scripts/agent.py
+++ b/family-office/cpa-tax-package-checklist/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the CPA Tax Package Checklist skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the CPA Tax Package Checklist as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "cpa-tax-package-checklist"
+SKILL_DISPLAY = "CPA Tax Package Checklist"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "CPA Tax Package Checklist"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("tax_year", "Tax year?"),
+    ("entities_in_scope", "Entities in scope (comma-separated legal names)?"),
+    ("key_income_sources", "Key income sources?"),
+    ("foreign_filings", "Foreign filings required (FBAR / 8938)?"),
+    ("cpa_firm", "CPA firm?"),
+    ("cpa_deadline", "CPA deadline for receipt (ISO date)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/cpa-tax-package-checklist/tests/test_smoke.py
+++ b/family-office/cpa-tax-package-checklist/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the CPA Tax Package Checklist skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/document-management-plan/.env.example
+++ b/family-office/document-management-plan/.env.example
@@ -1,0 +1,9 @@
+# Document Management Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/document-management-plan/SKILL.md
+++ b/family-office/document-management-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: document-management-plan
+display-name: "Document Management Plan"
+description: "Produce a document management plan — DMS choice, folder taxonomy, retention rules, access control."
+---
+
+# Document Management Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- document management
+- DMS plan
+- folder taxonomy
+- document retention
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Document Management Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/document-management-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `dms_platforms` — DMS platforms in use (SharePoint / Egnyte / Box)?
+- `top_level_taxonomy` — Top-level folder taxonomy?
+- `retention_defaults` — Retention defaults by document kind?
+- `access_roles` — Access roles (principal / COO / advisor / staff)?
+- `audit_cadence` — Access audit cadence?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"document-management-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/document-management-plan/requirements.txt
+++ b/family-office/document-management-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Document Management Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/document-management-plan/scripts/agent.py
+++ b/family-office/document-management-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Document Management Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Document Management Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "document-management-plan"
+SKILL_DISPLAY = "Document Management Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Document Management Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("dms_platforms", "DMS platforms in use (SharePoint / Egnyte / Box)?"),
+    ("top_level_taxonomy", "Top-level folder taxonomy?"),
+    ("retention_defaults", "Retention defaults by document kind?"),
+    ("access_roles", "Access roles (principal / COO / advisor / staff)?"),
+    ("audit_cadence", "Access audit cadence?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/document-management-plan/tests/test_smoke.py
+++ b/family-office/document-management-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Document Management Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/esg-impact-investing-mandate/.env.example
+++ b/family-office/esg-impact-investing-mandate/.env.example
@@ -1,0 +1,9 @@
+# ESG / Impact Investing Mandate — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/esg-impact-investing-mandate/SKILL.md
+++ b/family-office/esg-impact-investing-mandate/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: esg-impact-investing-mandate
+display-name: "ESG / Impact Investing Mandate"
+description: "Produce an ESG / impact investing mandate for the family office. Captures themes, exclusions, measurement framework, and blended-return tolerance."
+---
+
+# ESG / Impact Investing Mandate
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- ESG mandate
+- impact mandate
+- impact investing policy
+- ESG investment policy
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `ESG / Impact Investing Mandate`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/esg-impact-investing-mandate/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `themes` — Priority impact themes?
+- `exclusions` — Hard exclusions (sectors / behaviors)?
+- `measurement_framework` — Measurement framework (IRIS+, SDG, custom)?
+- `concessionary_tolerance` — Concessionary-return tolerance (bps below benchmark)?
+- `mandate_allocation_pct` — Target allocation % to mandate-aligned managers?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"esg-impact-investing-mandate"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/esg-impact-investing-mandate/requirements.txt
+++ b/family-office/esg-impact-investing-mandate/requirements.txt
@@ -1,0 +1,4 @@
+# ESG / Impact Investing Mandate
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/esg-impact-investing-mandate/scripts/agent.py
+++ b/family-office/esg-impact-investing-mandate/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the ESG / Impact Investing Mandate skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the ESG / Impact Investing Mandate as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "esg-impact-investing-mandate"
+SKILL_DISPLAY = "ESG / Impact Investing Mandate"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "ESG / Impact Investing Mandate"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("themes", "Priority impact themes?"),
+    ("exclusions", "Hard exclusions (sectors / behaviors)?"),
+    ("measurement_framework", "Measurement framework (IRIS+, SDG, custom)?"),
+    ("concessionary_tolerance", "Concessionary-return tolerance (bps below benchmark)?"),
+    ("mandate_allocation_pct", "Target allocation % to mandate-aligned managers?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/esg-impact-investing-mandate/tests/test_smoke.py
+++ b/family-office/esg-impact-investing-mandate/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the ESG / Impact Investing Mandate skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/estate-plan-summary-memo/.env.example
+++ b/family-office/estate-plan-summary-memo/.env.example
@@ -1,0 +1,9 @@
+# Estate Plan Summary Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/estate-plan-summary-memo/SKILL.md
+++ b/family-office/estate-plan-summary-memo/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: estate-plan-summary-memo
+display-name: "Estate Plan Summary Memo"
+description: "Produce an estate plan summary memo — wills, trusts, directives, guardianship, beneficiary designations, and gaps."
+---
+
+# Estate Plan Summary Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- estate plan summary
+- estate planning memo
+- estate overview
+- estate structure
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Estate Plan Summary Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/estate-plan-summary-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `current_documents` — Current estate documents in place?
+- `trustee_guardians` — Current trustees / guardians?
+- `beneficiary_designations_review` — Recent beneficiary designation review?
+- `state_of_residence` — State of residence?
+- `known_gaps` — Known gaps?
+- `counsel` — Estate counsel?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"estate-plan-summary-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/estate-plan-summary-memo/requirements.txt
+++ b/family-office/estate-plan-summary-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Estate Plan Summary Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/estate-plan-summary-memo/scripts/agent.py
+++ b/family-office/estate-plan-summary-memo/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Estate Plan Summary Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Estate Plan Summary Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "estate-plan-summary-memo"
+SKILL_DISPLAY = "Estate Plan Summary Memo"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Estate Plan Summary Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("current_documents", "Current estate documents in place?"),
+    ("trustee_guardians", "Current trustees / guardians?"),
+    ("beneficiary_designations_review", "Recent beneficiary designation review?"),
+    ("state_of_residence", "State of residence?"),
+    ("known_gaps", "Known gaps?"),
+    ("counsel", "Estate counsel?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/estate-plan-summary-memo/tests/test_smoke.py
+++ b/family-office/estate-plan-summary-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Estate Plan Summary Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/expedited-funding-access-plan/.env.example
+++ b/family-office/expedited-funding-access-plan/.env.example
@@ -1,0 +1,9 @@
+# Expedited Funding Access Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/expedited-funding-access-plan/SKILL.md
+++ b/family-office/expedited-funding-access-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: expedited-funding-access-plan
+display-name: "Expedited Funding Access Plan"
+description: "Produce a plan for expedited access to large liquidity when needed (margin, SBLOC, art loan, credit lines)."
+---
+
+# Expedited Funding Access Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- expedited funding
+- emergency liquidity
+- large cash access
+- SBLOC plan
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Expedited Funding Access Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/expedited-funding-access-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `target_access_amount` — Target liquidity access amount?
+- `acceptable_rate_range` — Acceptable rate range?
+- `collateral_candidates` — Collateral candidates (brokerage, art, real estate)?
+- `timing_required` — Timing required (days)?
+- `existing_credit_lines` — Existing credit lines?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"expedited-funding-access-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/expedited-funding-access-plan/requirements.txt
+++ b/family-office/expedited-funding-access-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Expedited Funding Access Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/expedited-funding-access-plan/scripts/agent.py
+++ b/family-office/expedited-funding-access-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Expedited Funding Access Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Expedited Funding Access Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "expedited-funding-access-plan"
+SKILL_DISPLAY = "Expedited Funding Access Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Expedited Funding Access Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("target_access_amount", "Target liquidity access amount?"),
+    ("acceptable_rate_range", "Acceptable rate range?"),
+    ("collateral_candidates", "Collateral candidates (brokerage, art, real estate)?"),
+    ("timing_required", "Timing required (days)?"),
+    ("existing_credit_lines", "Existing credit lines?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/expedited-funding-access-plan/tests/test_smoke.py
+++ b/family-office/expedited-funding-access-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Expedited Funding Access Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/external-advisor-management-plan/.env.example
+++ b/family-office/external-advisor-management-plan/.env.example
@@ -1,0 +1,9 @@
+# External Advisor Management Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/external-advisor-management-plan/SKILL.md
+++ b/family-office/external-advisor-management-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: external-advisor-management-plan
+display-name: "External Advisor Management Plan"
+description: "Produce a plan for managing external advisors (legal, tax, custodial, insurance, consulting). Captures advisor roster, meeting cadence, fee posture, and performance review."
+---
+
+# External Advisor Management Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- external advisors
+- manage outside advisors
+- advisor roster
+- legal and tax management plan
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `External Advisor Management Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/external-advisor-management-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `advisor_roster` — Advisor roster (name, firm, role)?
+- `meeting_cadence` — Meeting cadence per advisor?
+- `fee_summary` — Fee summary (flat / hourly / AUM)?
+- `performance_review_cadence` — Performance review cadence?
+- `open_issues` — Open coordination issues?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"external-advisor-management-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/external-advisor-management-plan/requirements.txt
+++ b/family-office/external-advisor-management-plan/requirements.txt
@@ -1,0 +1,4 @@
+# External Advisor Management Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/external-advisor-management-plan/scripts/agent.py
+++ b/family-office/external-advisor-management-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the External Advisor Management Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the External Advisor Management Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "external-advisor-management-plan"
+SKILL_DISPLAY = "External Advisor Management Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "External Advisor Management Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("advisor_roster", "Advisor roster (name, firm, role)?"),
+    ("meeting_cadence", "Meeting cadence per advisor?"),
+    ("fee_summary", "Fee summary (flat / hourly / AUM)?"),
+    ("performance_review_cadence", "Performance review cadence?"),
+    ("open_issues", "Open coordination issues?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/external-advisor-management-plan/tests/test_smoke.py
+++ b/family-office/external-advisor-management-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the External Advisor Management Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-board-development-plan/.env.example
+++ b/family-office/family-board-development-plan/.env.example
@@ -1,0 +1,9 @@
+# Family Board Development Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-board-development-plan/SKILL.md
+++ b/family-office/family-board-development-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: family-board-development-plan
+display-name: "Family Board Development Plan"
+description: "Produce a board development plan for the family enterprise — skills matrix, recruitment, education, evaluation."
+---
+
+# Family Board Development Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- board development
+- family board plan
+- board skills matrix
+- board recruitment
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Board Development Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-board-development-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `current_board_members` — Current board members and roles?
+- `skills_matrix_gaps` — Skills matrix gaps?
+- `recruitment_targets` — Recruitment targets?
+- `education_plan` — Education plan?
+- `evaluation_cadence` — Evaluation cadence?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-board-development-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-board-development-plan/requirements.txt
+++ b/family-office/family-board-development-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Family Board Development Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-board-development-plan/scripts/agent.py
+++ b/family-office/family-board-development-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Board Development Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Board Development Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-board-development-plan"
+SKILL_DISPLAY = "Family Board Development Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Board Development Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("current_board_members", "Current board members and roles?"),
+    ("skills_matrix_gaps", "Skills matrix gaps?"),
+    ("recruitment_targets", "Recruitment targets?"),
+    ("education_plan", "Education plan?"),
+    ("evaluation_cadence", "Evaluation cadence?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-board-development-plan/tests/test_smoke.py
+++ b/family-office/family-board-development-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Board Development Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-foundation-formation-plan/.env.example
+++ b/family-office/family-foundation-formation-plan/.env.example
@@ -1,0 +1,9 @@
+# Family Foundation Formation Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-foundation-formation-plan/SKILL.md
+++ b/family-office/family-foundation-formation-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: family-foundation-formation-plan
+display-name: "Family Foundation Formation Plan"
+description: "Produce a formation plan for a family foundation — legal structure, initial funding, governance, grant-making policy."
+---
+
+# Family Foundation Formation Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- family foundation
+- foundation formation
+- 501c3 plan
+- private foundation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Foundation Formation Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-foundation-formation-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `foundation_name` — Proposed foundation name?
+- `initial_funding` — Initial funding amount?
+- `legal_structure` — Structure (private operating vs non-operating)?
+- `board_composition` — Board composition?
+- `grantmaking_policy` — Grantmaking policy?
+- `counsel` — Counsel firm?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-foundation-formation-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-foundation-formation-plan/requirements.txt
+++ b/family-office/family-foundation-formation-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Family Foundation Formation Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-foundation-formation-plan/scripts/agent.py
+++ b/family-office/family-foundation-formation-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Foundation Formation Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Foundation Formation Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-foundation-formation-plan"
+SKILL_DISPLAY = "Family Foundation Formation Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Foundation Formation Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("foundation_name", "Proposed foundation name?"),
+    ("initial_funding", "Initial funding amount?"),
+    ("legal_structure", "Structure (private operating vs non-operating)?"),
+    ("board_composition", "Board composition?"),
+    ("grantmaking_policy", "Grantmaking policy?"),
+    ("counsel", "Counsel firm?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-foundation-formation-plan/tests/test_smoke.py
+++ b/family-office/family-foundation-formation-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Foundation Formation Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-governance-charter/.env.example
+++ b/family-office/family-governance-charter/.env.example
@@ -1,0 +1,9 @@
+# Family Governance Charter — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-governance-charter/SKILL.md
+++ b/family-office/family-governance-charter/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: family-governance-charter
+display-name: "Family Governance Charter"
+description: "Produce a family governance charter — principles, decision-making bodies, roles, meeting cadence, conflict-resolution."
+---
+
+# Family Governance Charter
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- family governance
+- governance charter
+- family council charter
+- family rules
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Governance Charter`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-governance-charter/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `governance_principles` — Governance principles?
+- `bodies` — Governance bodies (council / board / committees)?
+- `roles` — Defined roles?
+- `meeting_cadence` — Meeting cadence?
+- `conflict_resolution` — Conflict-resolution process?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-governance-charter"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-governance-charter/requirements.txt
+++ b/family-office/family-governance-charter/requirements.txt
@@ -1,0 +1,4 @@
+# Family Governance Charter
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-governance-charter/scripts/agent.py
+++ b/family-office/family-governance-charter/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Governance Charter skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Governance Charter as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-governance-charter"
+SKILL_DISPLAY = "Family Governance Charter"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Governance Charter"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("governance_principles", "Governance principles?"),
+    ("bodies", "Governance bodies (council / board / committees)?"),
+    ("roles", "Defined roles?"),
+    ("meeting_cadence", "Meeting cadence?"),
+    ("conflict_resolution", "Conflict-resolution process?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-governance-charter/tests/test_smoke.py
+++ b/family-office/family-governance-charter/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Governance Charter skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-meeting-agenda-minutes-template/.env.example
+++ b/family-office/family-meeting-agenda-minutes-template/.env.example
@@ -1,0 +1,9 @@
+# Family Meeting Agenda & Minutes Template — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-meeting-agenda-minutes-template/SKILL.md
+++ b/family-office/family-meeting-agenda-minutes-template/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: family-meeting-agenda-minutes-template
+display-name: "Family Meeting Agenda & Minutes Template"
+description: "Produce an agenda and minutes template for a recurring family meeting — attendees, agenda items, decisions, action items."
+---
+
+# Family Meeting Agenda & Minutes Template
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- family meeting agenda
+- meeting minutes template
+- family council agenda
+- family meeting prep
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Meeting Agenda & Minutes Template`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-meeting-agenda-minutes-template/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `meeting_type` — Meeting type (council / board / family assembly)?
+- `cadence` — Cadence?
+- `standing_agenda_items` — Standing agenda items?
+- `attendees` — Typical attendees?
+- `decision_record_format` — Decision record format?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-meeting-agenda-minutes-template"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-meeting-agenda-minutes-template/requirements.txt
+++ b/family-office/family-meeting-agenda-minutes-template/requirements.txt
@@ -1,0 +1,4 @@
+# Family Meeting Agenda & Minutes Template
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
+++ b/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Meeting Agenda & Minutes Template skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Meeting Agenda & Minutes Template as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-meeting-agenda-minutes-template"
+SKILL_DISPLAY = "Family Meeting Agenda & Minutes Template"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Meeting Agenda & Minutes Template"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("meeting_type", "Meeting type (council / board / family assembly)?"),
+    ("cadence", "Cadence?"),
+    ("standing_agenda_items", "Standing agenda items?"),
+    ("attendees", "Typical attendees?"),
+    ("decision_record_format", "Decision record format?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-meeting-agenda-minutes-template/tests/test_smoke.py
+++ b/family-office/family-meeting-agenda-minutes-template/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Meeting Agenda & Minutes Template skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-mission-statement/.env.example
+++ b/family-office/family-mission-statement/.env.example
@@ -1,0 +1,9 @@
+# Family Mission Statement — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-mission-statement/SKILL.md
+++ b/family-office/family-mission-statement/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: family-mission-statement
+display-name: "Family Mission Statement"
+description: "Produce a family mission statement — values, purpose, principles, and aspirations."
+---
+
+# Family Mission Statement
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- family mission
+- write mission statement
+- family values statement
+- family purpose
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Mission Statement`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-mission-statement/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `core_values` — Three to five core values?
+- `purpose_statement` — Family's purpose in one sentence?
+- `guiding_principles` — Guiding principles across generations?
+- `aspirations` — Aspirations for the next 10-30 years?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-mission-statement"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-mission-statement/requirements.txt
+++ b/family-office/family-mission-statement/requirements.txt
@@ -1,0 +1,4 @@
+# Family Mission Statement
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-mission-statement/scripts/agent.py
+++ b/family-office/family-mission-statement/scripts/agent.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Mission Statement skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Mission Statement as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-mission-statement"
+SKILL_DISPLAY = "Family Mission Statement"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Mission Statement"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("core_values", "Three to five core values?"),
+    ("purpose_statement", "Family's purpose in one sentence?"),
+    ("guiding_principles", "Guiding principles across generations?"),
+    ("aspirations", "Aspirations for the next 10-30 years?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-mission-statement/tests/test_smoke.py
+++ b/family-office/family-mission-statement/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Mission Statement skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-philanthropy-strategic-plan/.env.example
+++ b/family-office/family-philanthropy-strategic-plan/.env.example
@@ -1,0 +1,9 @@
+# Family Philanthropy Strategic Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-philanthropy-strategic-plan/SKILL.md
+++ b/family-office/family-philanthropy-strategic-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: family-philanthropy-strategic-plan
+display-name: "Family Philanthropy Strategic Plan"
+description: "Produce a strategic philanthropic plan — mission, causes, giving vehicles, budget, metrics, family engagement."
+---
+
+# Family Philanthropy Strategic Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- philanthropy plan
+- family giving strategy
+- charitable plan
+- philanthropic budget
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Philanthropy Strategic Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-philanthropy-strategic-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `mission` — Philanthropic mission statement?
+- `priority_causes` — Priority causes?
+- `annual_giving_budget` — Annual giving budget?
+- `giving_vehicles` — Giving vehicles (DAF / foundation / direct / CLT)?
+- `metrics` — Metrics for evaluating grants?
+- `family_engagement` — Family engagement model?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-philanthropy-strategic-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-philanthropy-strategic-plan/requirements.txt
+++ b/family-office/family-philanthropy-strategic-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Family Philanthropy Strategic Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-philanthropy-strategic-plan/scripts/agent.py
+++ b/family-office/family-philanthropy-strategic-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Philanthropy Strategic Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Philanthropy Strategic Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-philanthropy-strategic-plan"
+SKILL_DISPLAY = "Family Philanthropy Strategic Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Philanthropy Strategic Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("mission", "Philanthropic mission statement?"),
+    ("priority_causes", "Priority causes?"),
+    ("annual_giving_budget", "Annual giving budget?"),
+    ("giving_vehicles", "Giving vehicles (DAF / foundation / direct / CLT)?"),
+    ("metrics", "Metrics for evaluating grants?"),
+    ("family_engagement", "Family engagement model?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-philanthropy-strategic-plan/tests/test_smoke.py
+++ b/family-office/family-philanthropy-strategic-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Philanthropy Strategic Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/family-risk-management-plan/.env.example
+++ b/family-office/family-risk-management-plan/.env.example
@@ -1,0 +1,9 @@
+# Family Risk Management Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/family-risk-management-plan/SKILL.md
+++ b/family-office/family-risk-management-plan/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: family-risk-management-plan
+display-name: "Family Risk Management Plan"
+description: "Produce a family risk management plan covering cyber, personal security, travel security, reputational risk, and business-continuity. Example: an international trip to a higher-risk region."
+---
+
+# Family Risk Management Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- family risk management
+- cyber risk plan
+- travel security plan
+- Egypt travel security
+- family security
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Family Risk Management Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/family-risk-management-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `risk_categories_in_scope` — Risk categories in scope?
+- `cyber_posture` — Cyber posture (endpoint, identity, backup)?
+- `travel_risks` — Upcoming travel with risk profile?
+- `reputational_exposures` — Reputational exposures?
+- `provider_roster` — Providers under retainer (EP, cyber, crisis PR)?
+- `business_continuity` — Business-continuity arrangements?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"family-risk-management-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/family-risk-management-plan/requirements.txt
+++ b/family-office/family-risk-management-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Family Risk Management Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/family-risk-management-plan/scripts/agent.py
+++ b/family-office/family-risk-management-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Family Risk Management Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Family Risk Management Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "family-risk-management-plan"
+SKILL_DISPLAY = "Family Risk Management Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Family Risk Management Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("risk_categories_in_scope", "Risk categories in scope?"),
+    ("cyber_posture", "Cyber posture (endpoint, identity, backup)?"),
+    ("travel_risks", "Upcoming travel with risk profile?"),
+    ("reputational_exposures", "Reputational exposures?"),
+    ("provider_roster", "Providers under retainer (EP, cyber, crisis PR)?"),
+    ("business_continuity", "Business-continuity arrangements?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/family-risk-management-plan/tests/test_smoke.py
+++ b/family-office/family-risk-management-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Family Risk Management Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/healthcare-proxy-living-will-checklist/.env.example
+++ b/family-office/healthcare-proxy-living-will-checklist/.env.example
@@ -1,0 +1,9 @@
+# Healthcare Proxy & Living Will Checklist — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/healthcare-proxy-living-will-checklist/SKILL.md
+++ b/family-office/healthcare-proxy-living-will-checklist/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: healthcare-proxy-living-will-checklist
+display-name: "Healthcare Proxy & Living Will Checklist"
+description: "Produce a checklist for healthcare proxy and living will documents — agents, scope, end-of-life directives, HIPAA authorizations."
+---
+
+# Healthcare Proxy & Living Will Checklist
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- healthcare proxy
+- living will
+- advance directive
+- medical power of attorney
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Healthcare Proxy & Living Will Checklist`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/healthcare-proxy-living-will-checklist/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `agent_primary` — Primary healthcare agent?
+- `agent_alternate` — Alternate agent?
+- `end_of_life_directives` — End-of-life directives (resuscitation, life support)?
+- `organ_donation_preference` — Organ donation preference?
+- `hipaa_authorized_persons` — HIPAA-authorized persons?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"healthcare-proxy-living-will-checklist"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/healthcare-proxy-living-will-checklist/requirements.txt
+++ b/family-office/healthcare-proxy-living-will-checklist/requirements.txt
@@ -1,0 +1,4 @@
+# Healthcare Proxy & Living Will Checklist
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
+++ b/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Healthcare Proxy & Living Will Checklist skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Healthcare Proxy & Living Will Checklist as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "healthcare-proxy-living-will-checklist"
+SKILL_DISPLAY = "Healthcare Proxy & Living Will Checklist"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Healthcare Proxy & Living Will Checklist"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("agent_primary", "Primary healthcare agent?"),
+    ("agent_alternate", "Alternate agent?"),
+    ("end_of_life_directives", "End-of-life directives (resuscitation, life support)?"),
+    ("organ_donation_preference", "Organ donation preference?"),
+    ("hipaa_authorized_persons", "HIPAA-authorized persons?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/healthcare-proxy-living-will-checklist/tests/test_smoke.py
+++ b/family-office/healthcare-proxy-living-will-checklist/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Healthcare Proxy & Living Will Checklist skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/insurance-coverage-review-worksheet/.env.example
+++ b/family-office/insurance-coverage-review-worksheet/.env.example
@@ -1,0 +1,9 @@
+# Insurance Coverage Review Worksheet — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/insurance-coverage-review-worksheet/SKILL.md
+++ b/family-office/insurance-coverage-review-worksheet/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: insurance-coverage-review-worksheet
+display-name: "Insurance Coverage Review Worksheet"
+description: "Produce a worksheet reviewing all insurance coverage — health, life, property, auto/marine, liability, umbrella, casualty. Captures policies in force, gaps, and renewal dates."
+---
+
+# Insurance Coverage Review Worksheet
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- insurance review
+- coverage review
+- policy audit
+- insurance worksheet
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Insurance Coverage Review Worksheet`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/insurance-coverage-review-worksheet/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `coverage_types_in_scope` — Coverage types in scope (comma-separated)?
+- `carriers_in_force` — Carriers in force?
+- `known_gaps` — Known gaps in coverage?
+- `renewal_dates_near_term` — Near-term renewal dates?
+- `broker_relationship` — Primary insurance broker?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"insurance-coverage-review-worksheet"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/insurance-coverage-review-worksheet/requirements.txt
+++ b/family-office/insurance-coverage-review-worksheet/requirements.txt
@@ -1,0 +1,4 @@
+# Insurance Coverage Review Worksheet
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/insurance-coverage-review-worksheet/scripts/agent.py
+++ b/family-office/insurance-coverage-review-worksheet/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Insurance Coverage Review Worksheet skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Insurance Coverage Review Worksheet as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "insurance-coverage-review-worksheet"
+SKILL_DISPLAY = "Insurance Coverage Review Worksheet"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Insurance Coverage Review Worksheet"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("coverage_types_in_scope", "Coverage types in scope (comma-separated)?"),
+    ("carriers_in_force", "Carriers in force?"),
+    ("known_gaps", "Known gaps in coverage?"),
+    ("renewal_dates_near_term", "Near-term renewal dates?"),
+    ("broker_relationship", "Primary insurance broker?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/insurance-coverage-review-worksheet/tests/test_smoke.py
+++ b/family-office/insurance-coverage-review-worksheet/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Insurance Coverage Review Worksheet skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/insurance-procurement-framework/.env.example
+++ b/family-office/insurance-procurement-framework/.env.example
@@ -1,0 +1,9 @@
+# Insurance Procurement Framework — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/insurance-procurement-framework/SKILL.md
+++ b/family-office/insurance-procurement-framework/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: insurance-procurement-framework
+display-name: "Insurance Procurement Framework"
+description: "Produce a procurement framework for acquiring new insurance coverage — factors to consider, broker RFP structure, policy-terms checklist."
+---
+
+# Insurance Procurement Framework
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- insurance procurement
+- buy insurance
+- insurance RFP
+- coverage procurement factors
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Insurance Procurement Framework`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/insurance-procurement-framework/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `coverage_goal` — Coverage goal (what risk is being hedged)?
+- `asset_or_exposure_size` — Asset or exposure size?
+- `broker_candidates` — Broker candidates?
+- `key_policy_terms` — Key policy terms of interest?
+- `target_premium_range` — Target premium range?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"insurance-procurement-framework"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/insurance-procurement-framework/requirements.txt
+++ b/family-office/insurance-procurement-framework/requirements.txt
@@ -1,0 +1,4 @@
+# Insurance Procurement Framework
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/insurance-procurement-framework/scripts/agent.py
+++ b/family-office/insurance-procurement-framework/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Insurance Procurement Framework skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Insurance Procurement Framework as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "insurance-procurement-framework"
+SKILL_DISPLAY = "Insurance Procurement Framework"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Insurance Procurement Framework"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("coverage_goal", "Coverage goal (what risk is being hedged)?"),
+    ("asset_or_exposure_size", "Asset or exposure size?"),
+    ("broker_candidates", "Broker candidates?"),
+    ("key_policy_terms", "Key policy terms of interest?"),
+    ("target_premium_range", "Target premium range?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/insurance-procurement-framework/tests/test_smoke.py
+++ b/family-office/insurance-procurement-framework/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Insurance Procurement Framework skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/investment-operations-review-checklist/.env.example
+++ b/family-office/investment-operations-review-checklist/.env.example
@@ -1,0 +1,9 @@
+# Investment Operations Review Checklist — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/investment-operations-review-checklist/SKILL.md
+++ b/family-office/investment-operations-review-checklist/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: investment-operations-review-checklist
+display-name: "Investment Operations Review Checklist"
+description: "Produce a checklist for an ongoing investment operations review — custody, reconciliation, fee verification, performance reporting."
+---
+
+# Investment Operations Review Checklist
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- investment operations review
+- ops review
+- custody check
+- reconciliation review
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Investment Operations Review Checklist`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/investment-operations-review-checklist/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `review_period` — Review period (e.g. "2026 H1")?
+- `custodians_in_scope` — Custodians in scope?
+- `reporting_source` — Reporting source of truth (Addepar / Masttro / Eton)?
+- `fee_schedule_source` — Fee schedule source document?
+- `performance_benchmarks` — Performance benchmarks used?
+- `open_exceptions` — Open operational exceptions to resolve?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"investment-operations-review-checklist"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/investment-operations-review-checklist/requirements.txt
+++ b/family-office/investment-operations-review-checklist/requirements.txt
@@ -1,0 +1,4 @@
+# Investment Operations Review Checklist
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/investment-operations-review-checklist/scripts/agent.py
+++ b/family-office/investment-operations-review-checklist/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Investment Operations Review Checklist skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Investment Operations Review Checklist as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "investment-operations-review-checklist"
+SKILL_DISPLAY = "Investment Operations Review Checklist"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Investment Operations Review Checklist"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("review_period", "Review period (e.g. \"2026 H1\")?"),
+    ("custodians_in_scope", "Custodians in scope?"),
+    ("reporting_source", "Reporting source of truth (Addepar / Masttro / Eton)?"),
+    ("fee_schedule_source", "Fee schedule source document?"),
+    ("performance_benchmarks", "Performance benchmarks used?"),
+    ("open_exceptions", "Open operational exceptions to resolve?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/investment-operations-review-checklist/tests/test_smoke.py
+++ b/family-office/investment-operations-review-checklist/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Investment Operations Review Checklist skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/legacy-preservation-router/DISPATCH.yml
+++ b/family-office/legacy-preservation-router/DISPATCH.yml
@@ -1,0 +1,120 @@
+- skill: family-office-estate-plan-summary-memo
+  artifact: "Estate Plan Summary Memo"
+  triggers:
+    - "estate plan summary"
+    - "estate planning memo"
+    - "estate overview"
+    - "estate structure"
+- skill: family-office-trust-selection-memo
+  artifact: "Trust Selection Memo"
+  triggers:
+    - "trust selection"
+    - "which trust"
+    - "compare trust types"
+    - "trust recommendation"
+- skill: family-office-will-drafting-checklist
+  artifact: "Will Drafting Checklist"
+  triggers:
+    - "will drafting"
+    - "update will"
+    - "will checklist"
+    - "testator checklist"
+- skill: family-office-healthcare-proxy-living-will-checklist
+  artifact: "Healthcare Proxy & Living Will Checklist"
+  triggers:
+    - "healthcare proxy"
+    - "living will"
+    - "advance directive"
+    - "medical power of attorney"
+- skill: family-office-private-trust-company-formation-plan
+  artifact: "Private Trust Company Formation Plan"
+  triggers:
+    - "private trust company"
+    - "PTC formation"
+    - "family PTC plan"
+    - "PTC jurisdiction"
+- skill: family-office-trust-situs-selection-memo
+  artifact: "Trust Situs Selection Memo"
+  triggers:
+    - "trust situs"
+    - "situs selection"
+    - "jurisdiction comparison"
+    - "where to form trust"
+- skill: family-office-family-philanthropy-strategic-plan
+  artifact: "Family Philanthropy Strategic Plan"
+  triggers:
+    - "philanthropy plan"
+    - "family giving strategy"
+    - "charitable plan"
+    - "philanthropic budget"
+- skill: family-office-family-mission-statement
+  artifact: "Family Mission Statement"
+  triggers:
+    - "family mission"
+    - "write mission statement"
+    - "family values statement"
+    - "family purpose"
+- skill: family-office-family-foundation-formation-plan
+  artifact: "Family Foundation Formation Plan"
+  triggers:
+    - "family foundation"
+    - "foundation formation"
+    - "501c3 plan"
+    - "private foundation"
+- skill: family-office-charitable-trust-selection-memo
+  artifact: "Charitable Trust Selection Memo"
+  triggers:
+    - "charitable trust"
+    - "CRUT CLT comparison"
+    - "charitable remainder trust"
+    - "charitable lead trust"
+- skill: family-office-family-governance-charter
+  artifact: "Family Governance Charter"
+  triggers:
+    - "family governance"
+    - "governance charter"
+    - "family council charter"
+    - "family rules"
+- skill: family-office-family-board-development-plan
+  artifact: "Family Board Development Plan"
+  triggers:
+    - "board development"
+    - "family board plan"
+    - "board skills matrix"
+    - "board recruitment"
+- skill: family-office-succession-planning-memo
+  artifact: "Succession Planning Memo"
+  triggers:
+    - "succession planning"
+    - "successor plan"
+    - "leadership transition"
+    - "ownership succession"
+- skill: family-office-family-meeting-agenda-minutes-template
+  artifact: "Family Meeting Agenda & Minutes Template"
+  triggers:
+    - "family meeting agenda"
+    - "meeting minutes template"
+    - "family council agenda"
+    - "family meeting prep"
+- skill: family-office-community-engagement-plan
+  artifact: "Community Engagement Plan"
+  triggers:
+    - "community engagement"
+    - "civic involvement plan"
+    - "nonprofit board service"
+    - "public engagement plan"
+- skill: family-office-next-generation-education-curriculum
+  artifact: "Next-Generation Education Curriculum"
+  triggers:
+    - "next generation curriculum"
+    - "kids curriculum"
+    - "family education plan"
+    - "rising generation education"
+- skill: family-office-family-risk-management-plan
+  artifact: "Family Risk Management Plan"
+  triggers:
+    - "family risk management"
+    - "cyber risk plan"
+    - "travel security plan"
+    - "Egypt travel security"
+    - "family security"

--- a/family-office/legacy-preservation-router/SKILL.md
+++ b/family-office/legacy-preservation-router/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: legacy-preservation-router
+display-name: "Family Office — Legacy Preservation Router"
+description: "Pillar router for Legacy Preservation. Classifies a natural-language advisor ask into the matching leaf skill inside the Legacy Preservation pillar. Catalog rebuild tracked in issue #427."
+---
+
+# Family Office — Legacy Preservation Router
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active.
+
+## When to Use
+
+Invoke when the advisor asks a natural-language question about **Legacy Preservation**
+without naming a specific leaf skill. Representative phrases:
+
+- estate plan summary
+- estate planning memo
+- trust selection
+- which trust
+- will drafting
+- update will
+- healthcare proxy
+- living will
+- private trust company
+- PTC formation
+
+## Dispatch Table
+
+This router maps advisor prompts to the matching leaf skill inside the
+Legacy Preservation pillar. The table is embedded here (authoring source of truth)
+and mirrored in `DISPATCH.yml` for programmatic consumers.
+
+| Leaf slug | Artifact | Example triggers |
+|---|---|---|
+| `family-office-estate-plan-summary-memo` | Estate Plan Summary Memo | estate plan summary; estate planning memo; estate overview; estate structure |
+| `family-office-trust-selection-memo` | Trust Selection Memo | trust selection; which trust; compare trust types; trust recommendation |
+| `family-office-will-drafting-checklist` | Will Drafting Checklist | will drafting; update will; will checklist; testator checklist |
+| `family-office-healthcare-proxy-living-will-checklist` | Healthcare Proxy & Living Will Checklist | healthcare proxy; living will; advance directive; medical power of attorney |
+| `family-office-private-trust-company-formation-plan` | Private Trust Company Formation Plan | private trust company; PTC formation; family PTC plan; PTC jurisdiction |
+| `family-office-trust-situs-selection-memo` | Trust Situs Selection Memo | trust situs; situs selection; jurisdiction comparison; where to form trust |
+| `family-office-family-philanthropy-strategic-plan` | Family Philanthropy Strategic Plan | philanthropy plan; family giving strategy; charitable plan; philanthropic budget |
+| `family-office-family-mission-statement` | Family Mission Statement | family mission; write mission statement; family values statement; family purpose |
+| `family-office-family-foundation-formation-plan` | Family Foundation Formation Plan | family foundation; foundation formation; 501c3 plan; private foundation |
+| `family-office-charitable-trust-selection-memo` | Charitable Trust Selection Memo | charitable trust; CRUT CLT comparison; charitable remainder trust; charitable lead trust |
+| `family-office-family-governance-charter` | Family Governance Charter | family governance; governance charter; family council charter; family rules |
+| `family-office-family-board-development-plan` | Family Board Development Plan | board development; family board plan; board skills matrix; board recruitment |
+| `family-office-succession-planning-memo` | Succession Planning Memo | succession planning; successor plan; leadership transition; ownership succession |
+| `family-office-family-meeting-agenda-minutes-template` | Family Meeting Agenda & Minutes Template | family meeting agenda; meeting minutes template; family council agenda; family meeting prep |
+| `family-office-community-engagement-plan` | Community Engagement Plan | community engagement; civic involvement plan; nonprofit board service; public engagement plan |
+| `family-office-next-generation-education-curriculum` | Next-Generation Education Curriculum | next generation curriculum; kids curriculum; family education plan; rising generation education |
+| `family-office-family-risk-management-plan` | Family Risk Management Plan | family risk management; cyber risk plan; travel security plan; Egypt travel security; family security |
+
+## Workflow
+
+1. The router reads the advisor's prompt.
+2. It matches trigger phrases to the leaf skill whose artifact best fits.
+3. It confirms the match with the advisor if confidence is borderline
+   ("Nearest skill is X — run it?").
+4. If no leaf matches, it returns a clear "not built in this iteration"
+   message and suggests logging the ask as an open question.
+
+## Non-goals for this iteration
+
+This router does not programmatically invoke the leaf skill's Python agent.
+Cross-skill invocation is handled by the Claude Code harness: the router's
+job is to name the right leaf so the harness invokes it. The programmatic
+orchestration pipeline ships under the execution-pipeline PR tracked in
+issue #427.
+
+## Composition
+
+If the advisor's ask implies more than one leaf artifact (example: "exit the
+business AND plan the philanthropic vehicle that catches the proceeds"), the
+router proposes a two-leaf sequence with a shared interview that minimizes
+duplicate questions.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/leisure-asset-ownership-comparison/.env.example
+++ b/family-office/leisure-asset-ownership-comparison/.env.example
@@ -1,0 +1,9 @@
+# Leisure Asset Ownership Comparison — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/leisure-asset-ownership-comparison/SKILL.md
+++ b/family-office/leisure-asset-ownership-comparison/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: leisure-asset-ownership-comparison
+display-name: "Leisure Asset Ownership Comparison"
+description: "Produce a model comparing ownership options for a leisure asset (full ownership vs fractional vs chartered). Example: jet vs NetJets."
+---
+
+# Leisure Asset Ownership Comparison
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- jet vs NetJets
+- leisure asset comparison
+- fractional vs full ownership
+- yacht ownership model
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Leisure Asset Ownership Comparison`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/leisure-asset-ownership-comparison/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `asset_type` — Asset type (jet / yacht / car / wine)?
+- `expected_usage_hours` — Expected annual usage (hours or days)?
+- `full_ownership_cost_estimate` — Full ownership cost estimate (acquisition + annual carry)?
+- `fractional_cost_estimate` — Fractional / chartered cost estimate?
+- `resale_expectation` — Resale expectation (years, residual)?
+- `non_financial_factors` — Non-financial factors that matter?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"leisure-asset-ownership-comparison"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/leisure-asset-ownership-comparison/requirements.txt
+++ b/family-office/leisure-asset-ownership-comparison/requirements.txt
@@ -1,0 +1,4 @@
+# Leisure Asset Ownership Comparison
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/leisure-asset-ownership-comparison/scripts/agent.py
+++ b/family-office/leisure-asset-ownership-comparison/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Leisure Asset Ownership Comparison skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Leisure Asset Ownership Comparison as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "leisure-asset-ownership-comparison"
+SKILL_DISPLAY = "Leisure Asset Ownership Comparison"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Leisure Asset Ownership Comparison"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("asset_type", "Asset type (jet / yacht / car / wine)?"),
+    ("expected_usage_hours", "Expected annual usage (hours or days)?"),
+    ("full_ownership_cost_estimate", "Full ownership cost estimate (acquisition + annual carry)?"),
+    ("fractional_cost_estimate", "Fractional / chartered cost estimate?"),
+    ("resale_expectation", "Resale expectation (years, residual)?"),
+    ("non_financial_factors", "Non-financial factors that matter?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/leisure-asset-ownership-comparison/tests/test_smoke.py
+++ b/family-office/leisure-asset-ownership-comparison/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Leisure Asset Ownership Comparison skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/long-term-portfolio-strategy-plan/.env.example
+++ b/family-office/long-term-portfolio-strategy-plan/.env.example
@@ -1,0 +1,9 @@
+# Long-Term Portfolio Strategy Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/long-term-portfolio-strategy-plan/SKILL.md
+++ b/family-office/long-term-portfolio-strategy-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: long-term-portfolio-strategy-plan
+display-name: "Long-Term Portfolio Strategy Plan"
+description: "Produce a long-term portfolio strategy plan for a single family office. Captures time horizon, liquidity needs, return targets, risk tolerance, and constraints; outputs a memo an advisor hands to the principal."
+---
+
+# Long-Term Portfolio Strategy Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- long-term portfolio strategy
+- investment policy statement
+- portfolio plan
+- long horizon allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Long-Term Portfolio Strategy Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/long-term-portfolio-strategy-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `time_horizon` — Time horizon (years) for the strategy?
+- `liquidity_needs` — Annual liquidity needs (range, e.g. "$2M-$4M")?
+- `return_target` — Real return target (e.g. "CPI + 4%")?
+- `risk_tolerance` — Risk tolerance — conservative / moderate / aggressive?
+- `key_constraints` — Key constraints (concentrated positions, tax lots, ESG preferences)?
+- `review_cadence` — Review cadence (annual / semi-annual / quarterly)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"long-term-portfolio-strategy-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/long-term-portfolio-strategy-plan/requirements.txt
+++ b/family-office/long-term-portfolio-strategy-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Long-Term Portfolio Strategy Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
+++ b/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Long-Term Portfolio Strategy Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Long-Term Portfolio Strategy Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "long-term-portfolio-strategy-plan"
+SKILL_DISPLAY = "Long-Term Portfolio Strategy Plan"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Long-Term Portfolio Strategy Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("time_horizon", "Time horizon (years) for the strategy?"),
+    ("liquidity_needs", "Annual liquidity needs (range, e.g. \"$2M-$4M\")?"),
+    ("return_target", "Real return target (e.g. \"CPI + 4%\")?"),
+    ("risk_tolerance", "Risk tolerance — conservative / moderate / aggressive?"),
+    ("key_constraints", "Key constraints (concentrated positions, tax lots, ESG preferences)?"),
+    ("review_cadence", "Review cadence (annual / semi-annual / quarterly)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/long-term-portfolio-strategy-plan/tests/test_smoke.py
+++ b/family-office/long-term-portfolio-strategy-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Long-Term Portfolio Strategy Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-direct-co-investment/.env.example
+++ b/family-office/manager-dd-direct-co-investment/.env.example
@@ -1,0 +1,9 @@
+# Direct / Co-Investment DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-direct-co-investment/SKILL.md
+++ b/family-office/manager-dd-direct-co-investment/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: manager-dd-direct-co-investment
+display-name: "Direct / Co-Investment DD Memo"
+description: "Produce a due diligence memo for a direct or co-investment opportunity alongside a sponsor. Captures company, thesis, cap table, terms, and concentration risk."
+---
+
+# Direct / Co-Investment DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- direct investment DD
+- co-investment memo
+- SPV memo
+- direct co-invest
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Direct / Co-Investment DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-direct-co-investment/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `company_name` — Company name?
+- `sponsor` — Lead sponsor?
+- `round_type` — Round type (Series X / secondary / co-invest SPV)?
+- `check_size` — Proposed check size?
+- `valuation` — Valuation?
+- `concentration_after` — Portfolio concentration after this investment (%)?
+- `key_terms` — Key terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-direct-co-investment"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-direct-co-investment/requirements.txt
+++ b/family-office/manager-dd-direct-co-investment/requirements.txt
@@ -1,0 +1,4 @@
+# Direct / Co-Investment DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-direct-co-investment/scripts/agent.py
+++ b/family-office/manager-dd-direct-co-investment/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Direct / Co-Investment DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Direct / Co-Investment DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-direct-co-investment"
+SKILL_DISPLAY = "Direct / Co-Investment DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Direct / Co-Investment DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("company_name", "Company name?"),
+    ("sponsor", "Lead sponsor?"),
+    ("round_type", "Round type (Series X / secondary / co-invest SPV)?"),
+    ("check_size", "Proposed check size?"),
+    ("valuation", "Valuation?"),
+    ("concentration_after", "Portfolio concentration after this investment (%)?"),
+    ("key_terms", "Key terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-direct-co-investment/tests/test_smoke.py
+++ b/family-office/manager-dd-direct-co-investment/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Direct / Co-Investment DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-esg-impact/.env.example
+++ b/family-office/manager-dd-esg-impact/.env.example
@@ -1,0 +1,9 @@
+# ESG / Impact Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-esg-impact/SKILL.md
+++ b/family-office/manager-dd-esg-impact/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: manager-dd-esg-impact
+display-name: "ESG / Impact Manager DD Memo"
+description: "Produce a due diligence memo for a prospective ESG or impact-investing manager. Captures mandate, impact metrics, concessionary-return posture, and reporting."
+---
+
+# ESG / Impact Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- ESG manager DD
+- impact fund due diligence
+- impact investing memo
+- ESG allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `ESG / Impact Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-esg-impact/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — Manager name?
+- `mandate` — Mandate (environment / social / governance / blended)?
+- `impact_metrics` — Impact metrics tracked?
+- `concessionary_posture` — Concessionary-return posture?
+- `reporting_cadence` — Impact reporting cadence?
+- `fee_terms` — Fee terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-esg-impact"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-esg-impact/requirements.txt
+++ b/family-office/manager-dd-esg-impact/requirements.txt
@@ -1,0 +1,4 @@
+# ESG / Impact Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-esg-impact/scripts/agent.py
+++ b/family-office/manager-dd-esg-impact/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the ESG / Impact Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the ESG / Impact Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-esg-impact"
+SKILL_DISPLAY = "ESG / Impact Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "ESG / Impact Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "Manager name?"),
+    ("mandate", "Mandate (environment / social / governance / blended)?"),
+    ("impact_metrics", "Impact metrics tracked?"),
+    ("concessionary_posture", "Concessionary-return posture?"),
+    ("reporting_cadence", "Impact reporting cadence?"),
+    ("fee_terms", "Fee terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-esg-impact/tests/test_smoke.py
+++ b/family-office/manager-dd-esg-impact/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the ESG / Impact Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-hedge-fund/.env.example
+++ b/family-office/manager-dd-hedge-fund/.env.example
@@ -1,0 +1,9 @@
+# Hedge Fund Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-hedge-fund/SKILL.md
+++ b/family-office/manager-dd-hedge-fund/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: manager-dd-hedge-fund
+display-name: "Hedge Fund Manager DD Memo"
+description: "Produce a due diligence memo for a prospective hedge fund manager. Captures strategy, track record, drawdowns, gates, side pockets, and fee terms."
+---
+
+# Hedge Fund Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- hedge fund manager DD
+- hedge fund due diligence
+- HF allocation memo
+- evaluate hedge fund
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Hedge Fund Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-hedge-fund/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — Manager name?
+- `strategy` — Strategy (long/short, global macro, event-driven, etc.)?
+- `aum` — Fund AUM?
+- `inception` — Inception year?
+- `net_since_inception` — Net return since inception?
+- `max_drawdown` — Max drawdown observed?
+- `gate_lockup_terms` — Gate / lockup / side-pocket terms?
+- `fee_terms` — Fee terms (mgmt / perf / hurdle)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-hedge-fund"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-hedge-fund/requirements.txt
+++ b/family-office/manager-dd-hedge-fund/requirements.txt
@@ -1,0 +1,4 @@
+# Hedge Fund Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-hedge-fund/scripts/agent.py
+++ b/family-office/manager-dd-hedge-fund/scripts/agent.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Hedge Fund Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Hedge Fund Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-hedge-fund"
+SKILL_DISPLAY = "Hedge Fund Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Hedge Fund Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "Manager name?"),
+    ("strategy", "Strategy (long/short, global macro, event-driven, etc.)?"),
+    ("aum", "Fund AUM?"),
+    ("inception", "Inception year?"),
+    ("net_since_inception", "Net return since inception?"),
+    ("max_drawdown", "Max drawdown observed?"),
+    ("gate_lockup_terms", "Gate / lockup / side-pocket terms?"),
+    ("fee_terms", "Fee terms (mgmt / perf / hurdle)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-hedge-fund/tests/test_smoke.py
+++ b/family-office/manager-dd-hedge-fund/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Hedge Fund Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-private-debt/.env.example
+++ b/family-office/manager-dd-private-debt/.env.example
@@ -1,0 +1,9 @@
+# Private Debt Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-private-debt/SKILL.md
+++ b/family-office/manager-dd-private-debt/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: manager-dd-private-debt
+display-name: "Private Debt Manager DD Memo"
+description: "Produce a due diligence memo for a prospective private credit / private debt manager. Captures strategy, loss history, seniority, covenants, and yield profile."
+---
+
+# Private Debt Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- private debt DD
+- private credit manager
+- direct lending fund
+- private debt allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Private Debt Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-private-debt/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — Manager name?
+- `strategy` — Strategy (direct lending, mezz, distressed, specialty)?
+- `loss_rate_history` — Loss rate history?
+- `seniority_profile` — Typical seniority / security position?
+- `covenant_posture` — Covenant posture (covenant-lite vs tight)?
+- `expected_net_yield` — Expected net yield?
+- `fee_terms` — Fee terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-private-debt"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-private-debt/requirements.txt
+++ b/family-office/manager-dd-private-debt/requirements.txt
@@ -1,0 +1,4 @@
+# Private Debt Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-private-debt/scripts/agent.py
+++ b/family-office/manager-dd-private-debt/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Private Debt Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Private Debt Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-private-debt"
+SKILL_DISPLAY = "Private Debt Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Private Debt Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "Manager name?"),
+    ("strategy", "Strategy (direct lending, mezz, distressed, specialty)?"),
+    ("loss_rate_history", "Loss rate history?"),
+    ("seniority_profile", "Typical seniority / security position?"),
+    ("covenant_posture", "Covenant posture (covenant-lite vs tight)?"),
+    ("expected_net_yield", "Expected net yield?"),
+    ("fee_terms", "Fee terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-private-debt/tests/test_smoke.py
+++ b/family-office/manager-dd-private-debt/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Private Debt Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-private-equity/.env.example
+++ b/family-office/manager-dd-private-equity/.env.example
@@ -1,0 +1,9 @@
+# Private Equity Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-private-equity/SKILL.md
+++ b/family-office/manager-dd-private-equity/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: manager-dd-private-equity
+display-name: "Private Equity Manager DD Memo"
+description: "Produce a due diligence memo for a prospective private equity fund. Captures fund vintage, track record, sector focus, fee terms, and J-curve expectations."
+---
+
+# Private Equity Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- private equity manager DD
+- PE fund due diligence
+- buyout fund memo
+- PE allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Private Equity Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-private-equity/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — GP / manager name?
+- `fund_name` — Fund name / vintage?
+- `sector_focus` — Sector focus?
+- `fund_size` — Target fund size?
+- `prior_fund_tvpi` — Prior fund TVPI?
+- `prior_fund_dpi` — Prior fund DPI?
+- `fee_terms` — Fee terms (mgmt / carry / hurdle)?
+- `minimum_commit` — Minimum commitment size?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-private-equity"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-private-equity/requirements.txt
+++ b/family-office/manager-dd-private-equity/requirements.txt
@@ -1,0 +1,4 @@
+# Private Equity Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-private-equity/scripts/agent.py
+++ b/family-office/manager-dd-private-equity/scripts/agent.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Private Equity Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Private Equity Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-private-equity"
+SKILL_DISPLAY = "Private Equity Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Private Equity Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "GP / manager name?"),
+    ("fund_name", "Fund name / vintage?"),
+    ("sector_focus", "Sector focus?"),
+    ("fund_size", "Target fund size?"),
+    ("prior_fund_tvpi", "Prior fund TVPI?"),
+    ("prior_fund_dpi", "Prior fund DPI?"),
+    ("fee_terms", "Fee terms (mgmt / carry / hurdle)?"),
+    ("minimum_commit", "Minimum commitment size?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-private-equity/tests/test_smoke.py
+++ b/family-office/manager-dd-private-equity/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Private Equity Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-real-assets/.env.example
+++ b/family-office/manager-dd-real-assets/.env.example
@@ -1,0 +1,9 @@
+# Real Assets Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-real-assets/SKILL.md
+++ b/family-office/manager-dd-real-assets/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: manager-dd-real-assets
+display-name: "Real Assets Manager DD Memo"
+description: "Produce a due diligence memo for a prospective real assets manager (infrastructure, commodities, natural resources). Captures asset class, inflation-hedging profile, and yield."
+---
+
+# Real Assets Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- real assets manager DD
+- infrastructure fund
+- natural resources fund
+- commodities allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Real Assets Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-real-assets/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — Manager name?
+- `asset_class` — Asset class (infrastructure / commodities / natural resources)?
+- `inflation_hedge_profile` — Inflation-hedging profile?
+- `expected_yield` — Expected yield?
+- `liquidity_profile` — Liquidity profile / hold period?
+- `fee_terms` — Fee terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-real-assets"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-real-assets/requirements.txt
+++ b/family-office/manager-dd-real-assets/requirements.txt
@@ -1,0 +1,4 @@
+# Real Assets Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-real-assets/scripts/agent.py
+++ b/family-office/manager-dd-real-assets/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Real Assets Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Real Assets Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-real-assets"
+SKILL_DISPLAY = "Real Assets Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Real Assets Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "Manager name?"),
+    ("asset_class", "Asset class (infrastructure / commodities / natural resources)?"),
+    ("inflation_hedge_profile", "Inflation-hedging profile?"),
+    ("expected_yield", "Expected yield?"),
+    ("liquidity_profile", "Liquidity profile / hold period?"),
+    ("fee_terms", "Fee terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-real-assets/tests/test_smoke.py
+++ b/family-office/manager-dd-real-assets/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Real Assets Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-real-estate/.env.example
+++ b/family-office/manager-dd-real-estate/.env.example
@@ -1,0 +1,9 @@
+# Real Estate Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-real-estate/SKILL.md
+++ b/family-office/manager-dd-real-estate/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: manager-dd-real-estate
+display-name: "Real Estate Manager DD Memo"
+description: "Produce a due diligence memo for a prospective real estate fund. Captures property type, geography, cap rate, leverage, and NOI assumptions."
+---
+
+# Real Estate Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- real estate manager DD
+- RE fund due diligence
+- property fund memo
+- real estate allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Real Estate Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-real-estate/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — Manager name?
+- `property_type` — Property type (multifamily, industrial, office, retail, niche)?
+- `geography` — Geographic focus?
+- `target_cap_rate` — Target cap rate?
+- `leverage_policy` — Leverage policy?
+- `noi_growth_assumption` — NOI growth assumption?
+- `fee_terms` — Fee terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-real-estate"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-real-estate/requirements.txt
+++ b/family-office/manager-dd-real-estate/requirements.txt
@@ -1,0 +1,4 @@
+# Real Estate Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-real-estate/scripts/agent.py
+++ b/family-office/manager-dd-real-estate/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Real Estate Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Real Estate Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-real-estate"
+SKILL_DISPLAY = "Real Estate Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Real Estate Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "Manager name?"),
+    ("property_type", "Property type (multifamily, industrial, office, retail, niche)?"),
+    ("geography", "Geographic focus?"),
+    ("target_cap_rate", "Target cap rate?"),
+    ("leverage_policy", "Leverage policy?"),
+    ("noi_growth_assumption", "NOI growth assumption?"),
+    ("fee_terms", "Fee terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-real-estate/tests/test_smoke.py
+++ b/family-office/manager-dd-real-estate/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Real Estate Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/manager-dd-venture-capital/.env.example
+++ b/family-office/manager-dd-venture-capital/.env.example
@@ -1,0 +1,9 @@
+# Venture Capital Manager DD Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/manager-dd-venture-capital/SKILL.md
+++ b/family-office/manager-dd-venture-capital/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: manager-dd-venture-capital
+display-name: "Venture Capital Manager DD Memo"
+description: "Produce a due diligence memo for a prospective venture capital fund. Captures stage focus, sourcing model, portfolio construction, and prior-fund mark-ups."
+---
+
+# Venture Capital Manager DD Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- venture capital manager DD
+- VC fund due diligence
+- seed fund memo
+- VC allocation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Venture Capital Manager DD Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/manager-dd-venture-capital/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `manager_name` — GP name?
+- `fund_name` — Fund name / vintage?
+- `stage_focus` — Stage focus (pre-seed / seed / A / growth)?
+- `sector_focus` — Sector focus?
+- `portfolio_size_target` — Target portfolio size (number of companies)?
+- `prior_fund_mark_ups` — Prior fund mark-up history?
+- `fee_terms` — Fee terms?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"manager-dd-venture-capital"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/manager-dd-venture-capital/requirements.txt
+++ b/family-office/manager-dd-venture-capital/requirements.txt
@@ -1,0 +1,4 @@
+# Venture Capital Manager DD Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/manager-dd-venture-capital/scripts/agent.py
+++ b/family-office/manager-dd-venture-capital/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Venture Capital Manager DD Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Venture Capital Manager DD Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "manager-dd-venture-capital"
+SKILL_DISPLAY = "Venture Capital Manager DD Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Venture Capital Manager DD Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("manager_name", "GP name?"),
+    ("fund_name", "Fund name / vintage?"),
+    ("stage_focus", "Stage focus (pre-seed / seed / A / growth)?"),
+    ("sector_focus", "Sector focus?"),
+    ("portfolio_size_target", "Target portfolio size (number of companies)?"),
+    ("prior_fund_mark_ups", "Prior fund mark-up history?"),
+    ("fee_terms", "Fee terms?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/manager-dd-venture-capital/tests/test_smoke.py
+++ b/family-office/manager-dd-venture-capital/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Venture Capital Manager DD Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/new-business-diligence-memo/.env.example
+++ b/family-office/new-business-diligence-memo/.env.example
@@ -1,0 +1,9 @@
+# New Business Diligence Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/new-business-diligence-memo/SKILL.md
+++ b/family-office/new-business-diligence-memo/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: new-business-diligence-memo
+display-name: "New Business Diligence Memo"
+description: "Produce a diligence memo for a new business the principal is considering acquiring or starting. Captures thesis, unit economics, key risks, and recommended next steps."
+---
+
+# New Business Diligence Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- new business diligence
+- acquire business
+- evaluate new business
+- business investment memo
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `New Business Diligence Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/new-business-diligence-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `business_name` — Target business name?
+- `business_type` — Business type / sector?
+- `investment_size` — Expected investment size?
+- `thesis` — Thesis for the investment?
+- `key_risks` — Top 3 key risks?
+- `unit_economics` — Core unit economics (margin / payback / growth)?
+- `next_steps` — Next diligence steps required?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"new-business-diligence-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/new-business-diligence-memo/requirements.txt
+++ b/family-office/new-business-diligence-memo/requirements.txt
@@ -1,0 +1,4 @@
+# New Business Diligence Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/new-business-diligence-memo/scripts/agent.py
+++ b/family-office/new-business-diligence-memo/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the New Business Diligence Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the New Business Diligence Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "new-business-diligence-memo"
+SKILL_DISPLAY = "New Business Diligence Memo"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "New Business Diligence Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("business_name", "Target business name?"),
+    ("business_type", "Business type / sector?"),
+    ("investment_size", "Expected investment size?"),
+    ("thesis", "Thesis for the investment?"),
+    ("key_risks", "Top 3 key risks?"),
+    ("unit_economics", "Core unit economics (margin / payback / growth)?"),
+    ("next_steps", "Next diligence steps required?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/new-business-diligence-memo/tests/test_smoke.py
+++ b/family-office/new-business-diligence-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the New Business Diligence Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/next-generation-education-curriculum/.env.example
+++ b/family-office/next-generation-education-curriculum/.env.example
@@ -1,0 +1,9 @@
+# Next-Generation Education Curriculum — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/next-generation-education-curriculum/SKILL.md
+++ b/family-office/next-generation-education-curriculum/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: next-generation-education-curriculum
+display-name: "Next-Generation Education Curriculum"
+description: "Produce a curriculum for educating the next generation on family history, wealth, responsibility, and values. Includes modules, readings, and milestones."
+---
+
+# Next-Generation Education Curriculum
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- next generation curriculum
+- kids curriculum
+- family education plan
+- rising generation education
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Next-Generation Education Curriculum`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/next-generation-education-curriculum/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `learners` — Learners (ages and names)?
+- `themes` — Curriculum themes (history / financial literacy / philanthropy / values)?
+- `cadence` — Cadence (weekly / monthly / annual retreat)?
+- `milestones` — Key milestones and ages?
+- `outside_speakers` — Outside speakers / mentors desired?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"next-generation-education-curriculum"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/next-generation-education-curriculum/requirements.txt
+++ b/family-office/next-generation-education-curriculum/requirements.txt
@@ -1,0 +1,4 @@
+# Next-Generation Education Curriculum
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/next-generation-education-curriculum/scripts/agent.py
+++ b/family-office/next-generation-education-curriculum/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Next-Generation Education Curriculum skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Next-Generation Education Curriculum as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "next-generation-education-curriculum"
+SKILL_DISPLAY = "Next-Generation Education Curriculum"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Next-Generation Education Curriculum"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("learners", "Learners (ages and names)?"),
+    ("themes", "Curriculum themes (history / financial literacy / philanthropy / values)?"),
+    ("cadence", "Cadence (weekly / monthly / annual retreat)?"),
+    ("milestones", "Key milestones and ages?"),
+    ("outside_speakers", "Outside speakers / mentors desired?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/next-generation-education-curriculum/tests/test_smoke.py
+++ b/family-office/next-generation-education-curriculum/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Next-Generation Education Curriculum skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/password-management-setup-plan/.env.example
+++ b/family-office/password-management-setup-plan/.env.example
@@ -1,0 +1,9 @@
+# Password Management Setup Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/password-management-setup-plan/SKILL.md
+++ b/family-office/password-management-setup-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: password-management-setup-plan
+display-name: "Password Management Setup Plan"
+description: "Produce a password management setup plan — vault choice, account inventory, sharing model, 2FA, recovery."
+---
+
+# Password Management Setup Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- password manager setup
+- 1Password plan
+- credential vault
+- family password setup
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Password Management Setup Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/password-management-setup-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `vault_platform` — Vault platform (1Password / Bitwarden / other)?
+- `account_inventory_status` — Account inventory status?
+- `sharing_model` — Sharing model across family / staff?
+- `mfa_policy` — MFA policy?
+- `recovery_plan` — Recovery plan (emergency kit, trusted contact)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"password-management-setup-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/password-management-setup-plan/requirements.txt
+++ b/family-office/password-management-setup-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Password Management Setup Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/password-management-setup-plan/scripts/agent.py
+++ b/family-office/password-management-setup-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Password Management Setup Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Password Management Setup Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "password-management-setup-plan"
+SKILL_DISPLAY = "Password Management Setup Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Password Management Setup Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("vault_platform", "Vault platform (1Password / Bitwarden / other)?"),
+    ("account_inventory_status", "Account inventory status?"),
+    ("sharing_model", "Sharing model across family / staff?"),
+    ("mfa_policy", "MFA policy?"),
+    ("recovery_plan", "Recovery plan (emergency kit, trusted contact)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/password-management-setup-plan/tests/test_smoke.py
+++ b/family-office/password-management-setup-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Password Management Setup Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/portfolio-risk-register/.env.example
+++ b/family-office/portfolio-risk-register/.env.example
@@ -1,0 +1,9 @@
+# Portfolio Risk Register — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/portfolio-risk-register/SKILL.md
+++ b/family-office/portfolio-risk-register/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: portfolio-risk-register
+display-name: "Portfolio Risk Register"
+description: "Produce a portfolio risk register. Captures concentration risks, liquidity risks, counterparty risks, tax-lot risks, and mitigations."
+---
+
+# Portfolio Risk Register
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- portfolio risk
+- risk register
+- risk management memo
+- portfolio risks
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Portfolio Risk Register`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/portfolio-risk-register/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `concentration_exposures` — Top 3 concentration exposures and sizes?
+- `illiquid_pct` — Percentage of portfolio in illiquid positions?
+- `key_counterparties` — Key counterparties / custodians?
+- `material_tax_lots` — Material low-basis tax lots that constrain rebalancing?
+- `mitigations_in_place` — Mitigations already in place?
+- `open_risks` — Open unresolved risks?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"portfolio-risk-register"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/portfolio-risk-register/requirements.txt
+++ b/family-office/portfolio-risk-register/requirements.txt
@@ -1,0 +1,4 @@
+# Portfolio Risk Register
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/portfolio-risk-register/scripts/agent.py
+++ b/family-office/portfolio-risk-register/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Portfolio Risk Register skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Portfolio Risk Register as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "portfolio-risk-register"
+SKILL_DISPLAY = "Portfolio Risk Register"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Portfolio Risk Register"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("concentration_exposures", "Top 3 concentration exposures and sizes?"),
+    ("illiquid_pct", "Percentage of portfolio in illiquid positions?"),
+    ("key_counterparties", "Key counterparties / custodians?"),
+    ("material_tax_lots", "Material low-basis tax lots that constrain rebalancing?"),
+    ("mitigations_in_place", "Mitigations already in place?"),
+    ("open_risks", "Open unresolved risks?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/portfolio-risk-register/tests/test_smoke.py
+++ b/family-office/portfolio-risk-register/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Portfolio Risk Register skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/private-trust-company-formation-plan/.env.example
+++ b/family-office/private-trust-company-formation-plan/.env.example
@@ -1,0 +1,9 @@
+# Private Trust Company Formation Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/private-trust-company-formation-plan/SKILL.md
+++ b/family-office/private-trust-company-formation-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: private-trust-company-formation-plan
+display-name: "Private Trust Company Formation Plan"
+description: "Produce a formation plan for a private trust company — jurisdiction, capitalization, board, regulatory requirements."
+---
+
+# Private Trust Company Formation Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- private trust company
+- PTC formation
+- family PTC plan
+- PTC jurisdiction
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Private Trust Company Formation Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/private-trust-company-formation-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `preferred_jurisdiction` — Preferred jurisdiction (SD / NV / WY / TN)?
+- `expected_aum` — Expected AUM under the PTC?
+- `board_composition` — Board composition (family / independent / professional)?
+- `capitalization_plan` — Capitalization plan?
+- `counsel` — Counsel firm?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"private-trust-company-formation-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/private-trust-company-formation-plan/requirements.txt
+++ b/family-office/private-trust-company-formation-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Private Trust Company Formation Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/private-trust-company-formation-plan/scripts/agent.py
+++ b/family-office/private-trust-company-formation-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Private Trust Company Formation Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Private Trust Company Formation Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "private-trust-company-formation-plan"
+SKILL_DISPLAY = "Private Trust Company Formation Plan"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Private Trust Company Formation Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("preferred_jurisdiction", "Preferred jurisdiction (SD / NV / WY / TN)?"),
+    ("expected_aum", "Expected AUM under the PTC?"),
+    ("board_composition", "Board composition (family / independent / professional)?"),
+    ("capitalization_plan", "Capitalization plan?"),
+    ("counsel", "Counsel firm?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/private-trust-company-formation-plan/tests/test_smoke.py
+++ b/family-office/private-trust-company-formation-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Private Trust Company Formation Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/real-estate-acquisition-plan/.env.example
+++ b/family-office/real-estate-acquisition-plan/.env.example
@@ -1,0 +1,9 @@
+# Real Estate Acquisition Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/real-estate-acquisition-plan/SKILL.md
+++ b/family-office/real-estate-acquisition-plan/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: real-estate-acquisition-plan
+display-name: "Real Estate Acquisition Plan"
+description: "Produce a plan for acquiring a real estate asset — property thesis, financing, entity structure, due diligence, and closing checklist."
+---
+
+# Real Estate Acquisition Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- real estate acquisition
+- buy property plan
+- RE acquisition
+- property purchase plan
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Real Estate Acquisition Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/real-estate-acquisition-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `property_address` — Property address (or identifier)?
+- `use_case` — Use case (primary residence / investment / family compound)?
+- `purchase_price` — Purchase price?
+- `financing_plan` — Financing plan (cash / mortgage / seller financing)?
+- `owning_entity` — Owning entity (individual / LLC / trust)?
+- `target_close_date` — Target close date?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"real-estate-acquisition-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/real-estate-acquisition-plan/requirements.txt
+++ b/family-office/real-estate-acquisition-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Real Estate Acquisition Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/real-estate-acquisition-plan/scripts/agent.py
+++ b/family-office/real-estate-acquisition-plan/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Real Estate Acquisition Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Real Estate Acquisition Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "real-estate-acquisition-plan"
+SKILL_DISPLAY = "Real Estate Acquisition Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Real Estate Acquisition Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("property_address", "Property address (or identifier)?"),
+    ("use_case", "Use case (primary residence / investment / family compound)?"),
+    ("purchase_price", "Purchase price?"),
+    ("financing_plan", "Financing plan (cash / mortgage / seller financing)?"),
+    ("owning_entity", "Owning entity (individual / LLC / trust)?"),
+    ("target_close_date", "Target close date?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/real-estate-acquisition-plan/tests/test_smoke.py
+++ b/family-office/real-estate-acquisition-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Real Estate Acquisition Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/router/SKILL.md
+++ b/family-office/router/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: router
+display-name: "Family Office — Top-Level Router"
+description: "Top-level natural-language router for the Seren family-office catalog. Classifies an advisor ask into one of three pillars (Capital Allocation, Complexity Management, Legacy Preservation) and delegates to the pillar router, which in turn invokes the matching leaf. Single-family-office tenancy. Catalog rebuild tracked in issue #427."
+---
+
+# Family Office — Top-Level Router
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active.
+
+## When to Use
+
+Invoke when the advisor asks any family-office question in natural language
+without naming a specific skill or pillar. Representative phrases:
+
+- "What should my client do to minimize taxes before selling their business?"
+- "Create a budget for my client for 2026."
+- "My client would like to purchase an Andy Warhol painting — what do I need
+  to take into consideration?"
+- "Help me write a mission statement for a family."
+- "Plan international travel to Egypt focused on personal security."
+
+## Three-Pillar Framing
+
+Every family-office ask fits into one of three pillars:
+
+- **Capital Allocation** — portfolio strategy, asset allocation, risk, manager
+  due diligence, exits, new-business evaluation, alternatives, ESG mandates.
+- **Complexity Management** — tax, budgeting, cashflow, insurance, real
+  estate / art / leisure-asset / collectibles acquisition, concierge services,
+  credentials, mail.
+- **Legacy Preservation** — estate planning, trusts, wills, healthcare
+  directives, foundations, philanthropy, family governance, next-generation
+  education, risk.
+
+## Dispatch
+
+1. Classify the ask into one of the three pillars using the pillar
+   descriptions above.
+2. Delegate to the matching pillar router:
+   - `family-office-capital-allocation-router`
+   - `family-office-complexity-management-router`
+   - `family-office-legacy-preservation-router`
+3. If the ask spans pillars, ask a single clarifying question before
+   delegating.
+4. If no pillar claims confidence, respond plainly that no leaf currently
+   fits and suggest logging the ask as an open question in the knowledge
+   skill.
+
+## Demo script (for Rendero Trust)
+
+Advisor: *"What should my client do to minimize taxes before selling their
+business?"*
+→ Top router classifies as **Capital Allocation**.
+→ Delegates to `family-office-capital-allocation-router`.
+→ That router matches trigger `"sell business"` → invokes
+`family-office-business-exit-strategy`.
+→ The leaf runs an interview, renders the Exit Tax Minimization Plan, and
+writes artifact.md + interview.json + manifest.json under
+`artifacts/family-office/business-exit-strategy/<timestamp>/`.
+
+PDF / DOCX / XLSX renders, DMS push (SharePoint + Egnyte), Snowflake ingest,
+and approval-gated execution actions land in the execution-pipeline PR
+tracked under issue #427.
+
+## Non-goals for this iteration
+
+The top-level router does not programmatically invoke Python agents; the
+Claude Code harness does that when the router names the right skill. This
+skill's job is classification, not orchestration.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/succession-planning-memo/.env.example
+++ b/family-office/succession-planning-memo/.env.example
@@ -1,0 +1,9 @@
+# Succession Planning Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/succession-planning-memo/SKILL.md
+++ b/family-office/succession-planning-memo/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: succession-planning-memo
+display-name: "Succession Planning Memo"
+description: "Produce a succession planning memo for leadership, ownership, and trustee roles across the family enterprise."
+---
+
+# Succession Planning Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- succession planning
+- successor plan
+- leadership transition
+- ownership succession
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Succession Planning Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/succession-planning-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `role_in_scope` — Role in scope (principal / trustee / board chair)?
+- `current_holder` — Current holder?
+- `candidate_successors` — Candidate successors?
+- `transition_timeline` — Transition timeline?
+- `development_plan` — Successor development plan?
+- `contingency_plan` — Contingency plan for sudden transition?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"succession-planning-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/succession-planning-memo/requirements.txt
+++ b/family-office/succession-planning-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Succession Planning Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/succession-planning-memo/scripts/agent.py
+++ b/family-office/succession-planning-memo/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Succession Planning Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Succession Planning Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "succession-planning-memo"
+SKILL_DISPLAY = "Succession Planning Memo"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Succession Planning Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("role_in_scope", "Role in scope (principal / trustee / board chair)?"),
+    ("current_holder", "Current holder?"),
+    ("candidate_successors", "Candidate successors?"),
+    ("transition_timeline", "Transition timeline?"),
+    ("development_plan", "Successor development plan?"),
+    ("contingency_plan", "Contingency plan for sudden transition?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/succession-planning-memo/tests/test_smoke.py
+++ b/family-office/succession-planning-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Succession Planning Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/target-asset-allocation-model/.env.example
+++ b/family-office/target-asset-allocation-model/.env.example
@@ -1,0 +1,9 @@
+# Target Asset Allocation Model — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/target-asset-allocation-model/SKILL.md
+++ b/family-office/target-asset-allocation-model/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: target-asset-allocation-model
+display-name: "Target Asset Allocation Model"
+description: "Produce a target asset allocation model across public equities, fixed income, alternatives, real assets, and cash. Captures current allocation, target allocation, and drift bands."
+---
+
+# Target Asset Allocation Model
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- asset allocation
+- target allocation
+- allocation model
+- portfolio weights
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Target Asset Allocation Model`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/target-asset-allocation-model/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `current_equities_pct` — Current public equity allocation (%)?
+- `current_fi_pct` — Current fixed income allocation (%)?
+- `current_alts_pct` — Current alternatives allocation (%)?
+- `target_equities_pct` — Target public equity allocation (%)?
+- `target_fi_pct` — Target fixed income allocation (%)?
+- `target_alts_pct` — Target alternatives allocation (%)?
+- `drift_band_pct` — Drift band (± %) before rebalance?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"target-asset-allocation-model"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/target-asset-allocation-model/requirements.txt
+++ b/family-office/target-asset-allocation-model/requirements.txt
@@ -1,0 +1,4 @@
+# Target Asset Allocation Model
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/target-asset-allocation-model/scripts/agent.py
+++ b/family-office/target-asset-allocation-model/scripts/agent.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Target Asset Allocation Model skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Target Asset Allocation Model as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "target-asset-allocation-model"
+SKILL_DISPLAY = "Target Asset Allocation Model"
+PILLAR = "capital-allocation"
+ARTIFACT_NAME = "Target Asset Allocation Model"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("current_equities_pct", "Current public equity allocation (%)?"),
+    ("current_fi_pct", "Current fixed income allocation (%)?"),
+    ("current_alts_pct", "Current alternatives allocation (%)?"),
+    ("target_equities_pct", "Target public equity allocation (%)?"),
+    ("target_fi_pct", "Target fixed income allocation (%)?"),
+    ("target_alts_pct", "Target alternatives allocation (%)?"),
+    ("drift_band_pct", "Drift band (± %) before rebalance?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/target-asset-allocation-model/tests/test_smoke.py
+++ b/family-office/target-asset-allocation-model/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Target Asset Allocation Model skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/tax-strategy-memo/.env.example
+++ b/family-office/tax-strategy-memo/.env.example
@@ -1,0 +1,9 @@
+# Tax Strategy Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/tax-strategy-memo/SKILL.md
+++ b/family-office/tax-strategy-memo/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: tax-strategy-memo
+display-name: "Tax Strategy Memo"
+description: "Produce a tax strategy memo for the family. Captures current year tax posture, elections, harvesting opportunities, and planning moves."
+---
+
+# Tax Strategy Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- tax strategy
+- tax planning memo
+- year-end tax planning
+- tax posture
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Tax Strategy Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/tax-strategy-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `tax_year` — Tax year?
+- `expected_agi_range` — Expected AGI range?
+- `key_income_sources` — Key income sources (W2, K-1, LTCG, carried)?
+- `pending_elections` — Pending elections (mark-to-market, QSBS, etc.)?
+- `harvesting_opportunities` — Loss-harvesting opportunities?
+- `cpa_firm` — CPA firm preparing the return?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"tax-strategy-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/tax-strategy-memo/requirements.txt
+++ b/family-office/tax-strategy-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Tax Strategy Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/tax-strategy-memo/scripts/agent.py
+++ b/family-office/tax-strategy-memo/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Tax Strategy Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Tax Strategy Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "tax-strategy-memo"
+SKILL_DISPLAY = "Tax Strategy Memo"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Tax Strategy Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("tax_year", "Tax year?"),
+    ("expected_agi_range", "Expected AGI range?"),
+    ("key_income_sources", "Key income sources (W2, K-1, LTCG, carried)?"),
+    ("pending_elections", "Pending elections (mark-to-market, QSBS, etc.)?"),
+    ("harvesting_opportunities", "Loss-harvesting opportunities?"),
+    ("cpa_firm", "CPA firm preparing the return?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/tax-strategy-memo/tests/test_smoke.py
+++ b/family-office/tax-strategy-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Tax Strategy Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/trust-selection-memo/.env.example
+++ b/family-office/trust-selection-memo/.env.example
@@ -1,0 +1,9 @@
+# Trust Selection Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/trust-selection-memo/SKILL.md
+++ b/family-office/trust-selection-memo/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: trust-selection-memo
+display-name: "Trust Selection Memo"
+description: "Produce a trust selection memo comparing revocable, irrevocable, marital, asset-protection, special-needs, spendthrift, bypass, generation-skipping, and dynasty trust options."
+---
+
+# Trust Selection Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- trust selection
+- which trust
+- compare trust types
+- trust recommendation
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Trust Selection Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/trust-selection-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `goal` — Primary goal (tax / asset protection / control / legacy)?
+- `funding_amount` — Funding amount?
+- `beneficiaries` — Beneficiary list?
+- `situs_preference` — Situs preference (FL / DE / NV / WY / Dakotas)?
+- `grantor_status_preference` — Grantor-trust status preference?
+- `counsel` — Estate counsel?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"trust-selection-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/trust-selection-memo/requirements.txt
+++ b/family-office/trust-selection-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Trust Selection Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/trust-selection-memo/scripts/agent.py
+++ b/family-office/trust-selection-memo/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Trust Selection Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Trust Selection Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "trust-selection-memo"
+SKILL_DISPLAY = "Trust Selection Memo"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Trust Selection Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("goal", "Primary goal (tax / asset protection / control / legacy)?"),
+    ("funding_amount", "Funding amount?"),
+    ("beneficiaries", "Beneficiary list?"),
+    ("situs_preference", "Situs preference (FL / DE / NV / WY / Dakotas)?"),
+    ("grantor_status_preference", "Grantor-trust status preference?"),
+    ("counsel", "Estate counsel?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/trust-selection-memo/tests/test_smoke.py
+++ b/family-office/trust-selection-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Trust Selection Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/trust-situs-selection-memo/.env.example
+++ b/family-office/trust-situs-selection-memo/.env.example
@@ -1,0 +1,9 @@
+# Trust Situs Selection Memo — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/trust-situs-selection-memo/SKILL.md
+++ b/family-office/trust-situs-selection-memo/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: trust-situs-selection-memo
+display-name: "Trust Situs Selection Memo"
+description: "Produce a trust situs selection memo comparing Florida, Delaware, Nevada, Wyoming, and the Dakotas on tax, creditor protection, privacy, and administration."
+---
+
+# Trust Situs Selection Memo
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- trust situs
+- situs selection
+- jurisdiction comparison
+- where to form trust
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Trust Situs Selection Memo`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/trust-situs-selection-memo/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `goal_ranking` — Ranked goals (tax / asset protection / privacy / perpetuity / admin cost)?
+- `current_residence_state` — Principal's current state of residence?
+- `beneficiary_states` — Beneficiary states?
+- `asset_types_funded` — Asset types to be funded?
+- `counsel` — Counsel firm?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"trust-situs-selection-memo"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/trust-situs-selection-memo/requirements.txt
+++ b/family-office/trust-situs-selection-memo/requirements.txt
@@ -1,0 +1,4 @@
+# Trust Situs Selection Memo
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/trust-situs-selection-memo/scripts/agent.py
+++ b/family-office/trust-situs-selection-memo/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Trust Situs Selection Memo skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Trust Situs Selection Memo as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "trust-situs-selection-memo"
+SKILL_DISPLAY = "Trust Situs Selection Memo"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Trust Situs Selection Memo"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("goal_ranking", "Ranked goals (tax / asset protection / privacy / perpetuity / admin cost)?"),
+    ("current_residence_state", "Principal's current state of residence?"),
+    ("beneficiary_states", "Beneficiary states?"),
+    ("asset_types_funded", "Asset types to be funded?"),
+    ("counsel", "Counsel firm?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/trust-situs-selection-memo/tests/test_smoke.py
+++ b/family-office/trust-situs-selection-memo/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Trust Situs Selection Memo skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/virtual-mailbox-setup-plan/.env.example
+++ b/family-office/virtual-mailbox-setup-plan/.env.example
@@ -1,0 +1,9 @@
+# Virtual Mailbox Setup Plan — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/virtual-mailbox-setup-plan/SKILL.md
+++ b/family-office/virtual-mailbox-setup-plan/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: virtual-mailbox-setup-plan
+display-name: "Virtual Mailbox Setup Plan"
+description: "Produce a virtual mailbox setup plan — providers, forwarding rules, scanning cadence, privacy posture."
+---
+
+# Virtual Mailbox Setup Plan
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- virtual mailbox
+- mail scanning
+- mail forwarding plan
+- remote mail setup
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Virtual Mailbox Setup Plan`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/virtual-mailbox-setup-plan/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `provider` — Virtual mailbox provider?
+- `addresses_in_scope` — Addresses in scope?
+- `forwarding_rules` — Forwarding rules?
+- `scanning_cadence` — Scanning cadence?
+- `privacy_posture` — Privacy posture (PO box vs street / registered agent)?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"virtual-mailbox-setup-plan"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/virtual-mailbox-setup-plan/requirements.txt
+++ b/family-office/virtual-mailbox-setup-plan/requirements.txt
@@ -1,0 +1,4 @@
+# Virtual Mailbox Setup Plan
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/virtual-mailbox-setup-plan/scripts/agent.py
+++ b/family-office/virtual-mailbox-setup-plan/scripts/agent.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Virtual Mailbox Setup Plan skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Virtual Mailbox Setup Plan as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "virtual-mailbox-setup-plan"
+SKILL_DISPLAY = "Virtual Mailbox Setup Plan"
+PILLAR = "complexity-management"
+ARTIFACT_NAME = "Virtual Mailbox Setup Plan"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("provider", "Virtual mailbox provider?"),
+    ("addresses_in_scope", "Addresses in scope?"),
+    ("forwarding_rules", "Forwarding rules?"),
+    ("scanning_cadence", "Scanning cadence?"),
+    ("privacy_posture", "Privacy posture (PO box vs street / registered agent)?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/virtual-mailbox-setup-plan/tests/test_smoke.py
+++ b/family-office/virtual-mailbox-setup-plan/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Virtual Mailbox Setup Plan skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)

--- a/family-office/will-drafting-checklist/.env.example
+++ b/family-office/will-drafting-checklist/.env.example
@@ -1,0 +1,9 @@
+# Will Drafting Checklist — environment template.
+# Copy to .env and fill in before a live run.
+#
+# Memory writes are optional. When the knowledge skill's memory DSN is
+# supplied via config.memory_dsn (NOT this .env file), the agent writes
+# decision / assumption / open_question / commitment memories.
+#
+# Never commit .env. The repo-level .gitignore excludes it.
+LOG_LEVEL=INFO

--- a/family-office/will-drafting-checklist/SKILL.md
+++ b/family-office/will-drafting-checklist/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: will-drafting-checklist
+display-name: "Will Drafting Checklist"
+description: "Produce a checklist an attorney uses to draft or update the principal's will. Captures executor, beneficiaries, specific bequests, residuary, and guardianship."
+---
+
+# Will Drafting Checklist
+
+## For Claude: How to Use This Skill
+
+Skill instructions are preloaded in context when this skill is active. Do not
+perform filesystem searches or tool-driven exploration to rediscover them; use
+the guidance below directly.
+
+## When to Use
+
+Invoke when the advisor asks about:
+
+- will drafting
+- update will
+- will checklist
+- testator checklist
+
+## Artifact Specification
+
+This skill produces a single named deliverable:
+
+- **Artifact:** `Will Drafting Checklist`
+- **Format at this iteration:** markdown (`artifact.md`) plus a structured
+  `interview.json` capturing every advisor input. PDF / DOCX / XLSX companion
+  renders and DMS / Snowflake push land in the execution-pipeline PR tracked
+  under issue #427.
+
+The artifact is written to a skill-local path, not a global directory:
+
+```
+<invocation-cwd>/artifacts/family-office/will-drafting-checklist/<YYYYMMDD-HHMMSS>/
+  artifact.md
+  interview.json
+  manifest.json
+```
+
+## Interview Inputs
+
+Minimum-viable interview — the skill asks only what is needed to personalize
+the deliverable. Pre-fill rules against family memory land in the execution-
+pipeline PR.
+
+- `executor` — Executor?
+- `successor_executor` — Successor executor?
+- `primary_beneficiaries` — Primary beneficiaries?
+- `specific_bequests` — Specific bequests?
+- `residuary_disposition` — Residuary disposition?
+- `guardianship_nominations` — Guardianship nominations for minors?
+
+## Workflow
+
+1. Run `python scripts/agent.py --config config.json` (or invoke via Claude
+   Code with a config blob).
+2. The agent validates config, runs the interview (TTY or fixture-driven),
+   and produces the artifact under the canonical local path.
+3. The agent writes `manifest.json` with artifact metadata (name, version,
+   content hash, pillar, skill_name, created_at).
+4. The agent optionally writes memory entries to the knowledge skill's
+   `memory_objects` table via psycopg if `config.memory_dsn` is provided.
+   Without a DSN, memory writes are skipped cleanly.
+
+## Memory Conventions
+
+Memories written by this skill are tagged with:
+
+- `subject` = the artifact name
+- `source` = `"will-drafting-checklist"`
+- `memory_type` ∈ {`decision`, `assumption`, `commitment`, `open_question`}
+
+## Security & Confidentiality
+
+- Never log interview answers or artifact contents at INFO level.
+- Never include SSN, EIN, account numbers, or full financial amounts in
+  log lines. If a WHERE-clause field carries such data, log only a sha256
+  hash.
+- The artifact directory is local-only at this iteration. DMS push (with
+  confidentiality-label routing) is handled by the execution-pipeline PR.
+
+## Reference
+
+- Design spec: `20260419_Family_Office_Skill_Claude_Desigh.md`
+- Implementation plan: `20260420_FamilyOffice_Skills_Plan.md`
+- Catalog rebuild tracking: https://github.com/serenorg/seren-skills/issues/427

--- a/family-office/will-drafting-checklist/requirements.txt
+++ b/family-office/will-drafting-checklist/requirements.txt
@@ -1,0 +1,4 @@
+# Will Drafting Checklist
+# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
+# is supplied in config). Tests mock it via skip.
+psycopg[binary]>=3.1

--- a/family-office/will-drafting-checklist/scripts/agent.py
+++ b/family-office/will-drafting-checklist/scripts/agent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Agent runtime for the Will Drafting Checklist skill.
+
+Single-family-office tenancy. Self-contained: no cross-skill Python imports.
+
+Flow:
+    1. Load config (JSON; --config flag or default ./config.json).
+    2. Run minimum-viable interview (TTY or fixture-driven).
+    3. Render the Will Drafting Checklist as markdown.
+    4. Write artifact.md + interview.json + manifest.json to a skill-local
+       timestamped directory.
+    5. Optionally write memory entries to the knowledge skill's
+       memory_objects table when config.memory_dsn is provided.
+
+Security posture (applies to every family-office skill):
+    - Never log interview answers or artifact text.
+    - Never log memory_dsn.
+    - Parameterize every SQL call.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILL_NAME = "will-drafting-checklist"
+SKILL_DISPLAY = "Will Drafting Checklist"
+PILLAR = "legacy-preservation"
+ARTIFACT_NAME = "Will Drafting Checklist"
+
+# Per-skill interview schema. Each entry is (key, prompt).
+INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+    ("executor", "Executor?"),
+    ("successor_executor", "Successor executor?"),
+    ("primary_beneficiaries", "Primary beneficiaries?"),
+    ("specific_bequests", "Specific bequests?"),
+    ("residuary_disposition", "Residuary disposition?"),
+    ("guardianship_nominations", "Guardianship nominations for minors?"),
+]
+
+logger = logging.getLogger(f"family_office.{SKILL_NAME}")
+
+
+# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact(value: str, keep: int = 0) -> str:
+    if not value:
+        return ""
+    if keep >= len(value):
+        return value
+    return value[:keep] + ("*" * max(1, len(value) - keep))
+
+
+# ─── Interview ────────────────────────────────────────────────────────────
+
+def run_interview(
+    *, fixture: dict[str, str] | None = None, tty: bool = True
+) -> dict[str, str]:
+    """Run the interview. If fixture is supplied, answers come from it
+    (used by tests and by Claude-Code-driven invocation). Otherwise prompts
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
+    because a defaulted interview would produce a wrong artifact."""
+    answers: dict[str, str] = {}
+    for key, prompt in INTERVIEW_QUESTIONS:
+        if fixture is not None:
+            if key not in fixture:
+                raise ValueError(
+                    f"interview fixture missing required key: {key!r}"
+                )
+            answers[key] = str(fixture[key]).strip()
+        else:
+            if not tty:
+                raise RuntimeError(
+                    "interview requires either a fixture or a TTY"
+                )
+            answers[key] = input(f"{prompt}  ").strip()
+    return answers
+
+
+# ─── Artifact rendering ──────────────────────────────────────────────────
+
+def render_artifact(answers: dict[str, str]) -> str:
+    lines = [
+        f"# {ARTIFACT_NAME}",
+        "",
+        f"- **Pillar:** {PILLAR.replace('-', ' ').title()}",
+        f"- **Produced:** {_iso_now()}",
+        f"- **Skill:** `{SKILL_NAME}`",
+        "",
+        "## Inputs captured",
+        "",
+    ]
+    for key, prompt in INTERVIEW_QUESTIONS:
+        label = prompt.rstrip("?").rstrip()
+        value = answers.get(key, "")
+        lines.append(f"- **{label}:** {value}")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            (
+                "This is a first-iteration deliverable. PDF, DOCX, and "
+                "XLSX companion renders, DMS push, Snowflake ingest, and "
+                "approval-gated execution actions are added by the "
+                "execution-pipeline PR tracked under issue #427."
+            ),
+            "",
+            "## Confidentiality",
+            "",
+            (
+                "Treat this artifact as `office-private` by default. When "
+                "the execution pipeline ships, the skill will read the "
+                "configured confidentiality label from the office record "
+                "and route destinations accordingly."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ─── Write ───────────────────────────────────────────────────────────────
+
+def _canonical_out_dir(base: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out = base / "artifacts" / "family-office" / SKILL_NAME / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def write_artifact(
+    answers: dict[str, str], *, base: Path
+) -> dict[str, Any]:
+    out_dir = _canonical_out_dir(base)
+    md = render_artifact(answers)
+    (out_dir / "artifact.md").write_text(md, encoding="utf-8")
+    (out_dir / "interview.json").write_text(
+        json.dumps(answers, indent=2), encoding="utf-8"
+    )
+    manifest = {
+        "skill": SKILL_NAME,
+        "pillar": PILLAR,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_version": 1,
+        "created_at": _iso_now(),
+        "content_hash": _hash_text(md),
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return manifest
+
+
+# ─── Memory write (optional, psycopg) ────────────────────────────────────
+
+def _memory_id(memory_type: str) -> str:
+    return f"memory:{memory_type}-{uuid.uuid4().hex[:8]}"
+
+
+def write_memories(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    dsn: str,
+) -> list[str]:
+    """Write one decision + one assumption + one open_question + one
+    commitment memory per run. Uses psycopg; parameterized SQL only.
+
+    Returns list of memory ids written. Raises on connection failure --
+    callers decide whether to proceed without memory.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("psycopg is required for memory writes") from exc
+
+    ids: list[str] = []
+    memories = [
+        (
+            "decision",
+            f"Produced {ARTIFACT_NAME} on {manifest['created_at']}.",
+        ),
+        (
+            "assumption",
+            f"{ARTIFACT_NAME} generated from advisor-supplied inputs "
+            f"(interview.json, hash {manifest['content_hash'][:12]}).",
+        ),
+        (
+            "open_question",
+            f"Confirm {ARTIFACT_NAME} with principal before distributing.",
+        ),
+        (
+            "commitment",
+            f"Advisor to review {ARTIFACT_NAME} and address open items.",
+        ),
+    ]
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        for mtype, claim in memories:
+            mid = _memory_id(mtype)
+            conn.execute(
+                "INSERT INTO memory_objects "
+                "(id, memory_type, key_claim, subject, "
+                " confidence_score, importance_score, validity_status, "
+                " source, source_id, entity_refs, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, 'active', %s, %s, %s, "
+                "         now(), now())",
+                (
+                    mid,
+                    mtype,
+                    claim,
+                    ARTIFACT_NAME,
+                    "medium",
+                    "medium",
+                    SKILL_NAME,
+                    manifest["out_dir"],
+                    [f"skill:{SKILL_NAME}", f"pillar:{PILLAR}"],
+                ),
+            )
+            ids.append(mid)
+        conn.commit()
+    return ids
+
+
+# ─── CLI entry ───────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=SKILL_DISPLAY)
+    p.add_argument("--config", default="config.json", help="Config JSON path")
+    p.add_argument("--cwd", default=".", help="Base directory for artifacts")
+    p.add_argument(
+        "--no-tty",
+        action="store_true",
+        help="Fail rather than prompt for missing fixture keys",
+    )
+    return p.parse_args(argv)
+
+
+def load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args(argv)
+    cfg = load_config(args.config)
+
+    fixture = cfg.get("interview_answers")
+    tty = not args.no_tty
+
+    answers = run_interview(fixture=fixture, tty=tty)
+    manifest = write_artifact(answers, base=Path(args.cwd))
+
+    # Never log answers, manifest content, or the memory DSN.
+    logger.info(
+        "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
+        SKILL_NAME,
+        PILLAR,
+        manifest["content_hash"][:12],
+    )
+
+    memory_dsn = cfg.get("memory_dsn")
+    if memory_dsn and not cfg.get("skip_memory", False):
+        try:
+            ids = write_memories(manifest, answers, dsn=memory_dsn)
+            logger.info(
+                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
+            )
+        except Exception as exc:  # noqa: BLE001 — controlled degradation
+            logger.warning(
+                "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    print(manifest["out_dir"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/family-office/will-drafting-checklist/tests/test_smoke.py
+++ b/family-office/will-drafting-checklist/tests/test_smoke.py
@@ -1,0 +1,62 @@
+"""Critical smoke test for the Will Drafting Checklist skill.
+
+Uses importlib to load the skill's agent module by path. Avoids the
+sys.modules collision that would otherwise happen when the whole
+family-office/ tree is collected in one pytest run (every leaf has
+scripts/agent.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    # Unique module name per skill avoids sys.modules collisions across the
+    # 55-leaf test collection.
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader, f"cannot load agent at {_AGENT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(agent):
+    return {key: "fixture-value" for key, _ in agent.INTERVIEW_QUESTIONS}
+
+
+def test_agent_runs_end_to_end_and_writes_artifact(tmp_path: Path) -> None:
+    agent = _load_agent()
+    answers = agent.run_interview(fixture=_fixture(agent), tty=False)
+    assert set(answers) == {key for key, _ in agent.INTERVIEW_QUESTIONS}
+    manifest = agent.write_artifact(answers, base=tmp_path)
+
+    assert manifest["skill"] == agent.SKILL_NAME
+    assert manifest["pillar"] == agent.PILLAR
+    assert manifest["artifact_name"] == agent.ARTIFACT_NAME
+    assert manifest["artifact_version"] == 1
+    assert len(manifest["content_hash"]) == 64
+
+    out_dir = Path(manifest["out_dir"])
+    assert (out_dir / "artifact.md").exists()
+    assert (out_dir / "interview.json").exists()
+    assert (out_dir / "manifest.json").exists()
+
+    recaptured = json.loads((out_dir / "interview.json").read_text("utf-8"))
+    assert recaptured == answers
+
+
+def test_interview_rejects_missing_fixture_key() -> None:
+    agent = _load_agent()
+    partial = _fixture(agent)
+    partial.pop(next(iter(partial)))
+    with pytest.raises(ValueError):
+        agent.run_interview(fixture=partial, tty=False)


### PR DESCRIPTION
## Summary

Rebuilds the family-office catalog per the corrected structure agreed after the PR #425 → PR #426 revert. Ships **55 leaf skills + 4 routers** — all as proper 3-segment indexed skills. No `_base/` folder. No publisher-root `SKILL.md`. No stubs. Every new SKILL.md is picked up by `scripts/build-index.mjs`.

Closes the skill-authoring milestone of #427. The execution-pipeline (DMS drivers, Snowflake ingest, email/calendar handlers, approval gate, 8-point readiness check) ships as a follow-on PR tracked under the same issue.

## What's in the catalog

| Pillar | Leaves |
|---|---|
| Capital Allocation | 16 (including Mike-flagged `business-exit-strategy`) |
| Complexity Management | 22 (including Mike-flagged CPA checklist, budget, insurance procurement, art, leisure assets, collectibles) |
| Legacy Preservation | 17 (including Mike-flagged philanthropy plan, mission statement, next-gen curriculum, family risk) |
| **Total leaves** | **55** |
| Routers | `router` (top-level) + `capital-allocation-router` + `complexity-management-router` + `legacy-preservation-router` |
| **Grand total new skills** | **59** |
| Existing unchanged | `knowledge` |

## Per-skill shape (identical across 55)

- `SKILL.md` — frontmatter (`name`, `display-name`, `description`) + When to Use + Artifact Specification + Interview Inputs + Workflow + Memory Conventions + Security notes.
- `scripts/agent.py` — inline shared runtime (no cross-skill imports). Runs a minimum-viable interview (TTY or fixture-driven), writes `artifact.md` + `interview.json` + `manifest.json` to a skill-local timestamped directory. Optional `psycopg` memory_objects write if `config.memory_dsn` is supplied; skipped cleanly otherwise.
- `tests/test_smoke.py` — critical end-to-end test + interview-missing-key negative test. Loaded via `importlib` from the agent path to avoid the 55-way `agent` module name collision.
- `requirements.txt`, `.env.example`.

## Critical tests only

**110 tests pass** across the 55 leaves (2 per leaf, matching the plan's "functional test + security invariant" minimum). No snapshot tests, no trivial getters, no per-leaf integration tests that would duplicate the same assertions 55 times.

## CI — 4 jobs

1. **test** — Python 3.11 + 3.12 matrix; runs all 110 smoke tests with `--import-mode=importlib`.
2. **forbid-publisher-root-skill-md** — regression guard; fails if `family-office/SKILL.md` exists. (Lesson from #425.)
3. **forbid-non-skill-folders** — fails if any folder under `family-office/` (except `knowledge/`) lacks a SKILL.md. Prevents reintroduction of `_base/` or similar.
4. **indexer-smoke** — runs `scripts/build-index.mjs` and asserts exactly 60 family-office skills are indexed.

## Indexer pickup — verified

Running `node scripts/build-index.mjs` on this branch yields **60 family-office skills** indexed with proper `org-slug` form (`family-office-<leaf>`). Full list in the linked workflow run. This is the bar set by issue #427 ("all new SKILL.md is at the 3-segment path the indexer expects") — met.

## What's intentionally NOT in this PR

Per the "every SKILL.md is a real working indexed skill" discipline, only what stands alone ships. These are deferred to the execution-pipeline follow-on PR (same issue #427):

- DMS drivers (SharePoint + Egnyte), Snowflake ingest, email (Gmail/Outlook) and calendar (GCal/Outlook) handlers.
- Approval gate + 8-point execution readiness check (fail-closed on money-movement / filing / legal).
- PDF / DOCX / XLSX companion renders.
- Working brief + cadence + health signals + role digests.
- Canonical object model schema (16 tables) and `audit_query` — re-evaluated from the ground up in the follow-on PR now that we have real leaves consuming them, following YAGNI instead of the premature `_base/` from #425.

## Test plan

- [ ] CI `test` job green on Python 3.11 and 3.12
- [ ] CI `forbid-publisher-root-skill-md` green (no `family-office/SKILL.md`)
- [ ] CI `forbid-non-skill-folders` green (every folder under `family-office/` has a `SKILL.md` or is `knowledge/`)
- [ ] CI `indexer-smoke` green (60 family-office skills indexed)
- [ ] Knowledge skill diff vs main empty (`git diff main -- family-office/knowledge/`)
- [ ] Manual spot-check: invoke `family-office-business-exit-strategy` with a fixture config and confirm `artifact.md` + `interview.json` + `manifest.json` land on disk

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
