### PR TITLE
feat(seren-bucks): filter out business/company emails from outreach candidates

### DIFF
--- a/affiliates/seren-bucks/SKILL.md
+++ b/affiliates/seren-bucks/SKILL.md
@@ -90,6 +90,35 @@ Use only these sources in v1:
 
 Do not expand to LinkedIn, Apollo, web scraping, or purchased lists in v1.
 
+## Personal-Only Targeting Rule
+
+This skill targets **personal relationships only**. Business and company emails are automatically excluded from the candidate pool because affiliate marketing outreach to generic business addresses is inappropriate and ineffective.
+
+### Email Address Pattern Filter
+
+The following email prefixes are automatically rejected:
+
+- Generic: `info@`, `hello@`, `contact@`, `support@`, `sales@`, `partnerships@`, `team@`, `admin@`, `affiliates@`, `press@`, `media@`, `hr@`, `careers@`, `jobs@`, `billing@`, `legal@`
+- Role-based: `marketing@`, `engineering@`, `product@`, `design@`, `ops@`, `finance@`
+- Noreply: `noreply@`, `no-reply@`, `donotreply@`
+
+### Email Content Analysis
+
+When syncing from sent mail history, conversation context is analyzed:
+
+- Transactional threads (invoices, receipts, support tickets) are excluded
+- B2B sales/partnership inquiry threads are excluded
+- Personal/friendly exchanges are prioritized
+
+### Ranking Adjustments
+
+Borderline cases receive score penalties:
+- Business email pattern match: -100 points (effectively excluded)
+- Transactional content detected: -30 points
+- B2B content detected: -50 points
+
+The top-10 proposal set only includes candidates that pass the personal relationship filter.
+
 ## Persistence Rule
 
 Whenever a candidate is discovered or updated:

--- a/affiliates/seren-bucks/scripts/candidate_sync.py
+++ b/affiliates/seren-bucks/scripts/candidate_sync.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from email_filter import is_personal_relationship, compute_personal_score_penalty
+
 
 SOURCE_CATALOG = {
     "gmail_sent": [
@@ -67,6 +69,7 @@ def sync_candidates(config: dict) -> dict:
     source_flags = config["candidate_sources"]
     source_counts: dict[str, int] = {}
     candidates_by_id: dict[str, dict] = {}
+    filtered_out_business: int = 0
 
     for source_name, enabled in source_flags.items():
         if not enabled:
@@ -76,7 +79,19 @@ def sync_candidates(config: dict) -> dict:
         source_items = SOURCE_CATALOG.get(source_name, [])
         source_counts[source_name] = len(source_items)
         for item in source_items:
-            candidates_by_id[item["candidate_id"]] = item
+            email = item.get("email", "")
+            context = {"thread_content": item.get("thread_content", "")}
+
+            if not is_personal_relationship(email, context):
+                filtered_out_business += 1
+                continue
+
+            penalty = compute_personal_score_penalty(email, context)
+            adjusted_score = max(0, item["candidate_score"] - penalty)
+            item_copy = dict(item)
+            item_copy["candidate_score"] = adjusted_score
+            item_copy["personal_filter_applied"] = True
+            candidates_by_id[item["candidate_id"]] = item_copy
 
     candidates = sorted(
         candidates_by_id.values(),
@@ -90,5 +105,6 @@ def sync_candidates(config: dict) -> dict:
         "crm_source_of_truth": "skill_owned_serendb",
         "source_counts": source_counts,
         "discovered_count": len(candidates),
+        "filtered_out_business_emails": filtered_out_business,
         "candidates": candidates,
     }

--- a/affiliates/seren-bucks/scripts/email_filter.py
+++ b/affiliates/seren-bucks/scripts/email_filter.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import re
+
+BUSINESS_PREFIXES = frozenset([
+    "info",
+    "hello",
+    "contact",
+    "support",
+    "sales",
+    "partnerships",
+    "team",
+    "admin",
+    "affiliates",
+    "press",
+    "media",
+    "hr",
+    "careers",
+    "jobs",
+    "billing",
+    "legal",
+    "marketing",
+    "engineering",
+    "product",
+    "design",
+    "ops",
+    "finance",
+    "noreply",
+    "no-reply",
+    "donotreply",
+    "do-not-reply",
+    "help",
+    "service",
+    "services",
+    "feedback",
+    "enquiries",
+    "inquiries",
+    "office",
+    "general",
+    "business",
+    "corporate",
+    "investor",
+    "investors",
+    "relations",
+    "compliance",
+    "security",
+    "privacy",
+    "abuse",
+    "postmaster",
+    "webmaster",
+    "newsletter",
+    "notifications",
+    "alerts",
+    "updates",
+    "subscribe",
+    "unsubscribe",
+])
+
+TRANSACTIONAL_KEYWORDS = frozenset([
+    "invoice",
+    "receipt",
+    "order confirmation",
+    "shipping confirmation",
+    "tracking number",
+    "payment received",
+    "subscription",
+    "renewal",
+    "ticket",
+    "case number",
+    "reference number",
+    "automated message",
+    "do not reply",
+])
+
+B2B_KEYWORDS = frozenset([
+    "partnership proposal",
+    "business inquiry",
+    "rfp",
+    "request for proposal",
+    "vendor",
+    "procurement",
+    "contract",
+    "agreement",
+    "nda",
+    "sow",
+    "statement of work",
+    "purchase order",
+    "po number",
+])
+
+
+def is_business_email(email: str) -> bool:
+    if not email or "@" not in email:
+        return True
+
+    local_part = email.lower().split("@")[0]
+    local_normalized = re.sub(r"[.\-_+]", "", local_part)
+
+    for prefix in BUSINESS_PREFIXES:
+        normalized_prefix = re.sub(r"[.\-_+]", "", prefix)
+        if local_normalized == normalized_prefix:
+            return True
+        if local_normalized.startswith(normalized_prefix) and len(local_normalized) == len(normalized_prefix):
+            return True
+
+    if re.match(r"^[a-z]+\d{2,}$", local_normalized):
+        return True
+
+    return False
+
+
+def is_transactional_content(content: str) -> bool:
+    if not content:
+        return False
+
+    content_lower = content.lower()
+    matches = sum(1 for kw in TRANSACTIONAL_KEYWORDS if kw in content_lower)
+    return matches >= 2
+
+
+def is_b2b_content(content: str) -> bool:
+    if not content:
+        return False
+
+    content_lower = content.lower()
+    matches = sum(1 for kw in B2B_KEYWORDS if kw in content_lower)
+    return matches >= 1
+
+
+def is_personal_relationship(email: str, context: dict | None = None) -> bool:
+    if is_business_email(email):
+        return False
+
+    if context:
+        content = context.get("thread_content", "") or context.get("content", "")
+        if is_transactional_content(content):
+            return False
+        if is_b2b_content(content):
+            return False
+
+    return True
+
+
+def compute_personal_score_penalty(email: str, context: dict | None = None) -> int:
+    penalty = 0
+
+    if is_business_email(email):
+        penalty += 100
+
+    if context:
+        content = context.get("thread_content", "") or context.get("content", "")
+        if is_transactional_content(content):
+            penalty += 30
+        if is_b2b_content(content):
+            penalty += 50
+
+    return penalty

--- a/affiliates/seren-bucks/scripts/ranking.py
+++ b/affiliates/seren-bucks/scripts/ranking.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from common import proposal_size
+from email_filter import is_personal_relationship
 
 
 def build_editable_top10(candidates: list[dict], config: dict) -> dict:
-    ranked = [candidate for candidate in candidates if candidate["dnc_status"] != "blocked"]
+    ranked = [
+        candidate
+        for candidate in candidates
+        if candidate["dnc_status"] != "blocked"
+        and is_personal_relationship(candidate.get("email", ""))
+    ]
     ranked = sorted(ranked, key=lambda item: item["candidate_score"], reverse=True)
     limit = proposal_size(config)
 
@@ -15,8 +21,10 @@ def build_editable_top10(candidates: list[dict], config: dict) -> dict:
                 "rank_position": index,
                 "candidate_id": candidate["candidate_id"],
                 "full_name": candidate["full_name"],
+                "email": candidate.get("email", ""),
                 "organization": candidate["organization"],
                 "candidate_score": candidate["candidate_score"],
+                "personal_filter_applied": candidate.get("personal_filter_applied", False),
                 "editable": True,
             }
         )
@@ -25,5 +33,6 @@ def build_editable_top10(candidates: list[dict], config: dict) -> dict:
         "status": "ok",
         "editable": True,
         "proposal_size": limit,
+        "personal_only": True,
         "top10": top_candidates,
     }

--- a/affiliates/seren-bucks/tests/test_email_filter.py
+++ b/affiliates/seren-bucks/tests/test_email_filter.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from email_filter import (
+    is_business_email,
+    is_personal_relationship,
+    is_transactional_content,
+    is_b2b_content,
+    compute_personal_score_penalty,
+)
+
+
+class TestIsBusinessEmail:
+    def test_generic_prefixes_are_business(self):
+        assert is_business_email("info@company.com") is True
+        assert is_business_email("hello@startup.io") is True
+        assert is_business_email("contact@brand.com") is True
+        assert is_business_email("support@service.com") is True
+        assert is_business_email("partnerships@vercel.com") is True
+        assert is_business_email("affiliates@emergent.sh") is True
+
+    def test_role_prefixes_are_business(self):
+        assert is_business_email("marketing@company.com") is True
+        assert is_business_email("engineering@startup.io") is True
+        assert is_business_email("sales@brand.com") is True
+        assert is_business_email("hr@corp.com") is True
+
+    def test_noreply_is_business(self):
+        assert is_business_email("noreply@company.com") is True
+        assert is_business_email("no-reply@startup.io") is True
+        assert is_business_email("donotreply@brand.com") is True
+
+    def test_personal_names_are_not_business(self):
+        assert is_business_email("john.doe@company.com") is False
+        assert is_business_email("sarah@gmail.com") is False
+        assert is_business_email("mike.smith@startup.io") is False
+        assert is_business_email("alex@alpaca.markets") is False
+
+    def test_empty_or_invalid_is_business(self):
+        assert is_business_email("") is True
+        assert is_business_email("not-an-email") is True
+
+
+class TestIsPersonalRelationship:
+    def test_business_email_is_not_personal(self):
+        assert is_personal_relationship("partnerships@vercel.com") is False
+        assert is_personal_relationship("hello@windsurf.com") is False
+
+    def test_personal_email_with_no_context_is_personal(self):
+        assert is_personal_relationship("john.doe@company.com") is True
+        assert is_personal_relationship("sarah@gmail.com") is True
+
+    def test_transactional_context_is_not_personal(self):
+        context = {"thread_content": "Your invoice #12345 is attached. Payment received."}
+        assert is_personal_relationship("john@company.com", context) is False
+
+    def test_b2b_context_is_not_personal(self):
+        context = {"thread_content": "Please find the partnership proposal attached."}
+        assert is_personal_relationship("john@company.com", context) is False
+
+    def test_friendly_context_is_personal(self):
+        context = {"thread_content": "Hey! Great catching up at the conference last week."}
+        assert is_personal_relationship("john@company.com", context) is True
+
+
+class TestComputePersonalScorePenalty:
+    def test_business_email_gets_max_penalty(self):
+        penalty = compute_personal_score_penalty("info@company.com")
+        assert penalty >= 100
+
+    def test_personal_email_no_penalty(self):
+        penalty = compute_personal_score_penalty("john@gmail.com")
+        assert penalty == 0
+
+    def test_transactional_content_adds_penalty(self):
+        context = {"content": "Invoice #123 and receipt attached"}
+        penalty = compute_personal_score_penalty("john@gmail.com", context)
+        assert penalty == 30
+
+    def test_b2b_content_adds_penalty(self):
+        context = {"content": "Partnership proposal for your review"}
+        penalty = compute_personal_score_penalty("john@gmail.com", context)
+        assert penalty == 50


### PR DESCRIPTION
## Summary

- Add `email_filter.py` module with business email pattern detection
- Filter candidates during sync to exclude generic business addresses (info@, hello@, partnerships@, etc.)
- Apply score penalties for transactional and B2B content context
- Update ranking to enforce personal-only top-10 proposals
- Document personal-only targeting rule in SKILL.md
- Add 14 comprehensive tests for email pattern detection

## Test plan

- [x] All 22 tests pass including 14 new email filter tests
- [x] Business emails like `partnerships@vercel.com` are correctly identified
- [x] Personal emails like `john.doe@company.com` pass through
- [x] Transactional/B2B content context applies score penalties
- [x] Top-10 proposals only include personal relationship candidates

Fixes #435

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
