### PR TITLE
feat(seren-bucks): use google-contacts publisher for address book access

### DIFF
--- a/affiliates/seren-bucks/SKILL.md
+++ b/affiliates/seren-bucks/SKILL.md
@@ -83,10 +83,15 @@ Before claiming any tool, connector, or publisher exists or does not exist, atte
 
 Use only these sources in v1:
 
-1. Gmail sent folder
-2. Outlook sent folder
-3. Gmail address books
-4. Outlook address books
+1. Gmail sent folder — uses `gmail` publisher
+2. Outlook sent folder — uses `outlook` publisher
+3. Gmail address books — uses `google-contacts` publisher (People API)
+4. Outlook address books — uses `outlook-contacts` publisher
+
+**Publisher scope boundaries:**
+- `gmail` is scoped to email operations only (`/messages`, `/threads`, `/drafts`)
+- `google-contacts` is scoped to People API (`/otherContacts`, `/people:searchContacts`)
+- Do not call `/contacts` on the `gmail` publisher — it will return 403
 
 Do not expand to LinkedIn, Apollo, web scraping, or purchased lists in v1.
 

--- a/affiliates/seren-bucks/references/provider-mappings.md
+++ b/affiliates/seren-bucks/references/provider-mappings.md
@@ -3,10 +3,19 @@
 | Capability | Provider | Role in v1 |
 | --- | --- | --- |
 | Affiliate attribution and performance | `seren-affiliates` | Source of truth for campaign metrics |
-| Gmail sent history and address books | `gmail` | Candidate discovery input |
-| Outlook sent history and address books | `outlook` | Candidate discovery input |
+| Gmail sent mail history | `gmail` | Candidate discovery from sent emails |
+| Gmail address books | `google-contacts` | Candidate discovery from contacts (People API) |
+| Outlook sent mail history | `outlook` | Candidate discovery from sent emails |
+| Outlook address books | `outlook-contacts` | Candidate discovery from contacts |
 | Skill-owned CRM and run memory | `serendb` | Source of truth after persistence |
 | Draft generation support | `seren-models` | Optional drafting and rewrite support |
+
+## Publisher Scope Boundaries
+
+- `gmail` — scoped to email operations only: `/messages`, `/labels`, `/threads`, `/drafts`
+- `google-contacts` — scoped to People API: `/otherContacts`, `/people:searchContacts`
+- `outlook` — scoped to email operations only
+- `outlook-contacts` — scoped to contacts API
 
 ## Degradation behavior
 

--- a/affiliates/seren-bucks/scripts/candidate_sync.py
+++ b/affiliates/seren-bucks/scripts/candidate_sync.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from email_filter import is_personal_relationship, compute_personal_score_penalty
 
+PUBLISHER_ROUTING = {
+    "gmail_sent": "gmail",
+    "outlook_sent": "outlook",
+    "gmail_contacts": "google-contacts",
+    "outlook_contacts": "outlook-contacts",
+}
 
 SOURCE_CATALOG = {
     "gmail_sent": [

--- a/affiliates/seren-bucks/tests/test_publisher_routing.py
+++ b/affiliates/seren-bucks/tests/test_publisher_routing.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from candidate_sync import PUBLISHER_ROUTING
+
+
+def test_gmail_contacts_uses_google_contacts_publisher() -> None:
+    """Gmail address books must use google-contacts publisher, not gmail."""
+    assert PUBLISHER_ROUTING["gmail_contacts"] == "google-contacts"
+
+
+def test_gmail_sent_uses_gmail_publisher() -> None:
+    """Gmail sent mail uses gmail publisher."""
+    assert PUBLISHER_ROUTING["gmail_sent"] == "gmail"
+
+
+def test_outlook_contacts_uses_outlook_contacts_publisher() -> None:
+    """Outlook address books use outlook-contacts publisher."""
+    assert PUBLISHER_ROUTING["outlook_contacts"] == "outlook-contacts"
+
+
+def test_outlook_sent_uses_outlook_publisher() -> None:
+    """Outlook sent mail uses outlook publisher."""
+    assert PUBLISHER_ROUTING["outlook_sent"] == "outlook"


### PR DESCRIPTION
## Summary

- Document publisher scope boundaries (gmail for email, google-contacts for People API)
- Add PUBLISHER_ROUTING constant to candidate_sync.py
- gmail_contacts → google-contacts publisher
- outlook_contacts → outlook-contacts publisher
- Add 4 critical tests for publisher routing

Fixes #439

## Test plan

- [x] All 26 tests pass including 4 new publisher routing tests
- [ ] Run seren-bucks skill and verify gmail contacts sync uses google-contacts publisher

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com