### PR TITLE
feat(family-office): brand every skill as "Family Office · <Artifact>" for SerenDesktop

### DIFF
--- a/family-office/annual-budget-workbook/SKILL.md
+++ b/family-office/annual-budget-workbook/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: annual-budget-workbook
-display-name: "Annual Budget Workbook"
-description: "Produce an annual budget workbook for the family. Captures income sources, fixed expenses, variable expenses, savings targets, and charitable giving."
+display-name: "Family Office · Annual Budget Workbook"
+description: "Family office: Produce an annual budget workbook for the family. Captures income sources, fixed expenses, variable expenses, savings targets, and charitable giving."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Annual Budget Workbook

--- a/family-office/art-acquisition-due-diligence/SKILL.md
+++ b/family-office/art-acquisition-due-diligence/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: art-acquisition-due-diligence
-display-name: "Art Acquisition Due-Diligence Memo"
-description: "Produce a due diligence memo for an art acquisition — provenance, authentication, condition, insurance, storage, sale consideration."
+display-name: "Family Office · Art Acquisition Due-Diligence Memo"
+description: "Family office: Produce a due diligence memo for an art acquisition — provenance, authentication, condition, insurance, storage, sale consideration."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Art Acquisition Due-Diligence Memo

--- a/family-office/bookkeeping-bill-pay-setup-plan/SKILL.md
+++ b/family-office/bookkeeping-bill-pay-setup-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: bookkeeping-bill-pay-setup-plan
-display-name: "Bookkeeping & Bill Pay Setup Plan"
-description: "Produce a setup plan for family-office bookkeeping and bill pay operations — software, approvers, reconciliation, internal controls."
+display-name: "Family Office · Bookkeeping & Bill Pay Setup Plan"
+description: "Family office: Produce a setup plan for family-office bookkeeping and bill pay operations — software, approvers, reconciliation, internal controls."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Bookkeeping & Bill Pay Setup Plan

--- a/family-office/business-exit-strategy/SKILL.md
+++ b/family-office/business-exit-strategy/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: business-exit-strategy
-display-name: "Exit Tax Minimization Plan"
-description: "Produce an exit tax minimization plan for a principal selling an operating business. Captures business basis, expected proceeds, planning windows, and candidate structures (QSBS, charitable trusts, installment sales)."
+display-name: "Family Office · Exit Tax Minimization Plan"
+description: "Family office: Produce an exit tax minimization plan for a principal selling an operating business. Captures business basis, expected proceeds, planning windows, and candidate structures (QSBS, charitable trusts, installment sales)."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Exit Tax Minimization Plan

--- a/family-office/capital-allocation-router/SKILL.md
+++ b/family-office/capital-allocation-router/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: capital-allocation-router
-display-name: "Family Office — Capital Allocation Router"
-description: "Pillar router for Capital Allocation. Classifies a natural-language advisor ask into the matching leaf skill inside the Capital Allocation pillar. Catalog rebuild tracked in issue #427."
+display-name: "Family Office · Capital Allocation Router"
+description: "Family office: Pillar router for Capital Allocation. Classifies a natural-language advisor ask into the matching leaf skill inside the Capital Allocation pillar. Catalog rebuild tracked in issue #427."
+tags: [family-office, pillar:capital-allocation, type:router]
 ---
 
 # Family Office — Capital Allocation Router

--- a/family-office/cashflow-forecast-worksheet/SKILL.md
+++ b/family-office/cashflow-forecast-worksheet/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cashflow-forecast-worksheet
-display-name: "Cashflow Forecast Worksheet"
-description: "Produce a 12-month rolling cashflow forecast. Captures inflows, outflows, timing, and cushion requirements."
+display-name: "Family Office · Cashflow Forecast Worksheet"
+description: "Family office: Produce a 12-month rolling cashflow forecast. Captures inflows, outflows, timing, and cushion requirements."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Cashflow Forecast Worksheet

--- a/family-office/charitable-trust-selection-memo/SKILL.md
+++ b/family-office/charitable-trust-selection-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: charitable-trust-selection-memo
-display-name: "Charitable Trust Selection Memo"
-description: "Produce a memo comparing charitable trust options — CRUT, CRAT, CLT, CLAT — for the family's giving goals."
+display-name: "Family Office · Charitable Trust Selection Memo"
+description: "Family office: Produce a memo comparing charitable trust options — CRUT, CRAT, CLT, CLAT — for the family's giving goals."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Charitable Trust Selection Memo

--- a/family-office/client-sourced-deal-review-memo/SKILL.md
+++ b/family-office/client-sourced-deal-review-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: client-sourced-deal-review-memo
-display-name: "Client-Sourced Deal Review Memo"
-description: "Produce a review memo for a deal the principal sourced themselves. Captures deal sponsor, structure, terms, conflicts, and recommendation."
+display-name: "Family Office · Client-Sourced Deal Review Memo"
+description: "Family office: Produce a review memo for a deal the principal sourced themselves. Captures deal sponsor, structure, terms, conflicts, and recommendation."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Client-Sourced Deal Review Memo

--- a/family-office/collectibles-acquisition-logistics/SKILL.md
+++ b/family-office/collectibles-acquisition-logistics/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: collectibles-acquisition-logistics
-display-name: "Collectibles Acquisition & Logistics Plan"
-description: "Produce a plan for acquiring and moving a collectible asset (classic car, rare wine, timepiece, sports memorabilia). Example: antique Ferrari from Pebble Beach to Naples."
+display-name: "Family Office · Collectibles Acquisition & Logistics Plan"
+description: "Family office: Produce a plan for acquiring and moving a collectible asset (classic car, rare wine, timepiece, sports memorabilia). Example: antique Ferrari from Pebble Beach to Naples."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Collectibles Acquisition & Logistics Plan

--- a/family-office/community-engagement-plan/SKILL.md
+++ b/family-office/community-engagement-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: community-engagement-plan
-display-name: "Community Engagement Plan"
-description: "Produce a community engagement plan — relationships with civic, cultural, and nonprofit organizations; time commitments; reputational posture."
+display-name: "Family Office · Community Engagement Plan"
+description: "Family office: Produce a community engagement plan — relationships with civic, cultural, and nonprofit organizations; time commitments; reputational posture."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Community Engagement Plan

--- a/family-office/complexity-management-router/SKILL.md
+++ b/family-office/complexity-management-router/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: complexity-management-router
-display-name: "Family Office — Complexity Management Router"
-description: "Pillar router for Complexity Management. Classifies a natural-language advisor ask into the matching leaf skill inside the Complexity Management pillar. Catalog rebuild tracked in issue #427."
+display-name: "Family Office · Complexity Management Router"
+description: "Family office: Pillar router for Complexity Management. Classifies a natural-language advisor ask into the matching leaf skill inside the Complexity Management pillar. Catalog rebuild tracked in issue #427."
+tags: [family-office, pillar:complexity-management, type:router]
 ---
 
 # Family Office — Complexity Management Router

--- a/family-office/concierge-personal-protection-plan/SKILL.md
+++ b/family-office/concierge-personal-protection-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: concierge-personal-protection-plan
-display-name: "Personal Protection Plan"
-description: "Produce a personal protection plan — threat profile, physical security, executive protection providers, travel security."
+display-name: "Family Office · Personal Protection Plan"
+description: "Family office: Produce a personal protection plan — threat profile, physical security, executive protection providers, travel security."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Personal Protection Plan

--- a/family-office/concierge-personal-shopping-plan/SKILL.md
+++ b/family-office/concierge-personal-shopping-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: concierge-personal-shopping-plan
-display-name: "Personal Shopping Plan"
-description: "Produce a personal shopping plan — occasion, budget, brand preferences, sizing, delivery, returns."
+display-name: "Family Office · Personal Shopping Plan"
+description: "Family office: Produce a personal shopping plan — occasion, budget, brand preferences, sizing, delivery, returns."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Personal Shopping Plan

--- a/family-office/concierge-private-aviation-plan/SKILL.md
+++ b/family-office/concierge-private-aviation-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: concierge-private-aviation-plan
-display-name: "Private Aviation Coordination Plan"
-description: "Produce a private aviation coordination plan — operator roster, preferred aircraft, crew preferences, catering, ground transport."
+display-name: "Family Office · Private Aviation Coordination Plan"
+description: "Family office: Produce a private aviation coordination plan — operator roster, preferred aircraft, crew preferences, catering, ground transport."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Private Aviation Coordination Plan

--- a/family-office/concierge-private-car-plan/SKILL.md
+++ b/family-office/concierge-private-car-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: concierge-private-car-plan
-display-name: "Private Car Coordination Plan"
-description: "Produce a private car coordination plan — operators, drivers, vehicles, standing reservations, billing."
+display-name: "Family Office · Private Car Coordination Plan"
+description: "Family office: Produce a private car coordination plan — operators, drivers, vehicles, standing reservations, billing."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Private Car Coordination Plan

--- a/family-office/concierge-travel-coordination-plan/SKILL.md
+++ b/family-office/concierge-travel-coordination-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: concierge-travel-coordination-plan
-display-name: "Travel Coordination Plan"
-description: "Produce a travel coordination plan — itinerary, hotels, transfers, dining, contingency plans."
+display-name: "Family Office · Travel Coordination Plan"
+description: "Family office: Produce a travel coordination plan — itinerary, hotels, transfers, dining, contingency plans."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Travel Coordination Plan

--- a/family-office/consolidated-reporting-spec/SKILL.md
+++ b/family-office/consolidated-reporting-spec/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: consolidated-reporting-spec
-display-name: "Consolidated Reporting Specification"
-description: "Produce a specification for consolidated family-office reporting across entities, accounts, and asset classes."
+display-name: "Family Office · Consolidated Reporting Specification"
+description: "Family office: Produce a specification for consolidated family-office reporting across entities, accounts, and asset classes."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Consolidated Reporting Specification

--- a/family-office/cpa-tax-package-checklist/SKILL.md
+++ b/family-office/cpa-tax-package-checklist/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cpa-tax-package-checklist
-display-name: "CPA Tax Package Checklist"
-description: "Produce a checklist of every document the CPA needs for tax return preparation. Tailored to the family's entities and income sources."
+display-name: "Family Office · CPA Tax Package Checklist"
+description: "Family office: Produce a checklist of every document the CPA needs for tax return preparation. Tailored to the family's entities and income sources."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # CPA Tax Package Checklist

--- a/family-office/cpa-tax-package-checklist/tests/test_branding.py
+++ b/family-office/cpa-tax-package-checklist/tests/test_branding.py
@@ -1,0 +1,196 @@
+"""Critical catalog-wide branding test (issue #433).
+
+ONE test file — walks every family-office leaf + router and asserts:
+
+  1. display-name is `Family Office · <something non-empty>` for leaves
+     and matches a canonical map for routers.
+  2. description leads with `Family office: `.
+  3. tags contains `family-office`.
+  4. tags contains exactly one `pillar:<x>` tag for leaves and pillar
+     routers; the top-level router omits it.
+  5. Leaf's tag pillar matches the leaf's agent.py `PILLAR` constant
+     (source of truth, so tags cannot silently drift from code).
+  6. Routers carry `type:router`.
+  7. `knowledge/` is untouched (its SKILL.md is not required to match
+     the family-office branding).
+
+Per-leaf duplication of this test would catch no new bugs. Living
+inside cpa-tax-package-checklist/tests/ because the reference leaf is
+where catalog-wide assertions live in this repo (matches test_sinks.py
+and test_comms.py).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+FAMILY_OFFICE_ROOT = HERE.parent.parent  # .../family-office
+
+DISPLAY_PREFIX = "Family Office · "
+DESC_PREFIX = "Family office: "
+
+CANONICAL_ROUTER_DISPLAY = {
+    "router": "Family Office · Top-Level Router",
+    "capital-allocation-router": "Family Office · Capital Allocation Router",
+    "complexity-management-router": "Family Office · Complexity Management Router",
+    "legacy-preservation-router": "Family Office · Legacy Preservation Router",
+}
+
+PILLAR_ROUTER_PILLARS = {
+    "capital-allocation-router": "capital-allocation",
+    "complexity-management-router": "complexity-management",
+    "legacy-preservation-router": "legacy-preservation",
+}
+
+SKIP_DIRS = {"knowledge"}
+
+
+def _parse_frontmatter(md: str) -> dict[str, str]:
+    lines = md.split("\n")
+    assert lines and lines[0].strip() == "---", "missing frontmatter opener"
+    out: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        m = re.match(r"^([A-Za-z][A-Za-z0-9_\-]*):\s*(.*)$", line)
+        if not m:
+            continue
+        k = m.group(1).strip()
+        v = m.group(2).strip()
+        if (v.startswith('"') and v.endswith('"')) or (
+            v.startswith("'") and v.endswith("'")
+        ):
+            v = v[1:-1]
+        out[k] = v
+    raise AssertionError("missing frontmatter closer")
+
+
+def _parse_tags(value: str) -> list[str]:
+    v = value.strip()
+    if v.startswith("[") and v.endswith("]"):
+        inner = v[1:-1]
+    else:
+        inner = v
+    return [t.strip().strip("\"'") for t in inner.split(",") if t.strip()]
+
+
+def _pillar_from_agent(leaf_dir: Path) -> str:
+    agent = (leaf_dir / "scripts" / "agent.py").read_text(encoding="utf-8")
+    m = re.search(r'^PILLAR\s*=\s*"([^"]+)"', agent, re.MULTILINE)
+    assert m, f"cannot read PILLAR from {leaf_dir.name}/scripts/agent.py"
+    return m.group(1)
+
+
+def _catalog() -> dict[str, Path]:
+    """Return {slug: skill_dir} for every family-office skill except knowledge."""
+    out: dict[str, Path] = {}
+    for entry in sorted(FAMILY_OFFICE_ROOT.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("."):
+            continue
+        if entry.name in SKIP_DIRS:
+            continue
+        if not (entry / "SKILL.md").exists():
+            continue
+        out[entry.name] = entry
+    return out
+
+
+def test_catalog_has_55_leaves_and_4_routers() -> None:
+    catalog = _catalog()
+    assert len(catalog) == 59, (
+        f"expected 55 leaves + 4 routers = 59 branded skills; got {len(catalog)}"
+    )
+
+
+def _leaf_and_router_params():
+    out = []
+    for slug, skill_dir in _catalog().items():
+        is_router = slug in CANONICAL_ROUTER_DISPLAY
+        out.append(pytest.param(slug, skill_dir, is_router, id=slug))
+    return out
+
+
+@pytest.mark.parametrize("slug,skill_dir,is_router", _leaf_and_router_params())
+def test_skill_branded_correctly(slug: str, skill_dir: Path, is_router: bool) -> None:
+    md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    fm = _parse_frontmatter(md)
+
+    # 1. display-name branding.
+    display = fm.get("display-name", "")
+    if is_router:
+        assert display == CANONICAL_ROUTER_DISPLAY[slug], (
+            f"{slug}: router display-name must match canonical map; "
+            f"got {display!r}"
+        )
+    else:
+        assert display.startswith(DISPLAY_PREFIX), (
+            f"{slug}: leaf display-name must start with {DISPLAY_PREFIX!r}; "
+            f"got {display!r}"
+        )
+        # Reject the double-prefix regression seen during augmentation.
+        assert not display.startswith(DISPLAY_PREFIX + DISPLAY_PREFIX), (
+            f"{slug}: display-name double-prefixed"
+        )
+        assert len(display) > len(DISPLAY_PREFIX), (
+            f"{slug}: display-name has prefix but no artifact name"
+        )
+
+    # 2. description leads with Family office:.
+    desc = fm.get("description", "")
+    assert desc.startswith(DESC_PREFIX), (
+        f"{slug}: description must start with {DESC_PREFIX!r}; got {desc!r}"
+    )
+    assert not desc.startswith(DESC_PREFIX + DESC_PREFIX), (
+        f"{slug}: description double-prefixed"
+    )
+
+    # 3. tags — family-office always present.
+    tags = _parse_tags(fm.get("tags", ""))
+    assert "family-office" in tags, f"{slug}: tags missing 'family-office'"
+
+    # 4. Pillar tag correctness.
+    pillar_tags = [t for t in tags if t.startswith("pillar:")]
+    if slug == "router":
+        assert pillar_tags == [], f"{slug}: top-level router must NOT carry a pillar tag"
+    elif slug in PILLAR_ROUTER_PILLARS:
+        expected = f"pillar:{PILLAR_ROUTER_PILLARS[slug]}"
+        assert pillar_tags == [expected], (
+            f"{slug}: expected {expected!r}; got {pillar_tags!r}"
+        )
+    else:
+        # Leaf: must have exactly one pillar tag, and it must match the
+        # agent.py PILLAR constant (source of truth, not an inferred guess).
+        assert len(pillar_tags) == 1, (
+            f"{slug}: leaf must have exactly one pillar tag; got {pillar_tags!r}"
+        )
+        expected = f"pillar:{_pillar_from_agent(skill_dir)}"
+        assert pillar_tags[0] == expected, (
+            f"{slug}: tag {pillar_tags[0]!r} does not match agent.py pillar "
+            f"{expected!r} — tags would silently drift"
+        )
+
+    # 5. Routers carry type:router.
+    if is_router:
+        assert "type:router" in tags, f"{slug}: router missing 'type:router' tag"
+    else:
+        assert "type:router" not in tags, (
+            f"{slug}: leaf must not carry 'type:router' tag"
+        )
+
+
+def test_knowledge_skill_is_not_rebranded() -> None:
+    """Explicit guard: knowledge keeps its existing branding, untouched."""
+    knowledge_md = FAMILY_OFFICE_ROOT / "knowledge" / "SKILL.md"
+    assert knowledge_md.exists()
+    fm = _parse_frontmatter(knowledge_md.read_text(encoding="utf-8"))
+    display = fm.get("display-name", "")
+    assert not display.startswith(DISPLAY_PREFIX), (
+        "knowledge skill must NOT be rebranded — it ships with its original "
+        "display-name per the catalog's 'knowledge untouched' invariant"
+    )

--- a/family-office/document-management-plan/SKILL.md
+++ b/family-office/document-management-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: document-management-plan
-display-name: "Document Management Plan"
-description: "Produce a document management plan — DMS choice, folder taxonomy, retention rules, access control."
+display-name: "Family Office · Document Management Plan"
+description: "Family office: Produce a document management plan — DMS choice, folder taxonomy, retention rules, access control."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Document Management Plan

--- a/family-office/esg-impact-investing-mandate/SKILL.md
+++ b/family-office/esg-impact-investing-mandate/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: esg-impact-investing-mandate
-display-name: "ESG / Impact Investing Mandate"
-description: "Produce an ESG / impact investing mandate for the family office. Captures themes, exclusions, measurement framework, and blended-return tolerance."
+display-name: "Family Office · ESG / Impact Investing Mandate"
+description: "Family office: Produce an ESG / impact investing mandate for the family office. Captures themes, exclusions, measurement framework, and blended-return tolerance."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # ESG / Impact Investing Mandate

--- a/family-office/estate-plan-summary-memo/SKILL.md
+++ b/family-office/estate-plan-summary-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: estate-plan-summary-memo
-display-name: "Estate Plan Summary Memo"
-description: "Produce an estate plan summary memo — wills, trusts, directives, guardianship, beneficiary designations, and gaps."
+display-name: "Family Office · Estate Plan Summary Memo"
+description: "Family office: Produce an estate plan summary memo — wills, trusts, directives, guardianship, beneficiary designations, and gaps."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Estate Plan Summary Memo

--- a/family-office/expedited-funding-access-plan/SKILL.md
+++ b/family-office/expedited-funding-access-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: expedited-funding-access-plan
-display-name: "Expedited Funding Access Plan"
-description: "Produce a plan for expedited access to large liquidity when needed (margin, SBLOC, art loan, credit lines)."
+display-name: "Family Office · Expedited Funding Access Plan"
+description: "Family office: Produce a plan for expedited access to large liquidity when needed (margin, SBLOC, art loan, credit lines)."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Expedited Funding Access Plan

--- a/family-office/external-advisor-management-plan/SKILL.md
+++ b/family-office/external-advisor-management-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: external-advisor-management-plan
-display-name: "External Advisor Management Plan"
-description: "Produce a plan for managing external advisors (legal, tax, custodial, insurance, consulting). Captures advisor roster, meeting cadence, fee posture, and performance review."
+display-name: "Family Office · External Advisor Management Plan"
+description: "Family office: Produce a plan for managing external advisors (legal, tax, custodial, insurance, consulting). Captures advisor roster, meeting cadence, fee posture, and performance review."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # External Advisor Management Plan

--- a/family-office/family-board-development-plan/SKILL.md
+++ b/family-office/family-board-development-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-board-development-plan
-display-name: "Family Board Development Plan"
-description: "Produce a board development plan for the family enterprise — skills matrix, recruitment, education, evaluation."
+display-name: "Family Office · Family Board Development Plan"
+description: "Family office: Produce a board development plan for the family enterprise — skills matrix, recruitment, education, evaluation."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Board Development Plan

--- a/family-office/family-foundation-formation-plan/SKILL.md
+++ b/family-office/family-foundation-formation-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-foundation-formation-plan
-display-name: "Family Foundation Formation Plan"
-description: "Produce a formation plan for a family foundation — legal structure, initial funding, governance, grant-making policy."
+display-name: "Family Office · Family Foundation Formation Plan"
+description: "Family office: Produce a formation plan for a family foundation — legal structure, initial funding, governance, grant-making policy."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Foundation Formation Plan

--- a/family-office/family-governance-charter/SKILL.md
+++ b/family-office/family-governance-charter/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-governance-charter
-display-name: "Family Governance Charter"
-description: "Produce a family governance charter — principles, decision-making bodies, roles, meeting cadence, conflict-resolution."
+display-name: "Family Office · Family Governance Charter"
+description: "Family office: Produce a family governance charter — principles, decision-making bodies, roles, meeting cadence, conflict-resolution."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Governance Charter

--- a/family-office/family-meeting-agenda-minutes-template/SKILL.md
+++ b/family-office/family-meeting-agenda-minutes-template/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-meeting-agenda-minutes-template
-display-name: "Family Meeting Agenda & Minutes Template"
-description: "Produce an agenda and minutes template for a recurring family meeting — attendees, agenda items, decisions, action items."
+display-name: "Family Office · Family Meeting Agenda & Minutes Template"
+description: "Family office: Produce an agenda and minutes template for a recurring family meeting — attendees, agenda items, decisions, action items."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Meeting Agenda & Minutes Template

--- a/family-office/family-mission-statement/SKILL.md
+++ b/family-office/family-mission-statement/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-mission-statement
-display-name: "Family Mission Statement"
-description: "Produce a family mission statement — values, purpose, principles, and aspirations."
+display-name: "Family Office · Family Mission Statement"
+description: "Family office: Produce a family mission statement — values, purpose, principles, and aspirations."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Mission Statement

--- a/family-office/family-philanthropy-strategic-plan/SKILL.md
+++ b/family-office/family-philanthropy-strategic-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-philanthropy-strategic-plan
-display-name: "Family Philanthropy Strategic Plan"
-description: "Produce a strategic philanthropic plan — mission, causes, giving vehicles, budget, metrics, family engagement."
+display-name: "Family Office · Family Philanthropy Strategic Plan"
+description: "Family office: Produce a strategic philanthropic plan — mission, causes, giving vehicles, budget, metrics, family engagement."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Philanthropy Strategic Plan

--- a/family-office/family-risk-management-plan/SKILL.md
+++ b/family-office/family-risk-management-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: family-risk-management-plan
-display-name: "Family Risk Management Plan"
-description: "Produce a family risk management plan covering cyber, personal security, travel security, reputational risk, and business-continuity. Example: an international trip to a higher-risk region."
+display-name: "Family Office · Family Risk Management Plan"
+description: "Family office: Produce a family risk management plan covering cyber, personal security, travel security, reputational risk, and business-continuity. Example: an international trip to a higher-risk region."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Family Risk Management Plan

--- a/family-office/healthcare-proxy-living-will-checklist/SKILL.md
+++ b/family-office/healthcare-proxy-living-will-checklist/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: healthcare-proxy-living-will-checklist
-display-name: "Healthcare Proxy & Living Will Checklist"
-description: "Produce a checklist for healthcare proxy and living will documents — agents, scope, end-of-life directives, HIPAA authorizations."
+display-name: "Family Office · Healthcare Proxy & Living Will Checklist"
+description: "Family office: Produce a checklist for healthcare proxy and living will documents — agents, scope, end-of-life directives, HIPAA authorizations."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Healthcare Proxy & Living Will Checklist

--- a/family-office/insurance-coverage-review-worksheet/SKILL.md
+++ b/family-office/insurance-coverage-review-worksheet/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: insurance-coverage-review-worksheet
-display-name: "Insurance Coverage Review Worksheet"
-description: "Produce a worksheet reviewing all insurance coverage — health, life, property, auto/marine, liability, umbrella, casualty. Captures policies in force, gaps, and renewal dates."
+display-name: "Family Office · Insurance Coverage Review Worksheet"
+description: "Family office: Produce a worksheet reviewing all insurance coverage — health, life, property, auto/marine, liability, umbrella, casualty. Captures policies in force, gaps, and renewal dates."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Insurance Coverage Review Worksheet

--- a/family-office/insurance-procurement-framework/SKILL.md
+++ b/family-office/insurance-procurement-framework/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: insurance-procurement-framework
-display-name: "Insurance Procurement Framework"
-description: "Produce a procurement framework for acquiring new insurance coverage — factors to consider, broker RFP structure, policy-terms checklist."
+display-name: "Family Office · Insurance Procurement Framework"
+description: "Family office: Produce a procurement framework for acquiring new insurance coverage — factors to consider, broker RFP structure, policy-terms checklist."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Insurance Procurement Framework

--- a/family-office/investment-operations-review-checklist/SKILL.md
+++ b/family-office/investment-operations-review-checklist/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: investment-operations-review-checklist
-display-name: "Investment Operations Review Checklist"
-description: "Produce a checklist for an ongoing investment operations review — custody, reconciliation, fee verification, performance reporting."
+display-name: "Family Office · Investment Operations Review Checklist"
+description: "Family office: Produce a checklist for an ongoing investment operations review — custody, reconciliation, fee verification, performance reporting."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Investment Operations Review Checklist

--- a/family-office/legacy-preservation-router/SKILL.md
+++ b/family-office/legacy-preservation-router/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: legacy-preservation-router
-display-name: "Family Office — Legacy Preservation Router"
-description: "Pillar router for Legacy Preservation. Classifies a natural-language advisor ask into the matching leaf skill inside the Legacy Preservation pillar. Catalog rebuild tracked in issue #427."
+display-name: "Family Office · Legacy Preservation Router"
+description: "Family office: Pillar router for Legacy Preservation. Classifies a natural-language advisor ask into the matching leaf skill inside the Legacy Preservation pillar. Catalog rebuild tracked in issue #427."
+tags: [family-office, pillar:legacy-preservation, type:router]
 ---
 
 # Family Office — Legacy Preservation Router

--- a/family-office/leisure-asset-ownership-comparison/SKILL.md
+++ b/family-office/leisure-asset-ownership-comparison/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: leisure-asset-ownership-comparison
-display-name: "Leisure Asset Ownership Comparison"
-description: "Produce a model comparing ownership options for a leisure asset (full ownership vs fractional vs chartered). Example: jet vs NetJets."
+display-name: "Family Office · Leisure Asset Ownership Comparison"
+description: "Family office: Produce a model comparing ownership options for a leisure asset (full ownership vs fractional vs chartered). Example: jet vs NetJets."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Leisure Asset Ownership Comparison

--- a/family-office/long-term-portfolio-strategy-plan/SKILL.md
+++ b/family-office/long-term-portfolio-strategy-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: long-term-portfolio-strategy-plan
-display-name: "Long-Term Portfolio Strategy Plan"
-description: "Produce a long-term portfolio strategy plan for a single family office. Captures time horizon, liquidity needs, return targets, risk tolerance, and constraints; outputs a memo an advisor hands to the principal."
+display-name: "Family Office · Long-Term Portfolio Strategy Plan"
+description: "Family office: Produce a long-term portfolio strategy plan for a single family office. Captures time horizon, liquidity needs, return targets, risk tolerance, and constraints; outputs a memo an advisor hands to the principal."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Long-Term Portfolio Strategy Plan

--- a/family-office/manager-dd-direct-co-investment/SKILL.md
+++ b/family-office/manager-dd-direct-co-investment/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-direct-co-investment
-display-name: "Direct / Co-Investment DD Memo"
-description: "Produce a due diligence memo for a direct or co-investment opportunity alongside a sponsor. Captures company, thesis, cap table, terms, and concentration risk."
+display-name: "Family Office · Direct / Co-Investment DD Memo"
+description: "Family office: Produce a due diligence memo for a direct or co-investment opportunity alongside a sponsor. Captures company, thesis, cap table, terms, and concentration risk."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Direct / Co-Investment DD Memo

--- a/family-office/manager-dd-esg-impact/SKILL.md
+++ b/family-office/manager-dd-esg-impact/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-esg-impact
-display-name: "ESG / Impact Manager DD Memo"
-description: "Produce a due diligence memo for a prospective ESG or impact-investing manager. Captures mandate, impact metrics, concessionary-return posture, and reporting."
+display-name: "Family Office · ESG / Impact Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective ESG or impact-investing manager. Captures mandate, impact metrics, concessionary-return posture, and reporting."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # ESG / Impact Manager DD Memo

--- a/family-office/manager-dd-hedge-fund/SKILL.md
+++ b/family-office/manager-dd-hedge-fund/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-hedge-fund
-display-name: "Hedge Fund Manager DD Memo"
-description: "Produce a due diligence memo for a prospective hedge fund manager. Captures strategy, track record, drawdowns, gates, side pockets, and fee terms."
+display-name: "Family Office · Hedge Fund Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective hedge fund manager. Captures strategy, track record, drawdowns, gates, side pockets, and fee terms."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Hedge Fund Manager DD Memo

--- a/family-office/manager-dd-private-debt/SKILL.md
+++ b/family-office/manager-dd-private-debt/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-private-debt
-display-name: "Private Debt Manager DD Memo"
-description: "Produce a due diligence memo for a prospective private credit / private debt manager. Captures strategy, loss history, seniority, covenants, and yield profile."
+display-name: "Family Office · Private Debt Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective private credit / private debt manager. Captures strategy, loss history, seniority, covenants, and yield profile."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Private Debt Manager DD Memo

--- a/family-office/manager-dd-private-equity/SKILL.md
+++ b/family-office/manager-dd-private-equity/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-private-equity
-display-name: "Private Equity Manager DD Memo"
-description: "Produce a due diligence memo for a prospective private equity fund. Captures fund vintage, track record, sector focus, fee terms, and J-curve expectations."
+display-name: "Family Office · Private Equity Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective private equity fund. Captures fund vintage, track record, sector focus, fee terms, and J-curve expectations."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Private Equity Manager DD Memo

--- a/family-office/manager-dd-real-assets/SKILL.md
+++ b/family-office/manager-dd-real-assets/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-real-assets
-display-name: "Real Assets Manager DD Memo"
-description: "Produce a due diligence memo for a prospective real assets manager (infrastructure, commodities, natural resources). Captures asset class, inflation-hedging profile, and yield."
+display-name: "Family Office · Real Assets Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective real assets manager (infrastructure, commodities, natural resources). Captures asset class, inflation-hedging profile, and yield."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Real Assets Manager DD Memo

--- a/family-office/manager-dd-real-estate/SKILL.md
+++ b/family-office/manager-dd-real-estate/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-real-estate
-display-name: "Real Estate Manager DD Memo"
-description: "Produce a due diligence memo for a prospective real estate fund. Captures property type, geography, cap rate, leverage, and NOI assumptions."
+display-name: "Family Office · Real Estate Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective real estate fund. Captures property type, geography, cap rate, leverage, and NOI assumptions."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Real Estate Manager DD Memo

--- a/family-office/manager-dd-venture-capital/SKILL.md
+++ b/family-office/manager-dd-venture-capital/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: manager-dd-venture-capital
-display-name: "Venture Capital Manager DD Memo"
-description: "Produce a due diligence memo for a prospective venture capital fund. Captures stage focus, sourcing model, portfolio construction, and prior-fund mark-ups."
+display-name: "Family Office · Venture Capital Manager DD Memo"
+description: "Family office: Produce a due diligence memo for a prospective venture capital fund. Captures stage focus, sourcing model, portfolio construction, and prior-fund mark-ups."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Venture Capital Manager DD Memo

--- a/family-office/new-business-diligence-memo/SKILL.md
+++ b/family-office/new-business-diligence-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: new-business-diligence-memo
-display-name: "New Business Diligence Memo"
-description: "Produce a diligence memo for a new business the principal is considering acquiring or starting. Captures thesis, unit economics, key risks, and recommended next steps."
+display-name: "Family Office · New Business Diligence Memo"
+description: "Family office: Produce a diligence memo for a new business the principal is considering acquiring or starting. Captures thesis, unit economics, key risks, and recommended next steps."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # New Business Diligence Memo

--- a/family-office/next-generation-education-curriculum/SKILL.md
+++ b/family-office/next-generation-education-curriculum/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: next-generation-education-curriculum
-display-name: "Next-Generation Education Curriculum"
-description: "Produce a curriculum for educating the next generation on family history, wealth, responsibility, and values. Includes modules, readings, and milestones."
+display-name: "Family Office · Next-Generation Education Curriculum"
+description: "Family office: Produce a curriculum for educating the next generation on family history, wealth, responsibility, and values. Includes modules, readings, and milestones."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Next-Generation Education Curriculum

--- a/family-office/password-management-setup-plan/SKILL.md
+++ b/family-office/password-management-setup-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: password-management-setup-plan
-display-name: "Password Management Setup Plan"
-description: "Produce a password management setup plan — vault choice, account inventory, sharing model, 2FA, recovery."
+display-name: "Family Office · Password Management Setup Plan"
+description: "Family office: Produce a password management setup plan — vault choice, account inventory, sharing model, 2FA, recovery."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Password Management Setup Plan

--- a/family-office/portfolio-risk-register/SKILL.md
+++ b/family-office/portfolio-risk-register/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: portfolio-risk-register
-display-name: "Portfolio Risk Register"
-description: "Produce a portfolio risk register. Captures concentration risks, liquidity risks, counterparty risks, tax-lot risks, and mitigations."
+display-name: "Family Office · Portfolio Risk Register"
+description: "Family office: Produce a portfolio risk register. Captures concentration risks, liquidity risks, counterparty risks, tax-lot risks, and mitigations."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Portfolio Risk Register

--- a/family-office/private-trust-company-formation-plan/SKILL.md
+++ b/family-office/private-trust-company-formation-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: private-trust-company-formation-plan
-display-name: "Private Trust Company Formation Plan"
-description: "Produce a formation plan for a private trust company — jurisdiction, capitalization, board, regulatory requirements."
+display-name: "Family Office · Private Trust Company Formation Plan"
+description: "Family office: Produce a formation plan for a private trust company — jurisdiction, capitalization, board, regulatory requirements."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Private Trust Company Formation Plan

--- a/family-office/real-estate-acquisition-plan/SKILL.md
+++ b/family-office/real-estate-acquisition-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: real-estate-acquisition-plan
-display-name: "Real Estate Acquisition Plan"
-description: "Produce a plan for acquiring a real estate asset — property thesis, financing, entity structure, due diligence, and closing checklist."
+display-name: "Family Office · Real Estate Acquisition Plan"
+description: "Family office: Produce a plan for acquiring a real estate asset — property thesis, financing, entity structure, due diligence, and closing checklist."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Real Estate Acquisition Plan

--- a/family-office/router/SKILL.md
+++ b/family-office/router/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: router
-display-name: "Family Office — Top-Level Router"
-description: "Top-level natural-language router for the Seren family-office catalog. Classifies an advisor ask into one of three pillars (Capital Allocation, Complexity Management, Legacy Preservation) and delegates to the pillar router, which in turn invokes the matching leaf. Single-family-office tenancy. Catalog rebuild tracked in issue #427."
+display-name: "Family Office · Top-Level Router"
+description: "Family office: Top-level natural-language router for the Seren family-office catalog. Classifies an advisor ask into one of three pillars (Capital Allocation, Complexity Management, Legacy Preservation) and delegates to the pillar router, which in turn invokes the matching leaf. Single-family-office tenancy. Catalog rebuild tracked in issue #427."
+tags: [family-office, type:router]
 ---
 
 # Family Office — Top-Level Router

--- a/family-office/succession-planning-memo/SKILL.md
+++ b/family-office/succession-planning-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: succession-planning-memo
-display-name: "Succession Planning Memo"
-description: "Produce a succession planning memo for leadership, ownership, and trustee roles across the family enterprise."
+display-name: "Family Office · Succession Planning Memo"
+description: "Family office: Produce a succession planning memo for leadership, ownership, and trustee roles across the family enterprise."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Succession Planning Memo

--- a/family-office/target-asset-allocation-model/SKILL.md
+++ b/family-office/target-asset-allocation-model/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: target-asset-allocation-model
-display-name: "Target Asset Allocation Model"
-description: "Produce a target asset allocation model across public equities, fixed income, alternatives, real assets, and cash. Captures current allocation, target allocation, and drift bands."
+display-name: "Family Office · Target Asset Allocation Model"
+description: "Family office: Produce a target asset allocation model across public equities, fixed income, alternatives, real assets, and cash. Captures current allocation, target allocation, and drift bands."
+tags: [family-office, pillar:capital-allocation]
 ---
 
 # Target Asset Allocation Model

--- a/family-office/tax-strategy-memo/SKILL.md
+++ b/family-office/tax-strategy-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: tax-strategy-memo
-display-name: "Tax Strategy Memo"
-description: "Produce a tax strategy memo for the family. Captures current year tax posture, elections, harvesting opportunities, and planning moves."
+display-name: "Family Office · Tax Strategy Memo"
+description: "Family office: Produce a tax strategy memo for the family. Captures current year tax posture, elections, harvesting opportunities, and planning moves."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Tax Strategy Memo

--- a/family-office/trust-selection-memo/SKILL.md
+++ b/family-office/trust-selection-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: trust-selection-memo
-display-name: "Trust Selection Memo"
-description: "Produce a trust selection memo comparing revocable, irrevocable, marital, asset-protection, special-needs, spendthrift, bypass, generation-skipping, and dynasty trust options."
+display-name: "Family Office · Trust Selection Memo"
+description: "Family office: Produce a trust selection memo comparing revocable, irrevocable, marital, asset-protection, special-needs, spendthrift, bypass, generation-skipping, and dynasty trust options."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Trust Selection Memo

--- a/family-office/trust-situs-selection-memo/SKILL.md
+++ b/family-office/trust-situs-selection-memo/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: trust-situs-selection-memo
-display-name: "Trust Situs Selection Memo"
-description: "Produce a trust situs selection memo comparing Florida, Delaware, Nevada, Wyoming, and the Dakotas on tax, creditor protection, privacy, and administration."
+display-name: "Family Office · Trust Situs Selection Memo"
+description: "Family office: Produce a trust situs selection memo comparing Florida, Delaware, Nevada, Wyoming, and the Dakotas on tax, creditor protection, privacy, and administration."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Trust Situs Selection Memo

--- a/family-office/virtual-mailbox-setup-plan/SKILL.md
+++ b/family-office/virtual-mailbox-setup-plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: virtual-mailbox-setup-plan
-display-name: "Virtual Mailbox Setup Plan"
-description: "Produce a virtual mailbox setup plan — providers, forwarding rules, scanning cadence, privacy posture."
+display-name: "Family Office · Virtual Mailbox Setup Plan"
+description: "Family office: Produce a virtual mailbox setup plan — providers, forwarding rules, scanning cadence, privacy posture."
+tags: [family-office, pillar:complexity-management]
 ---
 
 # Virtual Mailbox Setup Plan

--- a/family-office/will-drafting-checklist/SKILL.md
+++ b/family-office/will-drafting-checklist/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: will-drafting-checklist
-display-name: "Will Drafting Checklist"
-description: "Produce a checklist an attorney uses to draft or update the principal's will. Captures executor, beneficiaries, specific bequests, residuary, and guardianship."
+display-name: "Family Office · Will Drafting Checklist"
+description: "Family office: Produce a checklist an attorney uses to draft or update the principal's will. Captures executor, beneficiaries, specific bequests, residuary, and guardianship."
+tags: [family-office, pillar:legacy-preservation]
 ---
 
 # Will Drafting Checklist


### PR DESCRIPTION
## Summary

Makes every Family Office skill visually identifiable as a Family Office skill in SerenDesktop's Discovery panel. Previously a search like "Tax" mixed "Exit Tax Minimization Plan" (ours) next to "Kraken 1099-DA Tax" with nothing signaling the publisher.

Closes the branding milestone of #433.

## Frontmatter changes (55 leaves + 4 routers)

| Field | Before | After |
|---|---|---|
| `display-name` | `"Exit Tax Minimization Plan"` | `"Family Office · Exit Tax Minimization Plan"` |
| `description` | `"Produce an exit tax minimization plan ..."` | `"Family office: Produce an exit tax minimization plan ..."` |
| `tags` | (absent) | `[family-office, pillar:capital-allocation]` |

Routers receive canonical display-names from a map (to prevent double-prefix regressions) and an additional `type:router` tag.

## Middle-dot separator

`·` (middle dot) chosen over `—` (em-dash) and `:` (colon):
- Less visually heavy than em-dash
- No "field: value" parse ambiguity
- Common in breadcrumb UIs
- ~42 chars for the longest display-names — will wrap in narrow panels but clusters alphabetically

## Knowledge skill is not rebranded

Explicit test asserts `knowledge/`'s existing display-name is preserved — matches the catalog-wide "knowledge untouched" invariant from PR #428.

## Critical tests — one catalog-wide file

`family-office/cpa-tax-package-checklist/tests/test_branding.py` is the single new test file. It walks every skill and validates:

- Leaves: `display-name` starts with `"Family Office · "`; not double-prefixed.
- Routers: `display-name` matches a canonical map exactly.
- All: `description` starts with `"Family office: "`.
- All: `family-office` tag present.
- Leaves: exactly one `pillar:<x>` tag, and it matches the leaf's `scripts/agent.py` `PILLAR` constant (source of truth — tags cannot drift silently).
- Pillar routers: pillar tag matches map.
- Top router: no pillar tag.
- Routers: `type:router` present; leaves: absent.

Parametrized per-skill with pytest — a failing leaf prints its slug. **61 new tests** (59 skills + count guard + knowledge guard).

No per-leaf duplication of this invariant. Reference leaf hosts all catalog-wide tests (`test_sinks.py`, `test_comms.py`, now `test_branding.py`) by convention.

## Test results

Full suite: **194 passed** (110 smoke + 12 sinks + 11 comms + 61 branding).

## Indexer verification

`node scripts/build-index.mjs` after this change: 60 family-office skills indexed (unchanged count), every one with the new display-name and tags. Sample:

```
Family Office · Annual Budget Workbook            [family-office, pillar:complexity-management]
Family Office · Art Acquisition Due-Diligence Memo [family-office, pillar:complexity-management]
Family Office · Exit Tax Minimization Plan         [family-office, pillar:capital-allocation]
Family Office · Capital Allocation Router          [family-office, pillar:capital-allocation, type:router]
Family Office · Top-Level Router                   [family-office, type:router]
```

## Test plan

- [ ] CI `test` green on Python 3.11 + 3.12 (194 tests)
- [ ] CI regression guards green (indexer-smoke: 60 skills)
- [ ] Knowledge skill diff vs main: empty
- [ ] SerenDesktop Discovery panel: search "Tax" — Family Office entries now visually anchored; do not blend with Kraken Tax skills

## Out of scope (tracked separately in seren-desktop)

- Publisher group / collapsible sidebar section ("Family Office (55)")
- Filter chips built from indexer `tags`
- Publisher-level logo rendered as row icon

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
