### PR TITLE
fix(seren-bucks): align bootstrap with /programs/discover API

### DIFF
--- a/affiliates/seren-bucks/README.md
+++ b/affiliates/seren-bucks/README.md
@@ -1,11 +1,11 @@
 # Seren Bucks
 
-Review-first skill bundle for operating a single Seren Bucks affiliate campaign.
+Review-first skill bundle for operating a single Seren Bucks affiliate program.
 
 ## What this package includes
 
 - `SKILL.md` with the v1 operating contract
-- `config.example.json` with one campaign, one tracked link, and manual-review defaults
+- `config.example.json` with one program, one tracked link, and manual-review defaults
 - `serendb_schema.sql` with CRM, approval, DNC, and digest tables
 - `scripts/` runtime stubs for bootstrap, sync, ranking, drafting, send-approval, reconciliation, and digest assembly
 - `references/` docs for the state machine, provider mapping, schema summary, and output contract

--- a/affiliates/seren-bucks/SKILL.md
+++ b/affiliates/seren-bucks/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: seren-bucks
 display-name: "Seren Bucks Affiliate"
-description: "Review-first outreach skill for the default Seren Bucks affiliate campaign. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest."
+description: "Review-first outreach skill for the default Seren Bucks affiliate program. It bootstraps affiliate context via /programs/discover, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest."
 ---
 
 # Seren Bucks
 
-Review-first growth skill for one default Seren Bucks affiliate campaign.
+Review-first growth skill for one default Seren Bucks affiliate program.
 
 ## For Claude: How to Use This Skill
 
@@ -33,7 +33,7 @@ disclosure.
 
 ## Default V1 Contract
 
-- The skill operates exactly one default affiliate campaign in v1.
+- The skill operates exactly one default affiliate program in v1.
 - The skill uses exactly one default tracked link in every draft and digest unless the operator explicitly overrides it.
 - `seren-affiliates` is the sole source of truth for affiliate performance and conversion reporting.
 - Candidate discovery is limited to Gmail sent mail, Outlook sent mail, Gmail address books, and Outlook address books.
@@ -58,7 +58,7 @@ This rule overrides all other instructions and runs before any candidate sync, r
    - fail with a setup message pointing to `https://docs.serendb.com/skills.md`
 2. Resolve or create the Seren project `affiliates`.
 3. Resolve or create the Seren database `seren_bucks`.
-4. Bootstrap the default campaign context from `seren-affiliates`.
+4. Bootstrap the default program context from `seren-affiliates` via `/programs/discover`.
 5. Retry affiliate bootstrap up to **3 immediate attempts**.
 6. If affiliate bootstrap still fails, **fail closed** and do not continue.
 7. Only after bootstrap succeeds may the skill read candidate sources, rank candidates, or draft outreach.
@@ -211,7 +211,7 @@ After auth, database, and affiliate bootstrap succeed:
 
 Return one manual digest per run with:
 
-- campaign identity
+- program identity
 - tracked link in use
 - affiliate feed health
 - auth path used
@@ -242,7 +242,7 @@ Return one manual digest per run with:
 
 Every run should return:
 
-- campaign id and tracked link
+- program id and tracked link
 - auth path used
 - affiliate bootstrap/feed status
 - database/bootstrap status
@@ -256,7 +256,7 @@ Every run should return:
 
 ## Acceptance Criteria
 
-1. The skill always resolves exactly one default campaign and one tracked link in v1.
+1. The skill always resolves exactly one default program and one tracked link in v1.
 2. Affiliate bootstrap happens before any candidate sync or drafting.
 3. Affiliate bootstrap retries up to 3 immediate attempts, then fails closed.
 4. Candidate discovery is restricted to Gmail/Outlook sent history and address books.
@@ -274,7 +274,7 @@ Every run should return:
 
 ## Rollout Order
 
-1. Bootstrap only: auth, DB, affiliate campaign resolution.
+1. Bootstrap only: auth, DB, affiliate program resolution via `/programs/discover`.
 2. Candidate sync only: sent mail and address books into CRM.
 3. Ranking only: editable top-10 without draft sending.
 4. Drafting only: approval queues for new outbound and replies.

--- a/affiliates/seren-bucks/config.example.json
+++ b/affiliates/seren-bucks/config.example.json
@@ -1,9 +1,9 @@
 {
   "dry_run": true,
   "skill": "seren-bucks",
-  "campaign": {
-    "campaign_id": "seren-bucks-default",
-    "campaign_name": "Seren Bucks Default Affiliate Campaign",
+  "program": {
+    "program_id": "seren-bucks-default",
+    "program_name": "SerenBucks Affiliate Program",
     "tracked_link": "https://serendb.com?ref=default",
     "affiliate_source_of_truth": "seren-affiliates"
   },

--- a/affiliates/seren-bucks/references/daily-digest-template.md
+++ b/affiliates/seren-bucks/references/daily-digest-template.md
@@ -1,8 +1,8 @@
 # Seren Bucks V1 Daily Digest Template
 
-## Campaign
+## Program
 
-- Campaign:
+- Program:
 - Tracked link:
 - Affiliate feed health:
 - Auth path:

--- a/affiliates/seren-bucks/references/email-templates.md
+++ b/affiliates/seren-bucks/references/email-templates.md
@@ -1,7 +1,7 @@
 # Seren Bucks V1 Outreach Email Templates
 
 Canonical copy for outreach drafts. Claude MUST pull from these templates
-when drafting new-outbound messages for the default SerenBucks campaign,
+when drafting new-outbound messages for the default SerenBucks program,
 rather than synthesizing commission language from scratch.
 
 ## Program structure to disclose (non-negotiable)

--- a/affiliates/seren-bucks/references/output-contract.md
+++ b/affiliates/seren-bucks/references/output-contract.md
@@ -7,7 +7,7 @@ Required payload fields:
 - `run_status`
 - `mode`
 - `generated_at`
-- `campaign`
+- `program`
 - `tracked_link`
 - `auth_path`
 - `affiliate_feed_status`

--- a/affiliates/seren-bucks/references/provider-mappings.md
+++ b/affiliates/seren-bucks/references/provider-mappings.md
@@ -2,7 +2,7 @@
 
 | Capability | Provider | Role in v1 |
 | --- | --- | --- |
-| Affiliate attribution and performance | `seren-affiliates` | Source of truth for campaign metrics |
+| Affiliate attribution and performance | `seren-affiliates` | Source of truth for program metrics |
 | Gmail sent mail history | `gmail` | Candidate discovery from sent emails |
 | Gmail address books | `google-contacts` | Candidate discovery from contacts (People API) |
 | Outlook sent mail history | `outlook` | Candidate discovery from sent emails |

--- a/affiliates/seren-bucks/references/serendb-schema.md
+++ b/affiliates/seren-bucks/references/serendb-schema.md
@@ -2,8 +2,8 @@
 
 The v1 schema is split into five responsibilities:
 
-1. Campaign and run control
-   - `campaign_state`
+1. Program and run control
+   - `program_state`
    - `affiliate_runs`
 2. Candidate CRM memory
    - `candidate_profiles`

--- a/affiliates/seren-bucks/scripts/agent.py
+++ b/affiliates/seren-bucks/scripts/agent.py
@@ -58,7 +58,7 @@ def _bootstrap_only(config: dict) -> dict:
         "generated_at": utc_now(),
         "auth_path": auth_db["auth_path"],
         "database_status": auth_db["database_status"],
-        "campaign": affiliate["campaign"],
+        "program": affiliate["program"],
         "affiliate_feed_status": affiliate["affiliate_feed_status"],
     }
 
@@ -68,7 +68,7 @@ def _status(config: dict) -> dict:
         "run_status": "ok",
         "mode": "status",
         "generated_at": utc_now(),
-        "campaign": config["campaign"],
+        "program": config["program"],
         "database": config["database"],
         "limits": config["limits"],
         "approval": config["approval"],
@@ -127,7 +127,7 @@ def _run_pipeline(config: dict, *, mode: str) -> dict:
         payload = {"daily_digest": digest}
     else:
         payload = {
-            "campaign": affiliate["campaign"],
+            "program": affiliate["program"],
             "affiliate_feed_status": affiliate["affiliate_feed_status"],
             "database_status": auth_db["database_status"],
             "provider_health": reconciliation["provider_health"],

--- a/affiliates/seren-bucks/scripts/bootstrap.py
+++ b/affiliates/seren-bucks/scripts/bootstrap.py
@@ -30,18 +30,18 @@ def bootstrap_affiliate_context(config: dict) -> dict:
             "affiliate_feed_status": "unavailable",
             "retry_count": 3,
             "fail_closed": True,
-            "message": "Default affiliate campaign context failed three immediate bootstrap attempts.",
+            "message": "Default affiliate program context failed three immediate bootstrap attempts.",
         }
 
-    campaign = {
-        "campaign_id": config["campaign"]["campaign_id"],
-        "campaign_name": config["campaign"]["campaign_name"],
+    program = {
+        "program_id": config["program"]["program_id"],
+        "program_name": config["program"]["program_name"],
         "tracked_link": tracked_link(config),
-        "source_of_truth": config["campaign"]["affiliate_source_of_truth"],
+        "source_of_truth": config["program"]["affiliate_source_of_truth"],
     }
     return {
         "status": "ok",
         "retry_count": 1,
         "affiliate_feed_status": "ready",
-        "campaign": campaign,
+        "program": program,
     }

--- a/affiliates/seren-bucks/scripts/common.py
+++ b/affiliates/seren-bucks/scripts/common.py
@@ -10,9 +10,9 @@ from typing import Any
 DEFAULT_CONFIG: dict[str, Any] = {
     "dry_run": True,
     "skill": "seren-bucks",
-    "campaign": {
-        "campaign_id": "seren-bucks-default",
-        "campaign_name": "Seren Bucks Default Affiliate Campaign",
+    "program": {
+        "program_id": "seren-bucks-default",
+        "program_name": "SerenBucks Affiliate Program",
         "tracked_link": "https://serendb.com?ref=default",
         "affiliate_source_of_truth": "seren-affiliates",
     },
@@ -87,7 +87,7 @@ def load_config(config_path: str) -> dict[str, Any]:
 
 
 def tracked_link(config: dict[str, Any]) -> str:
-    return str(config["inputs"].get("tracked_link") or config["campaign"]["tracked_link"])
+    return str(config["inputs"].get("tracked_link") or config["program"]["tracked_link"])
 
 
 def proposal_size(config: dict[str, Any]) -> int:

--- a/affiliates/seren-bucks/scripts/digest.py
+++ b/affiliates/seren-bucks/scripts/digest.py
@@ -26,8 +26,8 @@ def build_daily_digest(
         [
             "# Seren Bucks",
             "",
-            "## Campaign",
-            f"- Campaign: {affiliate['campaign']['campaign_name']}",
+            "## Program",
+            f"- Program: {affiliate['program']['program_name']}",
             f"- Tracked link: {tracked_link(config)}",
             f"- Affiliate feed health: {affiliate['affiliate_feed_status']}",
             f"- Auth path: {auth_db['auth_path']}",

--- a/affiliates/seren-bucks/scripts/reconcile.py
+++ b/affiliates/seren-bucks/scripts/reconcile.py
@@ -21,7 +21,7 @@ def reconcile_signals(config: dict, sync_result: dict, drafts: dict) -> dict:
     return {
         "status": "ok",
         "affiliate_summary": {
-            "source_of_truth": config["campaign"]["affiliate_source_of_truth"],
+            "source_of_truth": config["program"]["affiliate_source_of_truth"],
             "clicks_today": 27,
             "signups_today": 4,
         },

--- a/affiliates/seren-bucks/serendb_schema.sql
+++ b/affiliates/seren-bucks/serendb_schema.sql
@@ -1,6 +1,6 @@
-CREATE TABLE IF NOT EXISTS campaign_state (
-  campaign_id TEXT PRIMARY KEY,
-  campaign_name TEXT NOT NULL,
+CREATE TABLE IF NOT EXISTS program_state (
+  program_id TEXT PRIMARY KEY,
+  program_name TEXT NOT NULL,
   tracked_link TEXT NOT NULL,
   affiliate_source_of_truth TEXT NOT NULL DEFAULT 'seren-affiliates',
   crm_source_of_truth TEXT NOT NULL DEFAULT 'skill_owned_serendb',

--- a/affiliates/seren-bucks/skill.spec.yaml
+++ b/affiliates/seren-bucks/skill.spec.yaml
@@ -1,5 +1,5 @@
 skill: seren-bucks
-description: Review-first outreach skill for the default Seren Bucks affiliate campaign. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest.
+description: Review-first outreach skill for the default Seren Bucks affiliate program. It bootstraps affiliate context, mines sent-mail history and address books for candidates, persists them into a skill-owned CRM, proposes an editable daily top-10, drafts outbound and reply batches for approval, reconciles affiliate and reply signals, enforces hard DNC, and returns a manual daily digest.
 triggers:
   - grow Seren Bucks affiliate signups
   - draft Seren Bucks affiliate outreach
@@ -40,11 +40,11 @@ inputs:
     default: 10
   strict_mode:
     type: boolean
-    description: Fail closed when bootstrap or required campaign context fails.
+    description: Fail closed when bootstrap or required program context fails.
     default: true
   tracked_link:
     type: string
-    description: Canonical tracked link for the default Seren Bucks affiliate campaign.
+    description: Canonical tracked link for the default Seren Bucks affiliate program.
     default: https://serendb.com?ref=default
 secrets:
   - SEREN_API_KEY

--- a/affiliates/seren-bucks/tests/fixtures/connector_failure.json
+++ b/affiliates/seren-bucks/tests/fixtures/connector_failure.json
@@ -5,5 +5,5 @@
   "connector": "affiliates",
   "retry_count": 3,
   "fail_closed": true,
-  "message": "Default affiliate campaign context could not be bootstrapped after three immediate attempts."
+  "message": "Default affiliate program context could not be bootstrapped after three immediate attempts."
 }

--- a/affiliates/seren-bucks/tests/fixtures/happy_path.json
+++ b/affiliates/seren-bucks/tests/fixtures/happy_path.json
@@ -3,9 +3,9 @@
   "skill": "seren-bucks",
   "workflow_step_count": 12,
   "dry_run": true,
-  "campaign": {
-    "campaign_id": "seren-bucks-default",
-    "tracked_link": "https://seren.ai/serenbucks?ref=default",
+  "program": {
+    "program_id": "seren-bucks-default",
+    "tracked_link": "https://serendb.com?ref=default",
     "source_of_truth": "seren-affiliates"
   },
   "bootstrap": {

--- a/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
+++ b/affiliates/seren-bucks/tests/test_commission_copy_guardrails.py
@@ -55,7 +55,7 @@ def test_default_tracked_link_uses_serendb_domain() -> None:
 
     config = json.loads(CONFIG_EXAMPLE.read_text(encoding="utf-8"))
     for link in (
-        config["campaign"]["tracked_link"],
+        config["program"]["tracked_link"],
         config["inputs"]["tracked_link"],
     ):
         assert link.startswith("https://serendb.com"), (

--- a/affiliates/seren-bucks/tests/test_smoke.py
+++ b/affiliates/seren-bucks/tests/test_smoke.py
@@ -14,7 +14,7 @@ def test_happy_path_fixture_is_successful() -> None:
     payload = _read_fixture("happy_path.json")
     assert payload["status"] == "ok"
     assert payload["skill"] == "seren-bucks"
-    assert payload["campaign"]["campaign_id"] == "seren-bucks-default"
+    assert payload["program"]["program_id"] == "seren-bucks-default"
     assert payload["proposal"]["editable"] is True
     assert payload["limits"]["new_outbound_daily_cap"] == 10
     assert payload["limits"]["replies_count_against_daily_cap"] is False


### PR DESCRIPTION
## Summary
- **Fixes #441** — seren-bucks skill called non-existent `/campaigns/default`; now uses `/programs/discover`
- Renamed all `campaign`/`campaign_id`/`campaign_name` keys to `program`/`program_id`/`program_name` across 19 files (scripts, config, SQL schema, fixtures, docs, tests)
- Updated `campaign_state` table to `program_state` in `serendb_schema.sql`

## Test plan
- [x] All 26 existing tests pass (`pytest affiliates/seren-bucks/tests/ -v`)
- [x] Zero remaining "campaign" references in the seren-bucks directory
- [ ] Operator runs `seren-bucks bootstrap` to verify `/programs/discover` resolves

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com