### PR TITLE
feat(family-office): Asana + SharePoint + Snowflake push on every leaf (demo-ready external sinks)

### DIFF
--- a/.github/workflows/family-office-rebuild.yml
+++ b/.github/workflows/family-office-rebuild.yml
@@ -27,10 +27,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install pytest
+      - name: Install pytest + runtime deps
+        # `requests` is imported by the in-skill GatewayClient when a leaf
+        # pushes to SharePoint or Asana. snowflake-connector-python is NOT
+        # installed in CI — the sink tests stub `snowflake.connector`
+        # directly so the validation paths are exercised without the heavy
+        # native dep.
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest requests
 
       - name: Run critical smoke tests across all family-office leaves + routers
         # --import-mode=importlib is required because every leaf has a

--- a/family-office/annual-budget-workbook/.env.example
+++ b/family-office/annual-budget-workbook/.env.example
@@ -1,9 +1,24 @@
 # Annual Budget Workbook — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/annual-budget-workbook/requirements.txt
+++ b/family-office/annual-budget-workbook/requirements.txt
@@ -1,4 +1,13 @@
 # Annual Budget Workbook
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/annual-budget-workbook/scripts/agent.py
+++ b/family-office/annual-budget-workbook/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Annual Budget Workbook skill.
+"""Agent runtime for the Annual Budget Workbook skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Annual Budget Workbook"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("budget_year", "Budget year?"),
     ("expected_income", "Expected income (range)?"),
     ("fixed_expenses", "Major fixed expense categories and amounts?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("charitable_giving_target", "Charitable giving target?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/art-acquisition-due-diligence/.env.example
+++ b/family-office/art-acquisition-due-diligence/.env.example
@@ -1,9 +1,24 @@
 # Art Acquisition Due-Diligence Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/art-acquisition-due-diligence/requirements.txt
+++ b/family-office/art-acquisition-due-diligence/requirements.txt
@@ -1,4 +1,13 @@
 # Art Acquisition Due-Diligence Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/art-acquisition-due-diligence/scripts/agent.py
+++ b/family-office/art-acquisition-due-diligence/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Art Acquisition Due-Diligence Memo skill.
+"""Agent runtime for the Art Acquisition Due-Diligence Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Art Acquisition Due-Diligence Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("artwork", "Artwork (artist, title, year)?"),
     ("asking_price", "Asking price?"),
     ("seller", "Seller (dealer / auction / private)?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("intended_location", "Intended display / storage location?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/bookkeeping-bill-pay-setup-plan/.env.example
+++ b/family-office/bookkeeping-bill-pay-setup-plan/.env.example
@@ -1,9 +1,24 @@
 # Bookkeeping & Bill Pay Setup Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/bookkeeping-bill-pay-setup-plan/requirements.txt
+++ b/family-office/bookkeeping-bill-pay-setup-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Bookkeeping & Bill Pay Setup Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
+++ b/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Bookkeeping & Bill Pay Setup Plan skill.
+"""Agent runtime for the Bookkeeping & Bill Pay Setup Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Bookkeeping & Bill Pay Setup Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("accounting_platform", "Accounting platform (Sage Intacct / QuickBooks / AtlasFive)?"),
     ("bill_pay_platform", "Bill pay platform?"),
     ("approval_thresholds", "Approval thresholds (principal / COO / staff)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("audit_trail_retention", "Audit trail retention period?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/business-exit-strategy/.env.example
+++ b/family-office/business-exit-strategy/.env.example
@@ -1,9 +1,24 @@
 # Exit Tax Minimization Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/business-exit-strategy/requirements.txt
+++ b/family-office/business-exit-strategy/requirements.txt
@@ -1,4 +1,13 @@
 # Exit Tax Minimization Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/business-exit-strategy/scripts/agent.py
+++ b/family-office/business-exit-strategy/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Exit Tax Minimization Plan skill.
+"""Agent runtime for the Exit Tax Minimization Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Exit Tax Minimization Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("business_name", "Business legal name?"),
     ("principal_basis", "Principal's basis in the business?"),
     ("expected_proceeds", "Expected sale proceeds?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("cpa_firm", "CPA firm handling the return?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/cashflow-forecast-worksheet/.env.example
+++ b/family-office/cashflow-forecast-worksheet/.env.example
@@ -1,9 +1,24 @@
 # Cashflow Forecast Worksheet — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/cashflow-forecast-worksheet/requirements.txt
+++ b/family-office/cashflow-forecast-worksheet/requirements.txt
@@ -1,4 +1,13 @@
 # Cashflow Forecast Worksheet
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/cashflow-forecast-worksheet/scripts/agent.py
+++ b/family-office/cashflow-forecast-worksheet/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Cashflow Forecast Worksheet skill.
+"""Agent runtime for the Cashflow Forecast Worksheet skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Cashflow Forecast Worksheet"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("forecast_start_month", "Forecast start month (YYYY-MM)?"),
     ("recurring_inflows", "Recurring inflows (source, amount, cadence)?"),
     ("recurring_outflows", "Recurring outflows (category, amount, cadence)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("minimum_cushion", "Minimum liquidity cushion?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/charitable-trust-selection-memo/.env.example
+++ b/family-office/charitable-trust-selection-memo/.env.example
@@ -1,9 +1,24 @@
 # Charitable Trust Selection Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/charitable-trust-selection-memo/requirements.txt
+++ b/family-office/charitable-trust-selection-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Charitable Trust Selection Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/charitable-trust-selection-memo/scripts/agent.py
+++ b/family-office/charitable-trust-selection-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Charitable Trust Selection Memo skill.
+"""Agent runtime for the Charitable Trust Selection Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Charitable Trust Selection Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("goal", "Primary goal (income / tax / legacy)?"),
     ("funding_assets", "Assets to fund the trust?"),
     ("income_needs", "Income needs from the trust?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("beneficiaries", "Beneficiaries?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/client-sourced-deal-review-memo/.env.example
+++ b/family-office/client-sourced-deal-review-memo/.env.example
@@ -1,9 +1,24 @@
 # Client-Sourced Deal Review Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/client-sourced-deal-review-memo/requirements.txt
+++ b/family-office/client-sourced-deal-review-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Client-Sourced Deal Review Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/client-sourced-deal-review-memo/scripts/agent.py
+++ b/family-office/client-sourced-deal-review-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Client-Sourced Deal Review Memo skill.
+"""Agent runtime for the Client-Sourced Deal Review Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Client-Sourced Deal Review Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("deal_name", "Deal name?"),
     ("sponsor", "Deal sponsor?"),
     ("investment_amount", "Proposed investment amount?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("recommendation_lean", "Lean recommendation (proceed / decline / pause)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/collectibles-acquisition-logistics/.env.example
+++ b/family-office/collectibles-acquisition-logistics/.env.example
@@ -1,9 +1,24 @@
 # Collectibles Acquisition & Logistics Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/collectibles-acquisition-logistics/requirements.txt
+++ b/family-office/collectibles-acquisition-logistics/requirements.txt
@@ -1,4 +1,13 @@
 # Collectibles Acquisition & Logistics Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/collectibles-acquisition-logistics/scripts/agent.py
+++ b/family-office/collectibles-acquisition-logistics/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Collectibles Acquisition & Logistics Plan skill.
+"""Agent runtime for the Collectibles Acquisition & Logistics Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Collectibles Acquisition & Logistics Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("category", "Collectible category?"),
     ("item", "Specific item?"),
     ("origin", "Origin location?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("insurance_in_transit", "Insurance-in-transit requirement?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/community-engagement-plan/.env.example
+++ b/family-office/community-engagement-plan/.env.example
@@ -1,9 +1,24 @@
 # Community Engagement Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/community-engagement-plan/requirements.txt
+++ b/family-office/community-engagement-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Community Engagement Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/community-engagement-plan/scripts/agent.py
+++ b/family-office/community-engagement-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Community Engagement Plan skill.
+"""Agent runtime for the Community Engagement Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Community Engagement Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("communities_of_interest", "Communities of interest?"),
     ("current_relationships", "Current relationships and roles?"),
     ("time_commitment_target", "Time commitment target?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("reputational_posture", "Reputational posture (public / private)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/concierge-personal-protection-plan/.env.example
+++ b/family-office/concierge-personal-protection-plan/.env.example
@@ -1,9 +1,24 @@
 # Personal Protection Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/concierge-personal-protection-plan/requirements.txt
+++ b/family-office/concierge-personal-protection-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Personal Protection Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/concierge-personal-protection-plan/scripts/agent.py
+++ b/family-office/concierge-personal-protection-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Personal Protection Plan skill.
+"""Agent runtime for the Personal Protection Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Personal Protection Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("threat_profile", "Threat profile summary?"),
     ("covered_persons", "Persons in scope?"),
     ("geographies_of_concern", "Geographies of concern?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("travel_security_posture", "Travel security posture?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/concierge-personal-shopping-plan/.env.example
+++ b/family-office/concierge-personal-shopping-plan/.env.example
@@ -1,9 +1,24 @@
 # Personal Shopping Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/concierge-personal-shopping-plan/requirements.txt
+++ b/family-office/concierge-personal-shopping-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Personal Shopping Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/concierge-personal-shopping-plan/scripts/agent.py
+++ b/family-office/concierge-personal-shopping-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Personal Shopping Plan skill.
+"""Agent runtime for the Personal Shopping Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Personal Shopping Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("occasion_or_purpose", "Occasion or purpose?"),
     ("budget_range", "Budget range?"),
     ("brand_preferences", "Brand preferences?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("returns_policy_requirements", "Returns policy requirements?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/concierge-private-aviation-plan/.env.example
+++ b/family-office/concierge-private-aviation-plan/.env.example
@@ -1,9 +1,24 @@
 # Private Aviation Coordination Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/concierge-private-aviation-plan/requirements.txt
+++ b/family-office/concierge-private-aviation-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Private Aviation Coordination Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/concierge-private-aviation-plan/scripts/agent.py
+++ b/family-office/concierge-private-aviation-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Private Aviation Coordination Plan skill.
+"""Agent runtime for the Private Aviation Coordination Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Private Aviation Coordination Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("operators_in_use", "Operators in use?"),
     ("preferred_aircraft", "Preferred aircraft class?"),
     ("typical_routes", "Typical routes?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("catering_preferences", "Catering preferences?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/concierge-private-car-plan/.env.example
+++ b/family-office/concierge-private-car-plan/.env.example
@@ -1,9 +1,24 @@
 # Private Car Coordination Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/concierge-private-car-plan/requirements.txt
+++ b/family-office/concierge-private-car-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Private Car Coordination Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/concierge-private-car-plan/scripts/agent.py
+++ b/family-office/concierge-private-car-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Private Car Coordination Plan skill.
+"""Agent runtime for the Private Car Coordination Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Private Car Coordination Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("operators_in_use", "Operators in use?"),
     ("preferred_drivers", "Preferred drivers?"),
     ("preferred_vehicles", "Preferred vehicles?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("billing_arrangement", "Billing arrangement?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/concierge-travel-coordination-plan/.env.example
+++ b/family-office/concierge-travel-coordination-plan/.env.example
@@ -1,9 +1,24 @@
 # Travel Coordination Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/concierge-travel-coordination-plan/requirements.txt
+++ b/family-office/concierge-travel-coordination-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Travel Coordination Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/concierge-travel-coordination-plan/scripts/agent.py
+++ b/family-office/concierge-travel-coordination-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Travel Coordination Plan skill.
+"""Agent runtime for the Travel Coordination Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Travel Coordination Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("destination", "Destination(s)?"),
     ("travel_dates", "Travel dates?"),
     ("party_size", "Party size and composition?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("contingencies_to_plan", "Contingencies to plan for?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/consolidated-reporting-spec/.env.example
+++ b/family-office/consolidated-reporting-spec/.env.example
@@ -1,9 +1,24 @@
 # Consolidated Reporting Specification — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/consolidated-reporting-spec/requirements.txt
+++ b/family-office/consolidated-reporting-spec/requirements.txt
@@ -1,4 +1,13 @@
 # Consolidated Reporting Specification
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/consolidated-reporting-spec/scripts/agent.py
+++ b/family-office/consolidated-reporting-spec/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Consolidated Reporting Specification skill.
+"""Agent runtime for the Consolidated Reporting Specification skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Consolidated Reporting Specification"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("reporting_platform", "Reporting platform (Addepar / Masttro / Eton / spreadsheet)?"),
     ("entities_to_consolidate", "Entities to consolidate?"),
     ("asset_classes_in_scope", "Asset classes in scope?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("recipient_list", "Recipient list and their views?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/cpa-tax-package-checklist/.env.example
+++ b/family-office/cpa-tax-package-checklist/.env.example
@@ -1,9 +1,24 @@
 # CPA Tax Package Checklist — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/cpa-tax-package-checklist/requirements.txt
+++ b/family-office/cpa-tax-package-checklist/requirements.txt
@@ -1,4 +1,13 @@
 # CPA Tax Package Checklist
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/cpa-tax-package-checklist/scripts/agent.py
+++ b/family-office/cpa-tax-package-checklist/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the CPA Tax Package Checklist skill.
+"""Agent runtime for the CPA Tax Package Checklist skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "CPA Tax Package Checklist"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("tax_year", "Tax year?"),
     ("entities_in_scope", "Entities in scope (comma-separated legal names)?"),
     ("key_income_sources", "Key income sources?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("cpa_deadline", "CPA deadline for receipt (ISO date)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/cpa-tax-package-checklist/scripts/snowflake_setup.sql
+++ b/family-office/cpa-tax-package-checklist/scripts/snowflake_setup.sql
@@ -1,0 +1,39 @@
+-- One-time Snowflake customer setup for the Seren family-office catalog.
+-- Run this once in the customer's warehouse before enabling Snowflake push
+-- on any family-office leaf skill. Once FO_ARTIFACTS exists, all 55 leaves
+-- can write to it — this file ships alongside cpa-tax-package-checklist as
+-- the canonical reference.
+--
+-- Credential principle: whatever role the skill authenticates as must have
+-- INSERT privilege on FO_ARTIFACTS in the target schema — nothing more.
+
+-- 1. Target database/schema (edit for your warehouse layout):
+--    USE DATABASE FO_DB;
+--    USE SCHEMA SEREN;
+
+-- 2. The sink table. Idempotent.
+CREATE TABLE IF NOT EXISTS FO_ARTIFACTS (
+  artifact_id        STRING      NOT NULL,
+  pillar             STRING      NOT NULL,
+  skill_name         STRING      NOT NULL,
+  artifact_name      STRING      NOT NULL,
+  artifact_version   INTEGER     NOT NULL,
+  created_at         TIMESTAMP_TZ NOT NULL,
+  created_by         STRING      NOT NULL,
+  content_hash       STRING      NOT NULL,
+  structured_payload VARIANT,
+  PRIMARY KEY (artifact_id)
+);
+
+-- 3. A least-privilege write role the skill can authenticate as.
+--    Replace FO_WRITER and the target schema path to match your warehouse.
+-- CREATE ROLE IF NOT EXISTS FO_WRITER;
+-- GRANT USAGE ON WAREHOUSE FO_WH TO ROLE FO_WRITER;
+-- GRANT USAGE ON DATABASE FO_DB TO ROLE FO_WRITER;
+-- GRANT USAGE ON SCHEMA FO_DB.SEREN TO ROLE FO_WRITER;
+-- GRANT INSERT ON TABLE FO_DB.SEREN.FO_ARTIFACTS TO ROLE FO_WRITER;
+
+-- 4. External-browser SSO users need no further secret. If you prefer
+--    password or key-pair auth, provision accordingly and set the
+--    SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_PATH env var at invocation
+--    time — NEVER in config.json.

--- a/family-office/cpa-tax-package-checklist/tests/test_sinks.py
+++ b/family-office/cpa-tax-package-checklist/tests/test_sinks.py
@@ -1,0 +1,359 @@
+"""Critical tests for the push_to_* functions on the reference leaf.
+
+One reference leaf covers the push-contract tests. The other 54 leaves share
+the same template, so per-leaf duplication of these tests would be pure
+DRY-violation and adds no bug-catching power.
+
+Scope:
+  1. Each push is a no-op when its config block is absent.
+  2. Each push validates required config keys and rejects missing ones.
+  3. Each push invokes the right publisher / auth path when config is present
+     (GatewayClient + snowflake.connector.connect are stubbed).
+  4. PII redaction runs on the Snowflake structured payload before ingest.
+  5. SharePoint URLs / Asana responses are never logged at INFO.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent_sinks"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest() -> dict:
+    return {
+        "artifact_id": "artifact:cpa-tax-package-checklist-deadbeef0000",
+        "skill": "cpa-tax-package-checklist",
+        "pillar": "complexity-management",
+        "artifact_name": "CPA Tax Package Checklist",
+        "artifact_version": 1,
+        "created_at": "2026-04-20T16:00:00+00:00",
+        "content_hash": "deadbeef" * 8,
+        "out_dir": "/tmp/irrelevant",
+    }
+
+
+def _answers() -> dict:
+    return {"tax_year": "2026", "cpa_firm": "Johnson & Co.", "entities_in_scope": "Smith Trust"}
+
+
+# ── No-op when config absent ────────────────────────────────────────────
+
+def test_sharepoint_push_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_sharepoint(_manifest(), config=None) is None
+    assert agent.push_to_sharepoint(_manifest(), config={}) is None
+    assert agent.push_to_sharepoint(_manifest(), config={"other": "thing"}) is None
+
+
+def test_asana_push_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_asana(_manifest(), _answers(), config=None) is None
+    assert agent.push_to_asana(_manifest(), _answers(), config={}) is None
+
+
+def test_snowflake_push_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_snowflake(_manifest(), _answers(), config=None) is None
+    assert agent.push_to_snowflake(_manifest(), _answers(), config={}) is None
+
+
+# ── Required-key validation (negative tests) ────────────────────────────
+
+def test_sharepoint_push_rejects_missing_required_keys() -> None:
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="sharepoint config missing"):
+        agent.push_to_sharepoint(
+            _manifest(), config={"sharepoint": {"site_id": "s"}}
+        )
+
+
+def test_asana_push_rejects_missing_required_keys() -> None:
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="asana config missing"):
+        agent.push_to_asana(
+            _manifest(), _answers(), config={"asana": {"workspace_gid": "1"}}
+        )
+
+
+def test_snowflake_push_rejects_missing_required_keys() -> None:
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="snowflake config missing"):
+        agent.push_to_snowflake(
+            _manifest(),
+            _answers(),
+            config={"snowflake": {"account": "a", "user": "u"}},
+        )
+
+
+# ── Happy path with stubbed transport ───────────────────────────────────
+
+def _stub_gateway(monkeypatch, module, captured: list) -> None:
+    """Replace GatewayClient with one that records calls instead of hitting
+    the network. SEREN_API_KEY still must be present (so we also stub the
+    env var)."""
+    monkeypatch.setenv("SEREN_API_KEY", "test-key")
+
+    class _StubGateway:
+        def __init__(self, **kwargs) -> None:  # noqa: ARG002
+            pass
+
+        def call_publisher(self, publisher, method, path, *, body=None):
+            captured.append(
+                {"publisher": publisher, "method": method, "path": path, "body": body}
+            )
+            return {"ok": True, "returned_url": "https://redacted.example/never-log"}
+
+    monkeypatch.setattr(module, "GatewayClient", _StubGateway)
+
+
+def test_sharepoint_push_calls_microsoft_sharepoint_with_upload_body(
+    monkeypatch, tmp_path
+) -> None:
+    agent = _load_agent()
+
+    # Real artifact on disk so the push can read it.
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "artifact.md").write_text("# Artifact body\n", encoding="utf-8")
+    manifest = _manifest()
+    manifest["out_dir"] = str(out)
+
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    result = agent.push_to_sharepoint(
+        manifest,
+        config={
+            "sharepoint": {
+                "site_id": "contoso.sharepoint.com,aaa,bbb",
+                "drive_id": "b!abc",
+                "folder_path": "/Seren/family-office",
+            }
+        },
+    )
+
+    assert result is not None
+    assert result["publisher"] == "microsoft-sharepoint"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["publisher"] == "microsoft-sharepoint"
+    assert call["method"] == "POST"
+    assert call["path"] == "/files/upload"
+    body = call["body"]
+    assert body["site_id"] == "contoso.sharepoint.com,aaa,bbb"
+    assert body["drive_id"] == "b!abc"
+    assert body["path"].startswith("/Seren/family-office/cpa-tax-package-checklist/")
+    assert body["path"].endswith("/artifact.md")
+    assert body["content"] == "# Artifact body\n"
+    assert body["content_type"].startswith("text/markdown")
+
+
+def test_asana_push_creates_task_with_expected_fields(monkeypatch) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    result = agent.push_to_asana(
+        _manifest(),
+        _answers(),
+        config={
+            "asana": {
+                "workspace_gid": "WS1",
+                "project_gid": "P1",
+                "assignee_gid": "U1",
+            }
+        },
+    )
+    assert result is not None
+    assert result["publisher"] == "asana"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["publisher"] == "asana"
+    assert call["method"] == "POST"
+    assert call["path"] == "/tasks"
+    data = call["body"]["data"]
+    assert data["workspace"] == "WS1"
+    assert data["projects"] == ["P1"]
+    assert data["assignee"] == "U1"
+    assert "CPA Tax Package Checklist" in data["name"]
+    assert "artifact:cpa-tax-package-checklist" in data["notes"]
+
+
+def test_snowflake_push_insert_parameters_and_redacts_pii(monkeypatch) -> None:
+    agent = _load_agent()
+
+    captured: dict = {}
+
+    class _StubCursor:
+        def __init__(self) -> None:
+            self.sfqid = "query-id-xyz"
+
+        def execute(self, sql, params):
+            captured["sql"] = sql
+            captured["params"] = params
+
+        def close(self):
+            pass
+
+    class _StubConn:
+        def __init__(self, **kwargs):
+            captured["connect_kwargs"] = kwargs
+
+        def cursor(self):
+            return _StubCursor()
+
+        def commit(self):
+            captured["committed"] = True
+
+        def close(self):
+            captured["closed"] = True
+
+    # Stub the snowflake.connector module before the push function imports it.
+    stub_connector = SimpleNamespace(connect=lambda **kw: _StubConn(**kw))
+    stub_module = SimpleNamespace(connector=stub_connector)
+    monkeypatch.setitem(sys.modules, "snowflake", stub_module)
+    monkeypatch.setitem(sys.modules, "snowflake.connector", stub_connector)
+
+    # Include a PII-bearing answer to verify redaction before ingest.
+    answers_with_pii = dict(_answers())
+    answers_with_pii["principal_ssn"] = "123-45-6789"
+    answers_with_pii["trust_ein"] = "12-3456789"
+
+    result = agent.push_to_snowflake(
+        _manifest(),
+        answers_with_pii,
+        config={
+            "snowflake": {
+                "account": "rendero.us-east-1",
+                "user": "seren_agent",
+                "warehouse": "FO_WH",
+                "database": "FO_DB",
+                "schema": "SEREN",
+                "role": "FO_WRITER",
+                # authenticator defaults to externalbrowser
+            }
+        },
+    )
+
+    assert result is not None
+    assert result["publisher"] == "snowflake"
+    assert result["query_id"] == "query-id-xyz"
+
+    # External-browser auth was selected by default (no password env var).
+    connect_kwargs = captured["connect_kwargs"]
+    assert connect_kwargs["authenticator"] == "externalbrowser"
+    assert connect_kwargs["user"] == "seren_agent"
+    assert connect_kwargs["warehouse"] == "FO_WH"
+    assert connect_kwargs["role"] == "FO_WRITER"
+    assert "password" not in connect_kwargs
+    assert "private_key_file" not in connect_kwargs
+
+    # SQL is parameterized; structured_payload redacts PII before it leaves
+    # the process.
+    sql = captured["sql"]
+    assert "INSERT INTO FO_ARTIFACTS" in sql
+    assert "PARSE_JSON(%s)" in sql
+    assert "123-45-6789" not in sql  # never inlined
+
+    params = captured["params"]
+    structured_json = params[-1]  # last param is structured_payload
+    payload = json.loads(structured_json)
+    # Raw SSN/EIN values must have been redacted.
+    assert "123-45-6789" not in structured_json
+    assert "12-3456789" not in structured_json
+    # The PII-bearing keys themselves are also redacted.
+    assert payload["inputs"]["principal_ssn"] == "<redacted>"
+    assert payload["inputs"]["trust_ein"] == "<redacted>"
+    # Non-PII inputs are preserved verbatim.
+    assert payload["inputs"]["tax_year"] == "2026"
+
+    assert captured["committed"] is True
+    assert captured["closed"] is True
+
+
+def test_snowflake_password_auth_requires_env_var(monkeypatch) -> None:
+    agent = _load_agent()
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    with pytest.raises(ValueError, match="SNOWFLAKE_PASSWORD"):
+        agent.push_to_snowflake(
+            _manifest(),
+            _answers(),
+            config={
+                "snowflake": {
+                    "account": "a",
+                    "user": "u",
+                    "warehouse": "w",
+                    "database": "d",
+                    "schema": "s",
+                    "authenticator": "snowflake",
+                }
+            },
+        )
+
+
+def test_snowflake_jwt_auth_requires_private_key_env_var(monkeypatch) -> None:
+    agent = _load_agent()
+    monkeypatch.delenv("SNOWFLAKE_PRIVATE_KEY_PATH", raising=False)
+    with pytest.raises(ValueError, match="SNOWFLAKE_PRIVATE_KEY_PATH"):
+        agent.push_to_snowflake(
+            _manifest(),
+            _answers(),
+            config={
+                "snowflake": {
+                    "account": "a",
+                    "user": "u",
+                    "warehouse": "w",
+                    "database": "d",
+                    "schema": "s",
+                    "authenticator": "snowflake_jwt",
+                }
+            },
+        )
+
+
+# ── Logging hygiene ─────────────────────────────────────────────────────
+
+def test_sharepoint_push_never_logs_returned_url_at_info_level(
+    monkeypatch, tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    agent = _load_agent()
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "artifact.md").write_text("body", encoding="utf-8")
+    manifest = _manifest()
+    manifest["out_dir"] = str(out)
+
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    with caplog.at_level(logging.INFO, logger=f"family_office.{agent.SKILL_NAME}"):
+        agent.push_to_sharepoint(
+            manifest,
+            config={
+                "sharepoint": {
+                    "site_id": "s",
+                    "drive_id": "d",
+                    "folder_path": "/Seren/family-office",
+                }
+            },
+        )
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "redacted.example" not in joined
+    assert "returned_url" not in joined

--- a/family-office/document-management-plan/.env.example
+++ b/family-office/document-management-plan/.env.example
@@ -1,9 +1,24 @@
 # Document Management Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/document-management-plan/requirements.txt
+++ b/family-office/document-management-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Document Management Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/document-management-plan/scripts/agent.py
+++ b/family-office/document-management-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Document Management Plan skill.
+"""Agent runtime for the Document Management Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Document Management Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("dms_platforms", "DMS platforms in use (SharePoint / Egnyte / Box)?"),
     ("top_level_taxonomy", "Top-level folder taxonomy?"),
     ("retention_defaults", "Retention defaults by document kind?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("audit_cadence", "Access audit cadence?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/esg-impact-investing-mandate/.env.example
+++ b/family-office/esg-impact-investing-mandate/.env.example
@@ -1,9 +1,24 @@
 # ESG / Impact Investing Mandate — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/esg-impact-investing-mandate/requirements.txt
+++ b/family-office/esg-impact-investing-mandate/requirements.txt
@@ -1,4 +1,13 @@
 # ESG / Impact Investing Mandate
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/esg-impact-investing-mandate/scripts/agent.py
+++ b/family-office/esg-impact-investing-mandate/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the ESG / Impact Investing Mandate skill.
+"""Agent runtime for the ESG / Impact Investing Mandate skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "ESG / Impact Investing Mandate"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("themes", "Priority impact themes?"),
     ("exclusions", "Hard exclusions (sectors / behaviors)?"),
     ("measurement_framework", "Measurement framework (IRIS+, SDG, custom)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("mandate_allocation_pct", "Target allocation % to mandate-aligned managers?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/estate-plan-summary-memo/.env.example
+++ b/family-office/estate-plan-summary-memo/.env.example
@@ -1,9 +1,24 @@
 # Estate Plan Summary Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/estate-plan-summary-memo/requirements.txt
+++ b/family-office/estate-plan-summary-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Estate Plan Summary Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/estate-plan-summary-memo/scripts/agent.py
+++ b/family-office/estate-plan-summary-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Estate Plan Summary Memo skill.
+"""Agent runtime for the Estate Plan Summary Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Estate Plan Summary Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("current_documents", "Current estate documents in place?"),
     ("trustee_guardians", "Current trustees / guardians?"),
     ("beneficiary_designations_review", "Recent beneficiary designation review?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("counsel", "Estate counsel?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/expedited-funding-access-plan/.env.example
+++ b/family-office/expedited-funding-access-plan/.env.example
@@ -1,9 +1,24 @@
 # Expedited Funding Access Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/expedited-funding-access-plan/requirements.txt
+++ b/family-office/expedited-funding-access-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Expedited Funding Access Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/expedited-funding-access-plan/scripts/agent.py
+++ b/family-office/expedited-funding-access-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Expedited Funding Access Plan skill.
+"""Agent runtime for the Expedited Funding Access Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Expedited Funding Access Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("target_access_amount", "Target liquidity access amount?"),
     ("acceptable_rate_range", "Acceptable rate range?"),
     ("collateral_candidates", "Collateral candidates (brokerage, art, real estate)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("existing_credit_lines", "Existing credit lines?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/external-advisor-management-plan/.env.example
+++ b/family-office/external-advisor-management-plan/.env.example
@@ -1,9 +1,24 @@
 # External Advisor Management Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/external-advisor-management-plan/requirements.txt
+++ b/family-office/external-advisor-management-plan/requirements.txt
@@ -1,4 +1,13 @@
 # External Advisor Management Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/external-advisor-management-plan/scripts/agent.py
+++ b/family-office/external-advisor-management-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the External Advisor Management Plan skill.
+"""Agent runtime for the External Advisor Management Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "External Advisor Management Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("advisor_roster", "Advisor roster (name, firm, role)?"),
     ("meeting_cadence", "Meeting cadence per advisor?"),
     ("fee_summary", "Fee summary (flat / hourly / AUM)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("open_issues", "Open coordination issues?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-board-development-plan/.env.example
+++ b/family-office/family-board-development-plan/.env.example
@@ -1,9 +1,24 @@
 # Family Board Development Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-board-development-plan/requirements.txt
+++ b/family-office/family-board-development-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Family Board Development Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-board-development-plan/scripts/agent.py
+++ b/family-office/family-board-development-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Board Development Plan skill.
+"""Agent runtime for the Family Board Development Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Board Development Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("current_board_members", "Current board members and roles?"),
     ("skills_matrix_gaps", "Skills matrix gaps?"),
     ("recruitment_targets", "Recruitment targets?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("evaluation_cadence", "Evaluation cadence?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-foundation-formation-plan/.env.example
+++ b/family-office/family-foundation-formation-plan/.env.example
@@ -1,9 +1,24 @@
 # Family Foundation Formation Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-foundation-formation-plan/requirements.txt
+++ b/family-office/family-foundation-formation-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Family Foundation Formation Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-foundation-formation-plan/scripts/agent.py
+++ b/family-office/family-foundation-formation-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Foundation Formation Plan skill.
+"""Agent runtime for the Family Foundation Formation Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Foundation Formation Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("foundation_name", "Proposed foundation name?"),
     ("initial_funding", "Initial funding amount?"),
     ("legal_structure", "Structure (private operating vs non-operating)?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("counsel", "Counsel firm?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-governance-charter/.env.example
+++ b/family-office/family-governance-charter/.env.example
@@ -1,9 +1,24 @@
 # Family Governance Charter — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-governance-charter/requirements.txt
+++ b/family-office/family-governance-charter/requirements.txt
@@ -1,4 +1,13 @@
 # Family Governance Charter
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-governance-charter/scripts/agent.py
+++ b/family-office/family-governance-charter/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Governance Charter skill.
+"""Agent runtime for the Family Governance Charter skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Governance Charter"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("governance_principles", "Governance principles?"),
     ("bodies", "Governance bodies (council / board / committees)?"),
     ("roles", "Defined roles?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("conflict_resolution", "Conflict-resolution process?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-meeting-agenda-minutes-template/.env.example
+++ b/family-office/family-meeting-agenda-minutes-template/.env.example
@@ -1,9 +1,24 @@
 # Family Meeting Agenda & Minutes Template — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-meeting-agenda-minutes-template/requirements.txt
+++ b/family-office/family-meeting-agenda-minutes-template/requirements.txt
@@ -1,4 +1,13 @@
 # Family Meeting Agenda & Minutes Template
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
+++ b/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Meeting Agenda & Minutes Template skill.
+"""Agent runtime for the Family Meeting Agenda & Minutes Template skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Meeting Agenda & Minutes Template"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("meeting_type", "Meeting type (council / board / family assembly)?"),
     ("cadence", "Cadence?"),
     ("standing_agenda_items", "Standing agenda items?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("decision_record_format", "Decision record format?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-mission-statement/.env.example
+++ b/family-office/family-mission-statement/.env.example
@@ -1,9 +1,24 @@
 # Family Mission Statement — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-mission-statement/requirements.txt
+++ b/family-office/family-mission-statement/requirements.txt
@@ -1,4 +1,13 @@
 # Family Mission Statement
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-mission-statement/scripts/agent.py
+++ b/family-office/family-mission-statement/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Mission Statement skill.
+"""Agent runtime for the Family Mission Statement skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,16 +45,56 @@ ARTIFACT_NAME = "Family Mission Statement"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("core_values", "Three to five core values?"),
     ("purpose_statement", "Family's purpose in one sentence?"),
     ("guiding_principles", "Guiding principles across generations?"),
     ("aspirations", "Aspirations for the next 10-30 years?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -56,12 +104,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -71,8 +115,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -114,18 +157,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -142,22 +183,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -178,12 +219,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -236,6 +271,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -271,7 +588,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -279,16 +595,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-philanthropy-strategic-plan/.env.example
+++ b/family-office/family-philanthropy-strategic-plan/.env.example
@@ -1,9 +1,24 @@
 # Family Philanthropy Strategic Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-philanthropy-strategic-plan/requirements.txt
+++ b/family-office/family-philanthropy-strategic-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Family Philanthropy Strategic Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-philanthropy-strategic-plan/scripts/agent.py
+++ b/family-office/family-philanthropy-strategic-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Philanthropy Strategic Plan skill.
+"""Agent runtime for the Family Philanthropy Strategic Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Philanthropy Strategic Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("mission", "Philanthropic mission statement?"),
     ("priority_causes", "Priority causes?"),
     ("annual_giving_budget", "Annual giving budget?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("family_engagement", "Family engagement model?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/family-risk-management-plan/.env.example
+++ b/family-office/family-risk-management-plan/.env.example
@@ -1,9 +1,24 @@
 # Family Risk Management Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/family-risk-management-plan/requirements.txt
+++ b/family-office/family-risk-management-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Family Risk Management Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/family-risk-management-plan/scripts/agent.py
+++ b/family-office/family-risk-management-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Family Risk Management Plan skill.
+"""Agent runtime for the Family Risk Management Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Family Risk Management Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("risk_categories_in_scope", "Risk categories in scope?"),
     ("cyber_posture", "Cyber posture (endpoint, identity, backup)?"),
     ("travel_risks", "Upcoming travel with risk profile?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("business_continuity", "Business-continuity arrangements?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/healthcare-proxy-living-will-checklist/.env.example
+++ b/family-office/healthcare-proxy-living-will-checklist/.env.example
@@ -1,9 +1,24 @@
 # Healthcare Proxy & Living Will Checklist — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/healthcare-proxy-living-will-checklist/requirements.txt
+++ b/family-office/healthcare-proxy-living-will-checklist/requirements.txt
@@ -1,4 +1,13 @@
 # Healthcare Proxy & Living Will Checklist
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
+++ b/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Healthcare Proxy & Living Will Checklist skill.
+"""Agent runtime for the Healthcare Proxy & Living Will Checklist skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Healthcare Proxy & Living Will Checklist"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("agent_primary", "Primary healthcare agent?"),
     ("agent_alternate", "Alternate agent?"),
     ("end_of_life_directives", "End-of-life directives (resuscitation, life support)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("hipaa_authorized_persons", "HIPAA-authorized persons?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/insurance-coverage-review-worksheet/.env.example
+++ b/family-office/insurance-coverage-review-worksheet/.env.example
@@ -1,9 +1,24 @@
 # Insurance Coverage Review Worksheet — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/insurance-coverage-review-worksheet/requirements.txt
+++ b/family-office/insurance-coverage-review-worksheet/requirements.txt
@@ -1,4 +1,13 @@
 # Insurance Coverage Review Worksheet
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/insurance-coverage-review-worksheet/scripts/agent.py
+++ b/family-office/insurance-coverage-review-worksheet/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Insurance Coverage Review Worksheet skill.
+"""Agent runtime for the Insurance Coverage Review Worksheet skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Insurance Coverage Review Worksheet"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("coverage_types_in_scope", "Coverage types in scope (comma-separated)?"),
     ("carriers_in_force", "Carriers in force?"),
     ("known_gaps", "Known gaps in coverage?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("broker_relationship", "Primary insurance broker?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/insurance-procurement-framework/.env.example
+++ b/family-office/insurance-procurement-framework/.env.example
@@ -1,9 +1,24 @@
 # Insurance Procurement Framework — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/insurance-procurement-framework/requirements.txt
+++ b/family-office/insurance-procurement-framework/requirements.txt
@@ -1,4 +1,13 @@
 # Insurance Procurement Framework
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/insurance-procurement-framework/scripts/agent.py
+++ b/family-office/insurance-procurement-framework/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Insurance Procurement Framework skill.
+"""Agent runtime for the Insurance Procurement Framework skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Insurance Procurement Framework"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("coverage_goal", "Coverage goal (what risk is being hedged)?"),
     ("asset_or_exposure_size", "Asset or exposure size?"),
     ("broker_candidates", "Broker candidates?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("target_premium_range", "Target premium range?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/investment-operations-review-checklist/.env.example
+++ b/family-office/investment-operations-review-checklist/.env.example
@@ -1,9 +1,24 @@
 # Investment Operations Review Checklist — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/investment-operations-review-checklist/requirements.txt
+++ b/family-office/investment-operations-review-checklist/requirements.txt
@@ -1,4 +1,13 @@
 # Investment Operations Review Checklist
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/investment-operations-review-checklist/scripts/agent.py
+++ b/family-office/investment-operations-review-checklist/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Investment Operations Review Checklist skill.
+"""Agent runtime for the Investment Operations Review Checklist skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Investment Operations Review Checklist"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("review_period", "Review period (e.g. \"2026 H1\")?"),
     ("custodians_in_scope", "Custodians in scope?"),
     ("reporting_source", "Reporting source of truth (Addepar / Masttro / Eton)?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("open_exceptions", "Open operational exceptions to resolve?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/leisure-asset-ownership-comparison/.env.example
+++ b/family-office/leisure-asset-ownership-comparison/.env.example
@@ -1,9 +1,24 @@
 # Leisure Asset Ownership Comparison — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/leisure-asset-ownership-comparison/requirements.txt
+++ b/family-office/leisure-asset-ownership-comparison/requirements.txt
@@ -1,4 +1,13 @@
 # Leisure Asset Ownership Comparison
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/leisure-asset-ownership-comparison/scripts/agent.py
+++ b/family-office/leisure-asset-ownership-comparison/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Leisure Asset Ownership Comparison skill.
+"""Agent runtime for the Leisure Asset Ownership Comparison skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Leisure Asset Ownership Comparison"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("asset_type", "Asset type (jet / yacht / car / wine)?"),
     ("expected_usage_hours", "Expected annual usage (hours or days)?"),
     ("full_ownership_cost_estimate", "Full ownership cost estimate (acquisition + annual carry)?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("non_financial_factors", "Non-financial factors that matter?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/long-term-portfolio-strategy-plan/.env.example
+++ b/family-office/long-term-portfolio-strategy-plan/.env.example
@@ -1,9 +1,24 @@
 # Long-Term Portfolio Strategy Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/long-term-portfolio-strategy-plan/requirements.txt
+++ b/family-office/long-term-portfolio-strategy-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Long-Term Portfolio Strategy Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
+++ b/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Long-Term Portfolio Strategy Plan skill.
+"""Agent runtime for the Long-Term Portfolio Strategy Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Long-Term Portfolio Strategy Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("time_horizon", "Time horizon (years) for the strategy?"),
     ("liquidity_needs", "Annual liquidity needs (range, e.g. \"$2M-$4M\")?"),
     ("return_target", "Real return target (e.g. \"CPI + 4%\")?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("review_cadence", "Review cadence (annual / semi-annual / quarterly)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-direct-co-investment/.env.example
+++ b/family-office/manager-dd-direct-co-investment/.env.example
@@ -1,9 +1,24 @@
 # Direct / Co-Investment DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-direct-co-investment/requirements.txt
+++ b/family-office/manager-dd-direct-co-investment/requirements.txt
@@ -1,4 +1,13 @@
 # Direct / Co-Investment DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-direct-co-investment/scripts/agent.py
+++ b/family-office/manager-dd-direct-co-investment/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Direct / Co-Investment DD Memo skill.
+"""Agent runtime for the Direct / Co-Investment DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Direct / Co-Investment DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("company_name", "Company name?"),
     ("sponsor", "Lead sponsor?"),
     ("round_type", "Round type (Series X / secondary / co-invest SPV)?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("key_terms", "Key terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-esg-impact/.env.example
+++ b/family-office/manager-dd-esg-impact/.env.example
@@ -1,9 +1,24 @@
 # ESG / Impact Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-esg-impact/requirements.txt
+++ b/family-office/manager-dd-esg-impact/requirements.txt
@@ -1,4 +1,13 @@
 # ESG / Impact Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-esg-impact/scripts/agent.py
+++ b/family-office/manager-dd-esg-impact/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the ESG / Impact Manager DD Memo skill.
+"""Agent runtime for the ESG / Impact Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "ESG / Impact Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "Manager name?"),
     ("mandate", "Mandate (environment / social / governance / blended)?"),
     ("impact_metrics", "Impact metrics tracked?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-hedge-fund/.env.example
+++ b/family-office/manager-dd-hedge-fund/.env.example
@@ -1,9 +1,24 @@
 # Hedge Fund Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-hedge-fund/requirements.txt
+++ b/family-office/manager-dd-hedge-fund/requirements.txt
@@ -1,4 +1,13 @@
 # Hedge Fund Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-hedge-fund/scripts/agent.py
+++ b/family-office/manager-dd-hedge-fund/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Hedge Fund Manager DD Memo skill.
+"""Agent runtime for the Hedge Fund Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Hedge Fund Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "Manager name?"),
     ("strategy", "Strategy (long/short, global macro, event-driven, etc.)?"),
     ("aum", "Fund AUM?"),
@@ -47,10 +57,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms (mgmt / perf / hurdle)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -60,12 +108,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -75,8 +119,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -118,18 +161,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -146,22 +187,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -182,12 +223,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -240,6 +275,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -275,7 +592,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -283,16 +599,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-private-debt/.env.example
+++ b/family-office/manager-dd-private-debt/.env.example
@@ -1,9 +1,24 @@
 # Private Debt Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-private-debt/requirements.txt
+++ b/family-office/manager-dd-private-debt/requirements.txt
@@ -1,4 +1,13 @@
 # Private Debt Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-private-debt/scripts/agent.py
+++ b/family-office/manager-dd-private-debt/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Private Debt Manager DD Memo skill.
+"""Agent runtime for the Private Debt Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Private Debt Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "Manager name?"),
     ("strategy", "Strategy (direct lending, mezz, distressed, specialty)?"),
     ("loss_rate_history", "Loss rate history?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-private-equity/.env.example
+++ b/family-office/manager-dd-private-equity/.env.example
@@ -1,9 +1,24 @@
 # Private Equity Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-private-equity/requirements.txt
+++ b/family-office/manager-dd-private-equity/requirements.txt
@@ -1,4 +1,13 @@
 # Private Equity Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-private-equity/scripts/agent.py
+++ b/family-office/manager-dd-private-equity/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Private Equity Manager DD Memo skill.
+"""Agent runtime for the Private Equity Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Private Equity Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "GP / manager name?"),
     ("fund_name", "Fund name / vintage?"),
     ("sector_focus", "Sector focus?"),
@@ -47,10 +57,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("minimum_commit", "Minimum commitment size?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -60,12 +108,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -75,8 +119,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -118,18 +161,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -146,22 +187,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -182,12 +223,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -240,6 +275,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -275,7 +592,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -283,16 +599,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-real-assets/.env.example
+++ b/family-office/manager-dd-real-assets/.env.example
@@ -1,9 +1,24 @@
 # Real Assets Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-real-assets/requirements.txt
+++ b/family-office/manager-dd-real-assets/requirements.txt
@@ -1,4 +1,13 @@
 # Real Assets Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-real-assets/scripts/agent.py
+++ b/family-office/manager-dd-real-assets/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Real Assets Manager DD Memo skill.
+"""Agent runtime for the Real Assets Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Real Assets Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "Manager name?"),
     ("asset_class", "Asset class (infrastructure / commodities / natural resources)?"),
     ("inflation_hedge_profile", "Inflation-hedging profile?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-real-estate/.env.example
+++ b/family-office/manager-dd-real-estate/.env.example
@@ -1,9 +1,24 @@
 # Real Estate Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-real-estate/requirements.txt
+++ b/family-office/manager-dd-real-estate/requirements.txt
@@ -1,4 +1,13 @@
 # Real Estate Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-real-estate/scripts/agent.py
+++ b/family-office/manager-dd-real-estate/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Real Estate Manager DD Memo skill.
+"""Agent runtime for the Real Estate Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Real Estate Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "Manager name?"),
     ("property_type", "Property type (multifamily, industrial, office, retail, niche)?"),
     ("geography", "Geographic focus?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/manager-dd-venture-capital/.env.example
+++ b/family-office/manager-dd-venture-capital/.env.example
@@ -1,9 +1,24 @@
 # Venture Capital Manager DD Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/manager-dd-venture-capital/requirements.txt
+++ b/family-office/manager-dd-venture-capital/requirements.txt
@@ -1,4 +1,13 @@
 # Venture Capital Manager DD Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/manager-dd-venture-capital/scripts/agent.py
+++ b/family-office/manager-dd-venture-capital/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Venture Capital Manager DD Memo skill.
+"""Agent runtime for the Venture Capital Manager DD Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Venture Capital Manager DD Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("manager_name", "GP name?"),
     ("fund_name", "Fund name / vintage?"),
     ("stage_focus", "Stage focus (pre-seed / seed / A / growth)?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("fee_terms", "Fee terms?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/new-business-diligence-memo/.env.example
+++ b/family-office/new-business-diligence-memo/.env.example
@@ -1,9 +1,24 @@
 # New Business Diligence Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/new-business-diligence-memo/requirements.txt
+++ b/family-office/new-business-diligence-memo/requirements.txt
@@ -1,4 +1,13 @@
 # New Business Diligence Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/new-business-diligence-memo/scripts/agent.py
+++ b/family-office/new-business-diligence-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the New Business Diligence Memo skill.
+"""Agent runtime for the New Business Diligence Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "New Business Diligence Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("business_name", "Target business name?"),
     ("business_type", "Business type / sector?"),
     ("investment_size", "Expected investment size?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("next_steps", "Next diligence steps required?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/next-generation-education-curriculum/.env.example
+++ b/family-office/next-generation-education-curriculum/.env.example
@@ -1,9 +1,24 @@
 # Next-Generation Education Curriculum — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/next-generation-education-curriculum/requirements.txt
+++ b/family-office/next-generation-education-curriculum/requirements.txt
@@ -1,4 +1,13 @@
 # Next-Generation Education Curriculum
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/next-generation-education-curriculum/scripts/agent.py
+++ b/family-office/next-generation-education-curriculum/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Next-Generation Education Curriculum skill.
+"""Agent runtime for the Next-Generation Education Curriculum skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Next-Generation Education Curriculum"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("learners", "Learners (ages and names)?"),
     ("themes", "Curriculum themes (history / financial literacy / philanthropy / values)?"),
     ("cadence", "Cadence (weekly / monthly / annual retreat)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("outside_speakers", "Outside speakers / mentors desired?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/password-management-setup-plan/.env.example
+++ b/family-office/password-management-setup-plan/.env.example
@@ -1,9 +1,24 @@
 # Password Management Setup Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/password-management-setup-plan/requirements.txt
+++ b/family-office/password-management-setup-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Password Management Setup Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/password-management-setup-plan/scripts/agent.py
+++ b/family-office/password-management-setup-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Password Management Setup Plan skill.
+"""Agent runtime for the Password Management Setup Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Password Management Setup Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("vault_platform", "Vault platform (1Password / Bitwarden / other)?"),
     ("account_inventory_status", "Account inventory status?"),
     ("sharing_model", "Sharing model across family / staff?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("recovery_plan", "Recovery plan (emergency kit, trusted contact)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/portfolio-risk-register/.env.example
+++ b/family-office/portfolio-risk-register/.env.example
@@ -1,9 +1,24 @@
 # Portfolio Risk Register — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/portfolio-risk-register/requirements.txt
+++ b/family-office/portfolio-risk-register/requirements.txt
@@ -1,4 +1,13 @@
 # Portfolio Risk Register
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/portfolio-risk-register/scripts/agent.py
+++ b/family-office/portfolio-risk-register/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Portfolio Risk Register skill.
+"""Agent runtime for the Portfolio Risk Register skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Portfolio Risk Register"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("concentration_exposures", "Top 3 concentration exposures and sizes?"),
     ("illiquid_pct", "Percentage of portfolio in illiquid positions?"),
     ("key_counterparties", "Key counterparties / custodians?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("open_risks", "Open unresolved risks?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/private-trust-company-formation-plan/.env.example
+++ b/family-office/private-trust-company-formation-plan/.env.example
@@ -1,9 +1,24 @@
 # Private Trust Company Formation Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/private-trust-company-formation-plan/requirements.txt
+++ b/family-office/private-trust-company-formation-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Private Trust Company Formation Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/private-trust-company-formation-plan/scripts/agent.py
+++ b/family-office/private-trust-company-formation-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Private Trust Company Formation Plan skill.
+"""Agent runtime for the Private Trust Company Formation Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Private Trust Company Formation Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("preferred_jurisdiction", "Preferred jurisdiction (SD / NV / WY / TN)?"),
     ("expected_aum", "Expected AUM under the PTC?"),
     ("board_composition", "Board composition (family / independent / professional)?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("counsel", "Counsel firm?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/real-estate-acquisition-plan/.env.example
+++ b/family-office/real-estate-acquisition-plan/.env.example
@@ -1,9 +1,24 @@
 # Real Estate Acquisition Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/real-estate-acquisition-plan/requirements.txt
+++ b/family-office/real-estate-acquisition-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Real Estate Acquisition Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/real-estate-acquisition-plan/scripts/agent.py
+++ b/family-office/real-estate-acquisition-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Real Estate Acquisition Plan skill.
+"""Agent runtime for the Real Estate Acquisition Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Real Estate Acquisition Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("property_address", "Property address (or identifier)?"),
     ("use_case", "Use case (primary residence / investment / family compound)?"),
     ("purchase_price", "Purchase price?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("target_close_date", "Target close date?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/succession-planning-memo/.env.example
+++ b/family-office/succession-planning-memo/.env.example
@@ -1,9 +1,24 @@
 # Succession Planning Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/succession-planning-memo/requirements.txt
+++ b/family-office/succession-planning-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Succession Planning Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/succession-planning-memo/scripts/agent.py
+++ b/family-office/succession-planning-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Succession Planning Memo skill.
+"""Agent runtime for the Succession Planning Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Succession Planning Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("role_in_scope", "Role in scope (principal / trustee / board chair)?"),
     ("current_holder", "Current holder?"),
     ("candidate_successors", "Candidate successors?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("contingency_plan", "Contingency plan for sudden transition?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/target-asset-allocation-model/.env.example
+++ b/family-office/target-asset-allocation-model/.env.example
@@ -1,9 +1,24 @@
 # Target Asset Allocation Model — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/target-asset-allocation-model/requirements.txt
+++ b/family-office/target-asset-allocation-model/requirements.txt
@@ -1,4 +1,13 @@
 # Target Asset Allocation Model
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/target-asset-allocation-model/scripts/agent.py
+++ b/family-office/target-asset-allocation-model/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Target Asset Allocation Model skill.
+"""Agent runtime for the Target Asset Allocation Model skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Target Asset Allocation Model"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("current_equities_pct", "Current public equity allocation (%)?"),
     ("current_fi_pct", "Current fixed income allocation (%)?"),
     ("current_alts_pct", "Current alternatives allocation (%)?"),
@@ -46,10 +56,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("drift_band_pct", "Drift band (± %) before rebalance?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -59,12 +107,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -74,8 +118,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -117,18 +160,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -145,22 +186,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -181,12 +222,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -239,6 +274,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -274,7 +591,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -282,16 +598,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/tax-strategy-memo/.env.example
+++ b/family-office/tax-strategy-memo/.env.example
@@ -1,9 +1,24 @@
 # Tax Strategy Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/tax-strategy-memo/requirements.txt
+++ b/family-office/tax-strategy-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Tax Strategy Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/tax-strategy-memo/scripts/agent.py
+++ b/family-office/tax-strategy-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Tax Strategy Memo skill.
+"""Agent runtime for the Tax Strategy Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Tax Strategy Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("tax_year", "Tax year?"),
     ("expected_agi_range", "Expected AGI range?"),
     ("key_income_sources", "Key income sources (W2, K-1, LTCG, carried)?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("cpa_firm", "CPA firm preparing the return?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/trust-selection-memo/.env.example
+++ b/family-office/trust-selection-memo/.env.example
@@ -1,9 +1,24 @@
 # Trust Selection Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/trust-selection-memo/requirements.txt
+++ b/family-office/trust-selection-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Trust Selection Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/trust-selection-memo/scripts/agent.py
+++ b/family-office/trust-selection-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Trust Selection Memo skill.
+"""Agent runtime for the Trust Selection Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Trust Selection Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("goal", "Primary goal (tax / asset protection / control / legacy)?"),
     ("funding_amount", "Funding amount?"),
     ("beneficiaries", "Beneficiary list?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("counsel", "Estate counsel?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/trust-situs-selection-memo/.env.example
+++ b/family-office/trust-situs-selection-memo/.env.example
@@ -1,9 +1,24 @@
 # Trust Situs Selection Memo — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/trust-situs-selection-memo/requirements.txt
+++ b/family-office/trust-situs-selection-memo/requirements.txt
@@ -1,4 +1,13 @@
 # Trust Situs Selection Memo
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/trust-situs-selection-memo/scripts/agent.py
+++ b/family-office/trust-situs-selection-memo/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Trust Situs Selection Memo skill.
+"""Agent runtime for the Trust Situs Selection Memo skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Trust Situs Selection Memo"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("goal_ranking", "Ranked goals (tax / asset protection / privacy / perpetuity / admin cost)?"),
     ("current_residence_state", "Principal's current state of residence?"),
     ("beneficiary_states", "Beneficiary states?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("counsel", "Counsel firm?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/virtual-mailbox-setup-plan/.env.example
+++ b/family-office/virtual-mailbox-setup-plan/.env.example
@@ -1,9 +1,24 @@
 # Virtual Mailbox Setup Plan — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/virtual-mailbox-setup-plan/requirements.txt
+++ b/family-office/virtual-mailbox-setup-plan/requirements.txt
@@ -1,4 +1,13 @@
 # Virtual Mailbox Setup Plan
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/virtual-mailbox-setup-plan/scripts/agent.py
+++ b/family-office/virtual-mailbox-setup-plan/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Virtual Mailbox Setup Plan skill.
+"""Agent runtime for the Virtual Mailbox Setup Plan skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Virtual Mailbox Setup Plan"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("provider", "Virtual mailbox provider?"),
     ("addresses_in_scope", "Addresses in scope?"),
     ("forwarding_rules", "Forwarding rules?"),
@@ -44,10 +54,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("privacy_posture", "Privacy posture (PO box vs street / registered agent)?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -57,12 +105,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -72,8 +116,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -115,18 +158,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -143,22 +184,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -179,12 +220,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -237,6 +272,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -272,7 +589,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -280,16 +596,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )

--- a/family-office/will-drafting-checklist/.env.example
+++ b/family-office/will-drafting-checklist/.env.example
@@ -1,9 +1,24 @@
 # Will Drafting Checklist — environment template.
-# Copy to .env and fill in before a live run.
+# Copy to .env and fill in before a live run. Never commit .env.
 #
-# Memory writes are optional. When the knowledge skill's memory DSN is
-# supplied via config.memory_dsn (NOT this .env file), the agent writes
-# decision / assumption / open_question / commitment memories.
+# All credentials come from env vars — NEVER from config.json.
+
+# ── Seren API gateway (required for SharePoint / Asana push) ─────────
+# Used by the in-skill GatewayClient to call microsoft-sharepoint and
+# asana publishers. Obtain a key from https://serendb.com.
+SEREN_API_KEY=
+SEREN_API_BASE=https://api.serendb.com
+
+# ── Snowflake (only one of the auth families is used, per config) ────
+# External-browser SSO (default): no secret needed here. The user's
+# browser opens for OAuth on first connection.
 #
-# Never commit .env. The repo-level .gitignore excludes it.
+# Password auth: set SNOWFLAKE_PASSWORD.
+# SNOWFLAKE_PASSWORD=
+#
+# Key-pair JWT auth: set SNOWFLAKE_PRIVATE_KEY_PATH (path to PEM).
+# Optional passphrase: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE.
+# SNOWFLAKE_PRIVATE_KEY_PATH=
+# SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
+
 LOG_LEVEL=INFO

--- a/family-office/will-drafting-checklist/requirements.txt
+++ b/family-office/will-drafting-checklist/requirements.txt
@@ -1,4 +1,13 @@
 # Will Drafting Checklist
-# Minimal runtime deps. psycopg is optional (only needed when memory_dsn
-# is supplied in config). Tests mock it via skip.
+#
+# Runtime deps:
+#   requests           — required for SharePoint / Asana pushes via the Seren gateway
+#   psycopg[binary]    — optional; only exercised when config.memory_dsn is set
+#   snowflake-connector-python — optional; only exercised when config.snowflake is set
+#
+# None of these are invoked unless the corresponding config block is present,
+# but we list them here so a single `pip install -r requirements.txt` gets
+# the skill demo-ready end-to-end.
+requests>=2.31
 psycopg[binary]>=3.1
+snowflake-connector-python>=3.7

--- a/family-office/will-drafting-checklist/scripts/agent.py
+++ b/family-office/will-drafting-checklist/scripts/agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agent runtime for the Will Drafting Checklist skill.
+"""Agent runtime for the Will Drafting Checklist skill (issue #429 augmentation).
 
 Single-family-office tenancy. Self-contained: no cross-skill Python imports.
 
@@ -11,11 +11,18 @@ Flow:
        timestamped directory.
     5. Optionally write memory entries to the knowledge skill's
        memory_objects table when config.memory_dsn is provided.
+    6. Optionally push the artifact to external sinks:
+       - SharePoint (microsoft-sharepoint publisher via Seren gateway)
+       - Asana follow-up task (asana publisher via Seren gateway)
+       - Snowflake FO_ARTIFACTS row (snowflake-connector-python, external-browser SSO by default)
+       Each push is gated by presence of its config block; absent config = no-op.
 
 Security posture (applies to every family-office skill):
-    - Never log interview answers or artifact text.
-    - Never log memory_dsn.
-    - Parameterize every SQL call.
+    - Never log interview answers, artifact text, or credentials.
+    - Credentials come from env vars only (SEREN_API_KEY, SNOWFLAKE_PASSWORD,
+      SNOWFLAKE_PRIVATE_KEY_PATH). Never in config.json.
+    - Parameterized SQL only.
+    - SharePoint/Asana URLs redacted at INFO; DEBUG only.
 """
 from __future__ import annotations
 
@@ -24,6 +31,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -37,6 +45,8 @@ ARTIFACT_NAME = "Will Drafting Checklist"
 
 # Per-skill interview schema. Each entry is (key, prompt).
 INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
+
+
     ("executor", "Executor?"),
     ("successor_executor", "Successor executor?"),
     ("primary_beneficiaries", "Primary beneficiaries?"),
@@ -45,10 +55,48 @@ INTERVIEW_QUESTIONS: list[tuple[str, str]] = [
     ("guardianship_nominations", "Guardianship nominations for minors?"),
 ]
 
+DEFAULT_SEREN_API_BASE = "https://api.serendb.com"
+
 logger = logging.getLogger(f"family_office.{SKILL_NAME}")
 
 
-# ─── Helpers (inline — no _base/ import) ─────────────────────────────────
+# ─── Redaction (confidentiality floor) ───────────────────────────────────
+
+_PII_FIELD_PATTERN = re.compile(
+    r"(?i)(ssn|ein|itin|account_number|routing_number|full_name_of_principal)"
+)
+_SSN_VALUE = re.compile(r"\b\d{3}-?\d{2}-?\d{4}\b")
+_EIN_VALUE = re.compile(r"\b\d{2}-?\d{7}\b")
+
+
+def _redact_value(value: str) -> str:
+    if not isinstance(value, str):
+        return value
+    v = _SSN_VALUE.sub("<redacted-ssn>", value)
+    v = _EIN_VALUE.sub("<redacted-ein>", v)
+    return v
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of payload with PII-bearing fields redacted.
+
+    Called before any external push so the structured payload that leaves
+    the process never carries cleartext SSN / EIN / account numbers.
+    """
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if _PII_FIELD_PATTERN.search(str(k)):
+            out[k] = "<redacted>" if v else v
+        elif isinstance(v, dict):
+            out[k] = _redact_payload(v)
+        elif isinstance(v, list):
+            out[k] = [_redact_payload(x) if isinstance(x, dict) else _redact_value(x) for x in v]
+        else:
+            out[k] = _redact_value(v) if isinstance(v, str) else v
+    return out
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,12 +106,8 @@ def _hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _redact(value: str, keep: int = 0) -> str:
-    if not value:
-        return ""
-    if keep >= len(value):
-        return value
-    return value[:keep] + ("*" * max(1, len(value) - keep))
+def _artifact_id(manifest_content_hash: str) -> str:
+    return f"artifact:{SKILL_NAME}-{manifest_content_hash[:12]}"
 
 
 # ─── Interview ────────────────────────────────────────────────────────────
@@ -73,8 +117,7 @@ def run_interview(
 ) -> dict[str, str]:
     """Run the interview. If fixture is supplied, answers come from it
     (used by tests and by Claude-Code-driven invocation). Otherwise prompts
-    the TTY. Missing fixture keys raise ValueError -- no silent defaults,
-    because a defaulted interview would produce a wrong artifact."""
+    the TTY. Missing fixture keys raise ValueError -- no silent defaults."""
     answers: dict[str, str] = {}
     for key, prompt in INTERVIEW_QUESTIONS:
         if fixture is not None:
@@ -116,18 +159,16 @@ def render_artifact(answers: dict[str, str]) -> str:
             "",
             (
                 "This is a first-iteration deliverable. PDF, DOCX, and "
-                "XLSX companion renders, DMS push, Snowflake ingest, and "
-                "approval-gated execution actions are added by the "
-                "execution-pipeline PR tracked under issue #427."
+                "XLSX companion renders and approval-gated execution "
+                "actions are added by future PRs (see catalog tracking "
+                "issues on seren-skills)."
             ),
             "",
             "## Confidentiality",
             "",
             (
-                "Treat this artifact as `office-private` by default. When "
-                "the execution pipeline ships, the skill will read the "
-                "configured confidentiality label from the office record "
-                "and route destinations accordingly."
+                "Treat this artifact as `office-private` by default. Future "
+                "PRs add confidentiality labels + DMS routing."
             ),
             "",
         ]
@@ -144,22 +185,22 @@ def _canonical_out_dir(base: Path) -> Path:
     return out
 
 
-def write_artifact(
-    answers: dict[str, str], *, base: Path
-) -> dict[str, Any]:
+def write_artifact(answers: dict[str, str], *, base: Path) -> dict[str, Any]:
     out_dir = _canonical_out_dir(base)
     md = render_artifact(answers)
     (out_dir / "artifact.md").write_text(md, encoding="utf-8")
     (out_dir / "interview.json").write_text(
         json.dumps(answers, indent=2), encoding="utf-8"
     )
+    content_hash = _hash_text(md)
     manifest = {
+        "artifact_id": _artifact_id(content_hash),
         "skill": SKILL_NAME,
         "pillar": PILLAR,
         "artifact_name": ARTIFACT_NAME,
         "artifact_version": 1,
         "created_at": _iso_now(),
-        "content_hash": _hash_text(md),
+        "content_hash": content_hash,
         "out_dir": str(out_dir),
     }
     (out_dir / "manifest.json").write_text(
@@ -180,12 +221,6 @@ def write_memories(
     *,
     dsn: str,
 ) -> list[str]:
-    """Write one decision + one assumption + one open_question + one
-    commitment memory per run. Uses psycopg; parameterized SQL only.
-
-    Returns list of memory ids written. Raises on connection failure --
-    callers decide whether to proceed without memory.
-    """
     try:
         import psycopg  # type: ignore[import-not-found]
     except ImportError as exc:
@@ -238,6 +273,288 @@ def write_memories(
     return ids
 
 
+# ─── Seren Gateway Client (inline; mirrors knowledge skill pattern) ──────
+
+class GatewayClient:
+    """Thin Seren API gateway client. Used to call MCP publishers over
+    HTTP from within the skill. Authenticates with SEREN_API_KEY env var."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> None:
+        import requests  # type: ignore[import-not-found]
+
+        self.api_key = api_key or os.environ.get("SEREN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "SEREN_API_KEY is required for external-sink pushes"
+            )
+        self.api_base = (
+            api_base
+            or os.environ.get("SEREN_API_BASE")
+            or DEFAULT_SEREN_API_BASE
+        ).rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+    def call_publisher(
+        self,
+        publisher: str,
+        method: str,
+        path: str,
+        *,
+        body: Any | None = None,
+    ) -> Any:
+        url = f"{self.api_base}/publishers/{publisher}{path}"
+        response = self.session.request(
+            method=method, url=url, json=body, timeout=60
+        )
+        if response.status_code >= 400:
+            # Redact credentials / URLs in the error surface.
+            raise RuntimeError(
+                f"publisher {publisher} {method} failed: "
+                f"{response.status_code}"
+            )
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": response.status_code}
+
+
+# ─── Push: SharePoint (microsoft-sharepoint publisher) ───────────────────
+
+def push_to_sharepoint(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Upload artifact.md to SharePoint. No-op if config absent.
+
+    config.sharepoint = {
+        "site_id":   "<Graph site id>",
+        "drive_id":  "<Graph drive id>",
+        "folder_path": "/Seren/family-office"
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("sharepoint") or {}
+    if not cfg:
+        return None
+    required = ("site_id", "drive_id", "folder_path")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(
+            f"sharepoint config missing required keys: {missing}"
+        )
+    gw = GatewayClient()
+    out_dir = Path(manifest["out_dir"])
+    artifact_md = (out_dir / "artifact.md").read_text(encoding="utf-8")
+    target_path = (
+        f"{cfg['folder_path'].rstrip('/')}/"
+        f"{SKILL_NAME}/{out_dir.name}/artifact.md"
+    )
+    payload_body = {
+        "site_id": cfg["site_id"],
+        "drive_id": cfg["drive_id"],
+        "path": target_path,
+        "content": artifact_md,
+        "content_type": "text/markdown; charset=utf-8",
+    }
+    result = gw.call_publisher(
+        "microsoft-sharepoint", "POST", "/files/upload", body=payload_body
+    )
+    logger.info(
+        "sharepoint_push_ok skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    # Do not log the returned URL at INFO — it leaks path structure.
+    logger.debug("sharepoint_push_response skill=%s", SKILL_NAME)
+    return {"publisher": "microsoft-sharepoint", "result": result}
+
+
+# ─── Push: Asana (asana publisher) ───────────────────────────────────────
+
+def push_to_asana(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create an Asana follow-up task for the artifact. No-op if config
+    absent.
+
+    config.asana = {
+        "workspace_gid": "<gid>",
+        "project_gid":   "<gid>",
+        "assignee_gid":  "<gid>"   # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("asana") or {}
+    if not cfg:
+        return None
+    required = ("workspace_gid", "project_gid")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"asana config missing required keys: {missing}")
+    gw = GatewayClient()
+    task_body = {
+        "data": {
+            "name": f"Review {ARTIFACT_NAME} ({manifest['created_at'][:10]})",
+            "notes": (
+                f"Artifact ID: {manifest['artifact_id']}\n"
+                f"Skill: {SKILL_NAME}\n"
+                f"Pillar: {PILLAR}\n"
+                f"Produced: {manifest['created_at']}\n"
+                f"Local path: {manifest['out_dir']}\n"
+                "See SharePoint for the rendered artifact."
+            ),
+            "workspace": cfg["workspace_gid"],
+            "projects": [cfg["project_gid"]],
+        }
+    }
+    if cfg.get("assignee_gid"):
+        task_body["data"]["assignee"] = cfg["assignee_gid"]
+    result = gw.call_publisher("asana", "POST", "/tasks", body=task_body)
+    logger.info(
+        "asana_task_created skill=%s hash_prefix=%s",
+        SKILL_NAME,
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "asana", "result": result}
+
+
+# ─── Push: Snowflake (Python connector, external-browser SSO default) ────
+
+def push_to_snowflake(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Insert a row into FO_ARTIFACTS. No-op if config absent.
+
+    config.snowflake = {
+        "account":       "rendero.us-east-1",
+        "user":          "seren_agent",
+        "warehouse":     "FO_WH",
+        "database":      "FO_DB",
+        "schema":        "SEREN",
+        "role":          "FO_WRITER",
+        "authenticator": "externalbrowser"  # default; also: snowflake, oauth, snowflake_jwt
+    }
+
+    Customer prerequisite (one-time SQL, see snowflake_setup.sql):
+      CREATE TABLE FO_ARTIFACTS (
+        artifact_id STRING, pillar STRING, skill_name STRING,
+        artifact_name STRING, artifact_version INTEGER,
+        created_at TIMESTAMP_TZ, created_by STRING,
+        content_hash STRING, structured_payload VARIANT
+      );
+    """
+    if not config:
+        return None
+    cfg = config.get("snowflake") or {}
+    if not cfg:
+        return None
+    required = ("account", "user", "warehouse", "database", "schema")
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        raise ValueError(f"snowflake config missing required keys: {missing}")
+
+    authenticator = cfg.get("authenticator") or "externalbrowser"
+    conn_kwargs: dict[str, Any] = {
+        "account": cfg["account"],
+        "user": cfg["user"],
+        "warehouse": cfg["warehouse"],
+        "database": cfg["database"],
+        "schema": cfg["schema"],
+        "authenticator": authenticator,
+    }
+    if cfg.get("role"):
+        conn_kwargs["role"] = cfg["role"]
+
+    # Credentials strictly from env vars, never from config.json.
+    # Validate auth-required env vars BEFORE importing the connector so a
+    # caller without snowflake-connector-python installed still gets the
+    # "missing env var" error (and so tests can exercise the validation
+    # path without installing the heavy native dependency).
+    if authenticator in {"snowflake", "oauth"}:
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not password:
+            raise ValueError(
+                "SNOWFLAKE_PASSWORD env var required for "
+                f"authenticator={authenticator!r}"
+            )
+        conn_kwargs["password"] = password
+    elif authenticator == "snowflake_jwt":
+        key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
+        if not key_path:
+            raise ValueError(
+                "SNOWFLAKE_PRIVATE_KEY_PATH env var required for "
+                "authenticator='snowflake_jwt'"
+            )
+        conn_kwargs["private_key_file"] = key_path
+        if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+            conn_kwargs["private_key_file_pwd"] = os.environ[
+                "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            ]
+    # externalbrowser: no additional secret; the user's SSO handles auth.
+
+    try:
+        import snowflake.connector  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "snowflake-connector-python not installed; "
+            "install to enable Snowflake push"
+        ) from exc
+
+    structured_payload = _redact_payload({"inputs": answers})
+    structured_json = json.dumps(structured_payload)
+
+    conn = snowflake.connector.connect(**conn_kwargs)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO FO_ARTIFACTS "
+                "(artifact_id, pillar, skill_name, artifact_name, "
+                " artifact_version, created_at, created_by, "
+                " content_hash, structured_payload) "
+                "SELECT %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                "       PARSE_JSON(%s)",
+                (
+                    manifest["artifact_id"],
+                    manifest["pillar"],
+                    manifest["skill"],
+                    manifest["artifact_name"],
+                    manifest["artifact_version"],
+                    SKILL_NAME,
+                    manifest["content_hash"],
+                    structured_json,
+                ),
+            )
+            query_id = cur.sfqid
+        finally:
+            cur.close()
+        conn.commit()
+    finally:
+        conn.close()
+
+    logger.info(
+        "snowflake_insert_ok skill=%s query_id=%s",
+        SKILL_NAME,
+        query_id,
+    )
+    return {"publisher": "snowflake", "query_id": query_id}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -273,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
     answers = run_interview(fixture=fixture, tty=tty)
     manifest = write_artifact(answers, base=Path(args.cwd))
 
-    # Never log answers, manifest content, or the memory DSN.
     logger.info(
         "skill_run_completed skill=%s pillar=%s hash_prefix=%s",
         SKILL_NAME,
@@ -281,16 +597,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest["content_hash"][:12],
     )
 
+    # Optional memory write.
     memory_dsn = cfg.get("memory_dsn")
     if memory_dsn and not cfg.get("skip_memory", False):
         try:
             ids = write_memories(manifest, answers, dsn=memory_dsn)
-            logger.info(
-                "memory_written skill=%s count=%d", SKILL_NAME, len(ids)
-            )
+            logger.info("memory_written skill=%s count=%d", SKILL_NAME, len(ids))
         except Exception as exc:  # noqa: BLE001 — controlled degradation
             logger.warning(
                 "memory_write_failed skill=%s class=%s",
+                SKILL_NAME,
+                exc.__class__.__name__,
+            )
+
+    # Optional external sinks. Each push is independent; a failure in one
+    # does not block the others. Push failures are logged, not fatal.
+    for name, fn, args_pack in (
+        ("sharepoint", push_to_sharepoint, (manifest,)),
+        ("asana",      push_to_asana,      (manifest, answers)),
+        ("snowflake",  push_to_snowflake,  (manifest, answers)),
+    ):
+        try:
+            fn(*args_pack, config=cfg)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "push_failed sink=%s skill=%s class=%s",
+                name,
                 SKILL_NAME,
                 exc.__class__.__name__,
             )


### PR DESCRIPTION
## Summary

Adds three external sinks to every one of the 55 family-office leaves so the catalog is **genuinely demo-able**. Each push is optional, config-gated, and independent — a failure in one does not block the others.

- **Asana** — create a follow-up task per artifact (`asana` MCP publisher, POST `/tasks`).
- **SharePoint** — upload `artifact.md` to a configured Graph site + drive (`microsoft-sharepoint` MCP publisher, POST `/files/upload`).
- **Snowflake** — insert into `FO_ARTIFACTS` via `snowflake-connector-python`. **External-browser OAuth SSO is the default authenticator** (no stored passwords). Password and RSA key-pair JWT auth supported via env vars.

Closes the external-sink milestone of #429.

## Publisher audit (actual Seren MCP registry)

From `list_agent_publishers` (not the seren-skills folder tree — that distinction tripped me up initially):

| System | MCP publisher | Used in this PR |
|---|---|---|
| Asana | `asana` | ✅ |
| SharePoint | `microsoft-sharepoint` | ✅ |
| Microsoft Outlook email | `microsoft-outlook` | **Available but deferred** (follow-up PR — queued) |
| Gmail | `gmail` | **Available but deferred** |
| Google Calendar | `google-calendar` | **Available but deferred** |
| Google Drive / Docs / Sheets / Meet / Contacts / Trends | `google-*` | **Available but deferred** |
| Snowflake | no MCP publisher | Using `snowflake-connector-python` directly |
| Egnyte | no MCP publisher | N/A |
| Microsoft Word / Excel (direct edit) | no dedicated publisher | SharePoint upload handles `.docx`/`.xlsx` once the skill renders them |
| Outlook calendar | no dedicated publisher | Use `google-calendar` |

## Per-leaf changes (all 55)

Each leaf's `scripts/agent.py` gets an inline `GatewayClient` (mirrors the knowledge-skill pattern) + the three `push_to_*` functions + a `main()` loop that invokes them after `write_artifact`. Push failures are logged at WARNING, not fatal.

- `requirements.txt` — pinned `requests>=2.31`, `psycopg[binary]>=3.1`, `snowflake-connector-python>=3.7`. Latter two only exercised when their config block is present.
- `.env.example` — documents `SEREN_API_KEY`, `SEREN_API_BASE`, and the three Snowflake auth env vars with the credential-handling rule.
- No cross-skill imports. Each of the 55 leaves carries its own copy of the push functions (~400 lines per agent.py). Inline shared runtime per the "no `_base/` folder" discipline from the rebuild PR.

## Reference-leaf additions (`cpa-tax-package-checklist`)

- `scripts/snowflake_setup.sql` — one-time customer SQL to create `FO_ARTIFACTS`. Idempotent. Documents a least-privilege `FO_WRITER` role template (customer edits for their warehouse layout). Lives on the reference leaf as the canonical setup doc; **once the table exists, all 55 leaves can push**.
- `tests/test_sinks.py` — **12 critical tests**. DRY: one reference leaf covers the push-contract tests because per-leaf duplication of these would catch no new bugs.

## Security non-negotiables (enforced by tests)

- **Credentials never in `config.json`.** Env vars only: `SEREN_API_KEY`, `SNOWFLAKE_PASSWORD`, `SNOWFLAKE_PRIVATE_KEY_PATH`. Tests verify missing env vars raise `ValueError` *before* the native Snowflake connector import.
- **Parameterized SQL only.** `INSERT INTO FO_ARTIFACTS ... PARSE_JSON(%s)`. String-concat is banned. Test verifies `123-45-6789` SSN literal is never inlined in the SQL.
- **PII redaction pass** on `structured_payload` before Snowflake ingest. Test verifies `principal_ssn` and `trust_ein` fields (and the SSN / EIN value patterns) are replaced with `<redacted>` / `<redacted-ssn>` / `<redacted-ein>` before the payload leaves the process.
- **Logging hygiene.** SharePoint URLs, Asana task URLs, and raw response bodies never logged at INFO — DEBUG only. Test verifies no "returned_url" leakage at INFO level.
- **`try` / `finally` cursor + connection close** on Snowflake. Test verifies `commit` + `close` run even on happy path.
- **Least-privilege role** documented in `snowflake_setup.sql` (FO_WRITER should have INSERT on FO_ARTIFACTS only).

## Critical tests only (DRY + TDD)

**122 tests pass** — 110 smoke tests (one per leaf + one negative per leaf, same as rebuild PR) + 12 sink tests on the reference leaf. No duplication. Sink tests stub `GatewayClient` and `snowflake.connector` so no network and no heavy native deps in CI.

## CI

- `test` job now installs `requests` (needed to construct `GatewayClient` — tests stub the outgoing call but still import the class).
- `snowflake-connector-python` NOT installed in CI — sink tests stub via `sys.modules` injection.
- All three regression guards from the rebuild PR still green: `forbid-publisher-root-skill-md`, `forbid-non-skill-folders`, `indexer-smoke`.

## Test plan

- [ ] CI `test` green on Python 3.11 and 3.12 (122 tests)
- [ ] CI regression guards green (indexer-smoke: still 60 family-office skills)
- [ ] Manual: invoke `cpa-tax-package-checklist` with a config containing all three sink blocks against a seeded Rendero-style tenant; confirm (a) artifact lands in SharePoint, (b) Asana task appears, (c) `FO_ARTIFACTS` row present in Snowflake with PII redacted

## Out of scope (future PRs)

- Outlook email / Gmail / Google Calendar push (publishers all exist; single-function additions per leaf).
- Egnyte / Outlook calendar (requires new MCP publisher work).
- PDF / DOCX / XLSX companion renders.
- Approval gate + 8-point execution readiness check.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
