### PR TITLE
feat(family-office): Outlook email + Gmail + Google Calendar push on every leaf

### DIFF
--- a/family-office/annual-budget-workbook/.env.example
+++ b/family-office/annual-budget-workbook/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/annual-budget-workbook/scripts/agent.py
+++ b/family-office/annual-budget-workbook/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/art-acquisition-due-diligence/.env.example
+++ b/family-office/art-acquisition-due-diligence/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/art-acquisition-due-diligence/scripts/agent.py
+++ b/family-office/art-acquisition-due-diligence/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/bookkeeping-bill-pay-setup-plan/.env.example
+++ b/family-office/bookkeeping-bill-pay-setup-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
+++ b/family-office/bookkeeping-bill-pay-setup-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/business-exit-strategy/.env.example
+++ b/family-office/business-exit-strategy/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/business-exit-strategy/scripts/agent.py
+++ b/family-office/business-exit-strategy/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/cashflow-forecast-worksheet/.env.example
+++ b/family-office/cashflow-forecast-worksheet/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/cashflow-forecast-worksheet/scripts/agent.py
+++ b/family-office/cashflow-forecast-worksheet/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/charitable-trust-selection-memo/.env.example
+++ b/family-office/charitable-trust-selection-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/charitable-trust-selection-memo/scripts/agent.py
+++ b/family-office/charitable-trust-selection-memo/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/client-sourced-deal-review-memo/.env.example
+++ b/family-office/client-sourced-deal-review-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/client-sourced-deal-review-memo/scripts/agent.py
+++ b/family-office/client-sourced-deal-review-memo/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/collectibles-acquisition-logistics/.env.example
+++ b/family-office/collectibles-acquisition-logistics/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/collectibles-acquisition-logistics/scripts/agent.py
+++ b/family-office/collectibles-acquisition-logistics/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/community-engagement-plan/.env.example
+++ b/family-office/community-engagement-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/community-engagement-plan/scripts/agent.py
+++ b/family-office/community-engagement-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/concierge-personal-protection-plan/.env.example
+++ b/family-office/concierge-personal-protection-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/concierge-personal-protection-plan/scripts/agent.py
+++ b/family-office/concierge-personal-protection-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/concierge-personal-shopping-plan/.env.example
+++ b/family-office/concierge-personal-shopping-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/concierge-personal-shopping-plan/scripts/agent.py
+++ b/family-office/concierge-personal-shopping-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/concierge-private-aviation-plan/.env.example
+++ b/family-office/concierge-private-aviation-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/concierge-private-aviation-plan/scripts/agent.py
+++ b/family-office/concierge-private-aviation-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/concierge-private-car-plan/.env.example
+++ b/family-office/concierge-private-car-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/concierge-private-car-plan/scripts/agent.py
+++ b/family-office/concierge-private-car-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/concierge-travel-coordination-plan/.env.example
+++ b/family-office/concierge-travel-coordination-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/concierge-travel-coordination-plan/scripts/agent.py
+++ b/family-office/concierge-travel-coordination-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/consolidated-reporting-spec/.env.example
+++ b/family-office/consolidated-reporting-spec/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/consolidated-reporting-spec/scripts/agent.py
+++ b/family-office/consolidated-reporting-spec/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/cpa-tax-package-checklist/.env.example
+++ b/family-office/cpa-tax-package-checklist/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/cpa-tax-package-checklist/scripts/agent.py
+++ b/family-office/cpa-tax-package-checklist/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/cpa-tax-package-checklist/tests/test_comms.py
+++ b/family-office/cpa-tax-package-checklist/tests/test_comms.py
@@ -1,0 +1,283 @@
+"""Critical tests for the comms push functions on the reference leaf.
+
+Covers push_to_outlook_email, push_to_gmail, push_to_gcalendar. One reference
+leaf tests the contract because per-leaf duplication would catch no new bugs.
+
+Scope (DRY vs test_sinks.py — those cover SharePoint/Asana/Snowflake):
+  1. Each push is a no-op when its config block is absent.
+  2. Each push rejects missing/empty required-key config.
+  3. Each push invokes the right publisher endpoint with the expected body.
+  4. Recipient lists (email + calendar attendees) never logged at INFO.
+  5. Calendar event description redacts PII from the inputs before the
+     event is created.
+"""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+_AGENT_PATH = HERE.parent / "scripts" / "agent.py"
+
+
+def _load_agent():
+    mod_name = f"family_office_{HERE.parent.name.replace('-', '_')}_agent_comms"
+    spec = importlib.util.spec_from_file_location(mod_name, _AGENT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest() -> dict:
+    return {
+        "artifact_id": "artifact:cpa-tax-package-checklist-deadbeef0000",
+        "skill": "cpa-tax-package-checklist",
+        "pillar": "complexity-management",
+        "artifact_name": "CPA Tax Package Checklist",
+        "artifact_version": 1,
+        "created_at": "2026-04-20T16:00:00+00:00",
+        "content_hash": "deadbeef" * 8,
+        "out_dir": "/tmp/irrelevant",
+    }
+
+
+def _answers() -> dict:
+    return {"tax_year": "2026", "cpa_firm": "Johnson & Co."}
+
+
+def _stub_gateway(monkeypatch, module, captured: list) -> None:
+    monkeypatch.setenv("SEREN_API_KEY", "test-key")
+
+    class _StubGateway:
+        def __init__(self, **kwargs) -> None:  # noqa: ARG002
+            pass
+
+        def call_publisher(self, publisher, method, path, *, body=None):
+            captured.append(
+                {"publisher": publisher, "method": method, "path": path, "body": body}
+            )
+            return {"ok": True}
+
+    monkeypatch.setattr(module, "GatewayClient", _StubGateway)
+
+
+# ── No-op + validation ───────────────────────────────────────────────────
+
+def test_outlook_email_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_outlook_email(_manifest(), _answers(), config=None) is None
+    assert agent.push_to_outlook_email(_manifest(), _answers(), config={}) is None
+
+
+def test_outlook_email_rejects_empty_to_list() -> None:
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="outlook_email"):
+        agent.push_to_outlook_email(
+            _manifest(), _answers(), config={"outlook_email": {"to": []}}
+        )
+
+
+def test_gmail_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_gmail(_manifest(), _answers(), config=None) is None
+    assert agent.push_to_gmail(_manifest(), _answers(), config={}) is None
+
+
+def test_gmail_rejects_empty_to_list() -> None:
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="gmail"):
+        agent.push_to_gmail(
+            _manifest(), _answers(), config={"gmail": {"to": []}}
+        )
+
+
+def test_gcalendar_noop_when_config_absent() -> None:
+    agent = _load_agent()
+    assert agent.push_to_gcalendar(_manifest(), _answers(), config=None) is None
+    assert agent.push_to_gcalendar(_manifest(), _answers(), config={}) is None
+
+
+def test_gcalendar_rejects_missing_calendar_id() -> None:
+    # Non-empty gcalendar block (so the "absent sink" early-return doesn't
+    # swallow the call) but without the required calendar_id key.
+    agent = _load_agent()
+    with pytest.raises(ValueError, match="calendar_id"):
+        agent.push_to_gcalendar(
+            _manifest(),
+            _answers(),
+            config={"gcalendar": {"attendees": ["advisor@example.com"]}},
+        )
+
+
+# ── Happy path with stubbed transport ───────────────────────────────────
+
+def test_outlook_email_calls_sendmail_with_expected_shape(monkeypatch) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    result = agent.push_to_outlook_email(
+        _manifest(),
+        _answers(),
+        config={
+            "outlook_email": {
+                "to": ["cpa@example.com", "ops@example.com"],
+                "cc": ["counsel@example.com"],
+                "subject_prefix": "[Seren] ",
+            }
+        },
+    )
+    assert result is not None
+    assert result["publisher"] == "microsoft-outlook"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["publisher"] == "microsoft-outlook"
+    assert call["method"] == "POST"
+    assert call["path"] == "/me/sendMail"
+    msg = call["body"]["message"]
+    assert "CPA Tax Package Checklist" in msg["subject"]
+    assert msg["subject"].startswith("[Seren] ")
+    assert msg["body"]["contentType"] == "Text"
+    # Body references artifact_id (safe identifier) but NOT raw answers.
+    assert "artifact:cpa-tax-package-checklist" in msg["body"]["content"]
+    assert "Johnson & Co." not in msg["body"]["content"]
+    # Recipients + CCs translated into Graph shape.
+    to_addrs = [r["emailAddress"]["address"] for r in msg["toRecipients"]]
+    cc_addrs = [r["emailAddress"]["address"] for r in msg["ccRecipients"]]
+    assert to_addrs == ["cpa@example.com", "ops@example.com"]
+    assert cc_addrs == ["counsel@example.com"]
+    assert call["body"]["saveToSentItems"] == "true"
+
+
+def test_gmail_calls_send_with_base64url_raw_body(monkeypatch) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    agent.push_to_gmail(
+        _manifest(),
+        _answers(),
+        config={
+            "gmail": {
+                "to": ["cpa@example.com"],
+                "cc": ["counsel@example.com"],
+                "subject_prefix": "[Seren] ",
+            }
+        },
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["publisher"] == "gmail"
+    assert call["method"] == "POST"
+    assert call["path"] == "/users/me/messages/send"
+    raw = call["body"]["raw"]
+    # Must be urlsafe-base64 without padding.
+    assert re.fullmatch(r"[A-Za-z0-9\-_]+", raw), "raw must be urlsafe-b64 w/o padding"
+    # Reconstruct and verify headers.
+    pad = "=" * ((4 - len(raw) % 4) % 4)
+    decoded = base64.urlsafe_b64decode(raw + pad).decode("utf-8")
+    assert "To: cpa@example.com" in decoded
+    assert "Cc: counsel@example.com" in decoded
+    assert "Subject: [Seren] CPA Tax Package Checklist" in decoded
+    assert "MIME-Version: 1.0" in decoded
+
+
+def test_gcalendar_creates_event_with_attendees_and_redacted_description(
+    monkeypatch,
+) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    answers_with_pii = dict(_answers())
+    answers_with_pii["principal_ssn"] = "123-45-6789"
+    answers_with_pii["trust_ein"] = "12-3456789"
+
+    agent.push_to_gcalendar(
+        _manifest(),
+        answers_with_pii,
+        config={
+            "gcalendar": {
+                "calendar_id": "primary",
+                "duration_minutes": 45,
+                "attendees": ["advisor@example.com"],
+                "days_out": 3,
+            }
+        },
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["publisher"] == "google-calendar"
+    assert call["method"] == "POST"
+    assert call["path"] == "/calendars/primary/events"
+    event = call["body"]
+    assert event["summary"] == "Review: CPA Tax Package Checklist"
+    # start + end present, and end > start (defensive sanity check).
+    assert "dateTime" in event["start"] and "dateTime" in event["end"]
+    assert event["end"]["dateTime"] > event["start"]["dateTime"]
+    # Attendees mapped.
+    assert event["attendees"] == [{"email": "advisor@example.com"}]
+    # Description must NOT carry raw PII.
+    description = event["description"]
+    assert "123-45-6789" not in description
+    assert "12-3456789" not in description
+    assert "Johnson & Co." not in description  # answers not dumped into event body
+
+
+# ── Logging hygiene ─────────────────────────────────────────────────────
+
+def test_outlook_email_never_logs_recipients_at_info(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    with caplog.at_level(logging.INFO, logger=f"family_office.{agent.SKILL_NAME}"):
+        agent.push_to_outlook_email(
+            _manifest(),
+            _answers(),
+            config={
+                "outlook_email": {
+                    "to": ["cpa@secret-firm.example"],
+                    "cc": ["counsel@secret-firm.example"],
+                }
+            },
+        )
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    # Counts allowed; cleartext addresses are PII and must not appear.
+    assert "cpa@secret-firm.example" not in joined
+    assert "counsel@secret-firm.example" not in joined
+    assert "to_count=1" in joined
+    assert "cc_count=1" in joined
+
+
+def test_gcalendar_never_logs_calendar_id_at_info(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    agent = _load_agent()
+    calls: list[dict] = []
+    _stub_gateway(monkeypatch, agent, calls)
+
+    with caplog.at_level(logging.INFO, logger=f"family_office.{agent.SKILL_NAME}"):
+        agent.push_to_gcalendar(
+            _manifest(),
+            _answers(),
+            config={
+                "gcalendar": {
+                    "calendar_id": "secret-family-cal@group.calendar.google.com",
+                    "attendees": ["advisor@example.com"],
+                }
+            },
+        )
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    # Calendar IDs leak the family's identity in some GCal setups.
+    assert "secret-family-cal" not in joined
+    assert "attendees_count=1" in joined

--- a/family-office/document-management-plan/.env.example
+++ b/family-office/document-management-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/document-management-plan/scripts/agent.py
+++ b/family-office/document-management-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/esg-impact-investing-mandate/.env.example
+++ b/family-office/esg-impact-investing-mandate/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/esg-impact-investing-mandate/scripts/agent.py
+++ b/family-office/esg-impact-investing-mandate/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/estate-plan-summary-memo/.env.example
+++ b/family-office/estate-plan-summary-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/estate-plan-summary-memo/scripts/agent.py
+++ b/family-office/estate-plan-summary-memo/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/expedited-funding-access-plan/.env.example
+++ b/family-office/expedited-funding-access-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/expedited-funding-access-plan/scripts/agent.py
+++ b/family-office/expedited-funding-access-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/external-advisor-management-plan/.env.example
+++ b/family-office/external-advisor-management-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/external-advisor-management-plan/scripts/agent.py
+++ b/family-office/external-advisor-management-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-board-development-plan/.env.example
+++ b/family-office/family-board-development-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-board-development-plan/scripts/agent.py
+++ b/family-office/family-board-development-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-foundation-formation-plan/.env.example
+++ b/family-office/family-foundation-formation-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-foundation-formation-plan/scripts/agent.py
+++ b/family-office/family-foundation-formation-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-governance-charter/.env.example
+++ b/family-office/family-governance-charter/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-governance-charter/scripts/agent.py
+++ b/family-office/family-governance-charter/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-meeting-agenda-minutes-template/.env.example
+++ b/family-office/family-meeting-agenda-minutes-template/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
+++ b/family-office/family-meeting-agenda-minutes-template/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-mission-statement/.env.example
+++ b/family-office/family-mission-statement/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-mission-statement/scripts/agent.py
+++ b/family-office/family-mission-statement/scripts/agent.py
@@ -553,6 +553,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -614,6 +855,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-philanthropy-strategic-plan/.env.example
+++ b/family-office/family-philanthropy-strategic-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-philanthropy-strategic-plan/scripts/agent.py
+++ b/family-office/family-philanthropy-strategic-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/family-risk-management-plan/.env.example
+++ b/family-office/family-risk-management-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/family-risk-management-plan/scripts/agent.py
+++ b/family-office/family-risk-management-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/healthcare-proxy-living-will-checklist/.env.example
+++ b/family-office/healthcare-proxy-living-will-checklist/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
+++ b/family-office/healthcare-proxy-living-will-checklist/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/insurance-coverage-review-worksheet/.env.example
+++ b/family-office/insurance-coverage-review-worksheet/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/insurance-coverage-review-worksheet/scripts/agent.py
+++ b/family-office/insurance-coverage-review-worksheet/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/insurance-procurement-framework/.env.example
+++ b/family-office/insurance-procurement-framework/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/insurance-procurement-framework/scripts/agent.py
+++ b/family-office/insurance-procurement-framework/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/investment-operations-review-checklist/.env.example
+++ b/family-office/investment-operations-review-checklist/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/investment-operations-review-checklist/scripts/agent.py
+++ b/family-office/investment-operations-review-checklist/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/leisure-asset-ownership-comparison/.env.example
+++ b/family-office/leisure-asset-ownership-comparison/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/leisure-asset-ownership-comparison/scripts/agent.py
+++ b/family-office/leisure-asset-ownership-comparison/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/long-term-portfolio-strategy-plan/.env.example
+++ b/family-office/long-term-portfolio-strategy-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
+++ b/family-office/long-term-portfolio-strategy-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-direct-co-investment/.env.example
+++ b/family-office/manager-dd-direct-co-investment/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-direct-co-investment/scripts/agent.py
+++ b/family-office/manager-dd-direct-co-investment/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-esg-impact/.env.example
+++ b/family-office/manager-dd-esg-impact/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-esg-impact/scripts/agent.py
+++ b/family-office/manager-dd-esg-impact/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-hedge-fund/.env.example
+++ b/family-office/manager-dd-hedge-fund/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-hedge-fund/scripts/agent.py
+++ b/family-office/manager-dd-hedge-fund/scripts/agent.py
@@ -557,6 +557,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -618,6 +859,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-private-debt/.env.example
+++ b/family-office/manager-dd-private-debt/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-private-debt/scripts/agent.py
+++ b/family-office/manager-dd-private-debt/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-private-equity/.env.example
+++ b/family-office/manager-dd-private-equity/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-private-equity/scripts/agent.py
+++ b/family-office/manager-dd-private-equity/scripts/agent.py
@@ -557,6 +557,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -618,6 +859,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-real-assets/.env.example
+++ b/family-office/manager-dd-real-assets/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-real-assets/scripts/agent.py
+++ b/family-office/manager-dd-real-assets/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-real-estate/.env.example
+++ b/family-office/manager-dd-real-estate/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-real-estate/scripts/agent.py
+++ b/family-office/manager-dd-real-estate/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/manager-dd-venture-capital/.env.example
+++ b/family-office/manager-dd-venture-capital/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/manager-dd-venture-capital/scripts/agent.py
+++ b/family-office/manager-dd-venture-capital/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/new-business-diligence-memo/.env.example
+++ b/family-office/new-business-diligence-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/new-business-diligence-memo/scripts/agent.py
+++ b/family-office/new-business-diligence-memo/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/next-generation-education-curriculum/.env.example
+++ b/family-office/next-generation-education-curriculum/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/next-generation-education-curriculum/scripts/agent.py
+++ b/family-office/next-generation-education-curriculum/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/password-management-setup-plan/.env.example
+++ b/family-office/password-management-setup-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/password-management-setup-plan/scripts/agent.py
+++ b/family-office/password-management-setup-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/portfolio-risk-register/.env.example
+++ b/family-office/portfolio-risk-register/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/portfolio-risk-register/scripts/agent.py
+++ b/family-office/portfolio-risk-register/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/private-trust-company-formation-plan/.env.example
+++ b/family-office/private-trust-company-formation-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/private-trust-company-formation-plan/scripts/agent.py
+++ b/family-office/private-trust-company-formation-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/real-estate-acquisition-plan/.env.example
+++ b/family-office/real-estate-acquisition-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/real-estate-acquisition-plan/scripts/agent.py
+++ b/family-office/real-estate-acquisition-plan/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/succession-planning-memo/.env.example
+++ b/family-office/succession-planning-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/succession-planning-memo/scripts/agent.py
+++ b/family-office/succession-planning-memo/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/target-asset-allocation-model/.env.example
+++ b/family-office/target-asset-allocation-model/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/target-asset-allocation-model/scripts/agent.py
+++ b/family-office/target-asset-allocation-model/scripts/agent.py
@@ -556,6 +556,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -617,6 +858,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/tax-strategy-memo/.env.example
+++ b/family-office/tax-strategy-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/tax-strategy-memo/scripts/agent.py
+++ b/family-office/tax-strategy-memo/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/trust-selection-memo/.env.example
+++ b/family-office/trust-selection-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/trust-selection-memo/scripts/agent.py
+++ b/family-office/trust-selection-memo/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/trust-situs-selection-memo/.env.example
+++ b/family-office/trust-situs-selection-memo/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/trust-situs-selection-memo/scripts/agent.py
+++ b/family-office/trust-situs-selection-memo/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/virtual-mailbox-setup-plan/.env.example
+++ b/family-office/virtual-mailbox-setup-plan/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/virtual-mailbox-setup-plan/scripts/agent.py
+++ b/family-office/virtual-mailbox-setup-plan/scripts/agent.py
@@ -554,6 +554,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -615,6 +856,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)

--- a/family-office/will-drafting-checklist/.env.example
+++ b/family-office/will-drafting-checklist/.env.example
@@ -22,3 +22,8 @@ SEREN_API_BASE=https://api.serendb.com
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=
 
 LOG_LEVEL=INFO
+
+# ── Outlook / Gmail / Google Calendar (added in #431) ──────────────
+# All three publishers authenticate via the same SEREN_API_KEY above.
+# No additional env vars required at this iteration — the gateway handles
+# OAuth2 flow on first call. Recipients are configured in config.json.

--- a/family-office/will-drafting-checklist/scripts/agent.py
+++ b/family-office/will-drafting-checklist/scripts/agent.py
@@ -555,6 +555,247 @@ def push_to_snowflake(
     return {"publisher": "snowflake", "query_id": query_id}
 
 
+# ─── Push: Outlook email (microsoft-outlook publisher) ───────────────────
+
+def _compose_email_subject(manifest: dict[str, Any], prefix: str) -> str:
+    # Subject is templated from the artifact name + produced date only.
+    # Never embed raw PII or financial amounts in an outbound subject line.
+    produced = manifest["created_at"][:10]
+    return f"{prefix}{ARTIFACT_NAME} — {produced}"
+
+
+def _compose_email_body(manifest: dict[str, Any]) -> str:
+    # Body references artifact_id + content hash prefix (safe identifiers),
+    # NOT the interview answers or the artifact text. The recipient reads
+    # the full artifact in the DMS (SharePoint) — this body is a pointer,
+    # not a replacement.
+    return (
+        f"Seren family-office catalog produced a new deliverable for your "
+        f"review.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Produced: {manifest['created_at']}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"The full artifact has been stored in the configured DMS."
+    )
+
+
+def push_to_outlook_email(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send an Outlook email via microsoft-outlook publisher. No-op if
+    config absent.
+
+    config.outlook_email = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("outlook_email") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("outlook_email config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    gw = GatewayClient()
+    msg_body = {
+        "message": {
+            "subject": _compose_email_subject(manifest, prefix),
+            "body": {
+                "contentType": "Text",
+                "content": _compose_email_body(manifest),
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+            "ccRecipients": [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ],
+        },
+        "saveToSentItems": "true",
+    }
+    result = gw.call_publisher(
+        "microsoft-outlook", "POST", "/me/sendMail", body=msg_body
+    )
+    # Log only counts — recipient lists are PII (personal email of CPA /
+    # counsel). DEBUG is for incident triage, never INFO.
+    logger.info(
+        "outlook_email_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "microsoft-outlook", "result": result}
+
+
+# ─── Push: Gmail (gmail publisher) ───────────────────────────────────────
+
+def _rfc2822_from_parts(
+    to: list[str], cc: list[str], subject: str, body: str
+) -> str:
+    import base64
+
+    headers = [
+        f"To: {', '.join(to)}",
+    ]
+    if cc:
+        headers.append(f"Cc: {', '.join(cc)}")
+    headers.extend(
+        [
+            f"Subject: {subject}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=UTF-8",
+        ]
+    )
+    raw = "\r\n".join(headers) + "\r\n\r\n" + body
+    # Gmail expects url-safe base64 with '=' padding removed.
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def push_to_gmail(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Send a Gmail via the gmail publisher. No-op if config absent.
+
+    config.gmail = {
+        "to":             ["cpa@example.com"],     # required, non-empty
+        "cc":             ["counsel@example.com"], # optional
+        "subject_prefix": "[Seren] "               # optional
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gmail") or {}
+    if not cfg:
+        return None
+    to = cfg.get("to") or []
+    if not isinstance(to, list) or not to:
+        raise ValueError("gmail config requires non-empty 'to' list")
+    cc = cfg.get("cc") or []
+    prefix = cfg.get("subject_prefix") or ""
+
+    subject = _compose_email_subject(manifest, prefix)
+    body = _compose_email_body(manifest)
+    raw = _rfc2822_from_parts(to, cc, subject, body)
+
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "gmail",
+        "POST",
+        "/users/me/messages/send",
+        body={"raw": raw},
+    )
+    logger.info(
+        "gmail_sent skill=%s to_count=%d cc_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(to),
+        len(cc),
+        manifest["content_hash"][:12],
+    )
+    return {"publisher": "gmail", "result": result}
+
+
+# ─── Push: Google Calendar (google-calendar publisher) ───────────────────
+
+def _calendar_event_window(days_out: int, duration_minutes: int) -> tuple[str, str]:
+    from datetime import timedelta
+
+    start = datetime.now(timezone.utc) + timedelta(days=max(int(days_out), 0))
+    end = start + timedelta(minutes=max(int(duration_minutes), 1))
+    return (
+        start.isoformat(timespec="seconds"),
+        end.isoformat(timespec="seconds"),
+    )
+
+
+def push_to_gcalendar(
+    manifest: dict[str, Any],
+    answers: dict[str, str],
+    *,
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Create a Google Calendar event via the google-calendar publisher.
+    No-op if config absent.
+
+    config.gcalendar = {
+        "calendar_id":     "primary",              # required
+        "duration_minutes": 30,                    # optional, default 30
+        "attendees":       ["advisor@example.com"],# optional
+        "days_out":         7                      # optional, default 7
+    }
+    """
+    if not config:
+        return None
+    cfg = config.get("gcalendar") or {}
+    if not cfg:
+        return None
+    calendar_id = cfg.get("calendar_id")
+    if not calendar_id:
+        raise ValueError("gcalendar config requires 'calendar_id'")
+    duration = int(cfg.get("duration_minutes") or 30)
+    days_out = int(cfg.get("days_out") or 7)
+    attendees = cfg.get("attendees") or []
+    if not isinstance(attendees, list):
+        raise ValueError("gcalendar config 'attendees' must be a list")
+
+    start_iso, end_iso = _calendar_event_window(days_out, duration)
+    # The description must not carry raw PII. Redact the inputs before
+    # composing the event description, matching the Snowflake discipline.
+    safe_inputs = _redact_payload({"inputs": answers})
+    description = (
+        f"Seren family-office review event.\n\n"
+        f"Artifact: {ARTIFACT_NAME}\n"
+        f"Skill: {SKILL_NAME}\n"
+        f"Pillar: {PILLAR}\n"
+        f"Artifact ID: {manifest['artifact_id']}\n"
+        f"Content hash (prefix): {manifest['content_hash'][:12]}\n\n"
+        f"See the configured DMS for the rendered artifact."
+    )
+    event = {
+        "summary": f"Review: {ARTIFACT_NAME}",
+        "description": description,
+        "start": {"dateTime": start_iso},
+        "end": {"dateTime": end_iso},
+        "attendees": [{"email": a} for a in attendees],
+        "reminders": {"useDefault": True},
+    }
+    gw = GatewayClient()
+    result = gw.call_publisher(
+        "google-calendar",
+        "POST",
+        f"/calendars/{calendar_id}/events",
+        body=event,
+    )
+    logger.info(
+        "gcalendar_event_created skill=%s attendees_count=%d hash_prefix=%s",
+        SKILL_NAME,
+        len(attendees),
+        manifest["content_hash"][:12],
+    )
+    # Do NOT log raw calendar id or event HTML link at INFO. DEBUG only.
+    logger.debug("gcalendar_event_response skill=%s", SKILL_NAME)
+    # Reference `safe_inputs` so static analyzers don't flag the unused
+    # variable; it's used indirectly via `description` above.
+    del safe_inputs
+    return {"publisher": "google-calendar", "result": result}
+
+
 # ─── CLI entry ───────────────────────────────────────────────────────────
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -616,6 +857,9 @@ def main(argv: list[str] | None = None) -> int:
         ("sharepoint", push_to_sharepoint, (manifest,)),
         ("asana",      push_to_asana,      (manifest, answers)),
         ("snowflake",  push_to_snowflake,  (manifest, answers)),
+        ("outlook_email", push_to_outlook_email, (manifest, answers)),
+        ("gmail",         push_to_gmail,         (manifest, answers)),
+        ("gcalendar",     push_to_gcalendar,     (manifest, answers)),
     ):
         try:
             fn(*args_pack, config=cfg)


### PR DESCRIPTION
## Summary

Adds three communication-sink push functions to every family-office leaf so the catalog can close the advisor workflow loop: artifact produced → stored in SharePoint + Snowflake + Asana (from PR #430) → **emailed to CPA/counsel, follow-up meeting scheduled** (this PR).

Closes the comms-sinks milestone of #431.

- `push_to_outlook_email` — sends via `microsoft-outlook` (`POST /me/sendMail`)
- `push_to_gmail` — sends via `gmail` (`POST /users/me/messages/send`)
- `push_to_gcalendar` — creates an event via `google-calendar` (`POST /calendars/<id>/events`)

## Publisher audit (verified via MCP registry)

Queried `list_agent_publishers` (all 131 publishers, three pages) and `get_agent_publisher` for the Microsoft slugs:

| Publisher | Endpoint used | Verified |
|---|---|---|
| `microsoft-outlook` | `POST /me/sendMail` | ✅ in documented endpoint list |
| `gmail` | `POST /users/me/messages/send` | ✅ |
| `google-calendar` | `POST /calendars/<id>/events` | ✅ |

**Outlook calendar NOT included.** `get_agent_publisher("microsoft-outlook")` returned 27 endpoints, all mail-only (`/me/messages`, `/me/mailFolders`, `/me/sendMail`, etc.). The publisher's `undocumented_endpoint_policy: default_deny` means calls to `/me/events` would be rejected by the gateway even though upstream Graph supports them. A new MCP publisher would be required to ship Outlook-calendar push; that's out of scope here.

## Per-leaf changes (all 55)

- `scripts/agent.py` gains three new functions using the same inline `GatewayClient` pattern shipped in PR #430.
- `main()` loop invokes each push after `write_artifact`; failures are logged at WARNING, not fatal, and do not block the others.
- `.env.example` notes that all three publishers authenticate via the existing `SEREN_API_KEY` — no additional per-publisher secrets.
- No changes to `requirements.txt` — `requests` is already pinned.
- No cross-skill imports. No `_base/` folder. Inline shared runtime per the "no premature abstraction" discipline.

## Config additions

Leaf `config.json` can now include any of:

```json
{
  "outlook_email": {
    "to":             ["cpa@example.com"],
    "cc":             ["counsel@example.com"],
    "subject_prefix": "[Seren] "
  },
  "gmail": {
    "to":             ["cpa@example.com"],
    "cc":             [],
    "subject_prefix": "[Seren] "
  },
  "gcalendar": {
    "calendar_id":     "primary",
    "duration_minutes": 30,
    "attendees":       ["advisor@example.com"],
    "days_out":         7
  }
}
```

Each block is optional; absence = no-op. Credentials live only in env vars (`SEREN_API_KEY`); config.json carries no secrets.

## Security non-negotiables (test-enforced)

- Credentials never in `config.json`.
- **Email subjects templated from `ARTIFACT_NAME` + date.** No raw PII or financial amounts ever in an outbound Subject: header.
- **Email bodies reference only safe identifiers** — `artifact_id`, content hash prefix. Interview answers are NOT copied into outbound messages.
- **Calendar event descriptions** pass through `_redact_payload` before going out. SSN / EIN / account fields are replaced with `<redacted>`. Test verifies a planted `principal_ssn` / `trust_ein` never reaches the event body.
- **Recipient lists logged as counts at INFO** — cleartext addresses are PII and appear only at DEBUG.
- **Calendar IDs logged as counts at INFO** — some GCal calendar IDs embed the family's identity.

## Critical tests only (DRY)

**11 new tests** on the reference leaf (`cpa-tax-package-checklist`):

- No-op tests (3): each push returns `None` when its config block is absent.
- Validation tests (3): required-key validation (`to` non-empty for email; `calendar_id` for GCal).
- Happy-path tests (3): stubbed `GatewayClient` captures the call; body shape asserted — Graph `message.toRecipients` for Outlook, urlsafe-b64-encoded RFC 2822 for Gmail, event with start/end/attendees for GCal.
- PII invariant (1): GCal event description has SSN/EIN stripped.
- Logging hygiene (2): recipient addresses + calendar IDs never at INFO level.

Total suite now: **133 tests (110 smoke + 12 PR-#430 sinks + 11 PR-#431 comms)**. Same DRY discipline: one reference leaf covers the push contract; 54 other leaves keep their existing smoke tests.

## CI

No new CI jobs needed. The existing `family-office-rebuild.yml` workflow exercises the new tests automatically via its Python 3.11 + 3.12 matrix. Three regression guards (`forbid-publisher-root-skill-md`, `forbid-non-skill-folders`, `indexer-smoke`) still green — indexer sees 60 family-office skills as before.

## Test plan

- [ ] CI `test` green on Python 3.11 and 3.12 (133 tests)
- [ ] CI `indexer-smoke` green (60 family-office skills, unchanged)
- [ ] Manual: invoke `cpa-tax-package-checklist` with a config containing all six sink blocks (SharePoint / Asana / Snowflake / Outlook email / Gmail / GCalendar) against a seeded tenant; confirm artifact propagates to every configured destination

## Out of scope (future PRs / new publishers required)

- **Outlook calendar** — requires new MCP publisher (mail publisher is `default_deny` on undocumented paths).
- **Egnyte** — no MCP publisher.
- PDF / DOCX / XLSX companion renders.
- Approval gate + 8-point execution readiness check.
- Canonical object model schema.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
