### PR TITLE
fix(bat-sales-coach): canonicalize pipeline_stage with CHECK + migration

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -10,6 +10,16 @@ description: "Supportive sales-executive coaching skill that runs a Behavior-Att
 
 Skill instructions are preloaded in context when this skill is active. Do not perform filesystem searches or tool-driven exploration to rediscover them; use the guidance below directly.
 
+## Canonical Pipeline Stages
+
+`prospects.pipeline_stage` and `behavior_tasks.pipeline_stage` are restricted to exactly seven values:
+
+```
+lead | prospecting | discovery | demo_completed | proposal | closed_won | closed_lost
+```
+
+Any other spelling or casing is invalid and must be normalized. Read paths and write paths both rely on this canonical set — never invent new variants, never mix casing, never use hyphens (`closed-lost` is wrong; `closed_lost` is correct).
+
 ## Schema Guard (Mandatory — runs every invoke)
 
 This rule overrides all other instructions and applies before ANY read or write to SerenDB. No data may be read from or written to the database until this guard passes.
@@ -28,13 +38,22 @@ This rule overrides all other instructions and applies before ANY read or write 
    ```sql
    CREATE TABLE IF NOT EXISTS prospects (
      id SERIAL PRIMARY KEY, name TEXT NOT NULL, organization TEXT, email TEXT,
-     phone TEXT, pipeline_stage TEXT, opportunity_value NUMERIC,
+     phone TEXT,
+     pipeline_stage TEXT CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+       'lead','prospecting','discovery','demo_completed',
+       'proposal','closed_won','closed_lost'
+     )),
+     opportunity_value NUMERIC,
      expected_close_date TEXT, notes TEXT,
      created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
    );
    CREATE TABLE IF NOT EXISTS behavior_tasks (
      id SERIAL PRIMARY KEY, prospect_name TEXT, organization TEXT,
-     pipeline_stage TEXT, title TEXT NOT NULL, status TEXT DEFAULT 'planned',
+     pipeline_stage TEXT CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+       'lead','prospecting','discovery','demo_completed',
+       'proposal','closed_won','closed_lost'
+     )),
+     title TEXT NOT NULL, status TEXT DEFAULT 'planned',
      due_date TEXT, start_time TIMESTAMPTZ, completion_time TIMESTAMPTZ,
      opportunity_value NUMERIC, expected_close_date TEXT,
      prospect_response TEXT, next_behavior TEXT,
@@ -71,7 +90,38 @@ This rule overrides all other instructions and applies before ANY read or write 
      created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
    );
    ```
-5. Only after the schema guard passes, proceed to the Returning-User Behavior Check.
+5. Run the canonical-stage migration (idempotent — runs in one transaction every invoke). This normalizes any legacy variant rows and installs the CHECK constraint on databases provisioned before this guard existed. Execute via `run_sql_transaction`:
+   ```sql
+   BEGIN;
+
+   UPDATE prospects SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
+   UPDATE prospects SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
+   UPDATE prospects SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
+   UPDATE prospects SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+
+   UPDATE behavior_tasks SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
+   UPDATE behavior_tasks SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
+   UPDATE behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
+   UPDATE behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+
+   ALTER TABLE prospects DROP CONSTRAINT IF EXISTS prospects_pipeline_stage_check;
+   ALTER TABLE prospects ADD CONSTRAINT prospects_pipeline_stage_check
+     CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+       'lead','prospecting','discovery','demo_completed',
+       'proposal','closed_won','closed_lost'
+     ));
+
+   ALTER TABLE behavior_tasks DROP CONSTRAINT IF EXISTS behavior_tasks_pipeline_stage_check;
+   ALTER TABLE behavior_tasks ADD CONSTRAINT behavior_tasks_pipeline_stage_check
+     CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+       'lead','prospecting','discovery','demo_completed',
+       'proposal','closed_won','closed_lost'
+     ));
+
+   COMMIT;
+   ```
+   If `ALTER TABLE ... ADD CONSTRAINT` raises because a row still violates the canonical set, abort, surface the offending values to the operator, and do not proceed with reads or writes. The migration is one transaction — partial application is not allowed.
+6. Only after the schema guard and migration pass, proceed to the Returning-User Behavior Check.
 
 **Do not skip this guard.** Do not assume tables exist from a prior session. Do not proceed to any read or write if the check has not run. Violations of this rule are P0 data-loss defects.
 

--- a/sales/bat-sales-coach/serendb_schema.sql
+++ b/sales/bat-sales-coach/serendb_schema.sql
@@ -1,5 +1,9 @@
 -- BAT Sales Coach schema for SerenDB
 -- Tables: prospects, behavior_tasks, behavior_journals, attitude_journals, technique_plans, coaching_sessions
+--
+-- pipeline_stage is restricted to a canonical 7-value set:
+--   lead | prospecting | discovery | demo_completed | proposal | closed_won | closed_lost
+-- See SKILL.md "Canonical Pipeline Stages" for the contract.
 
 CREATE SCHEMA IF NOT EXISTS {{schema_name}};
 
@@ -7,7 +11,11 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.prospects (
     id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
     name            TEXT NOT NULL,
     organization    TEXT,
-    pipeline_stage  TEXT DEFAULT 'new_lead',
+    pipeline_stage  TEXT DEFAULT 'lead'
+        CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+            'lead','prospecting','discovery','demo_completed',
+            'proposal','closed_won','closed_lost'
+        )),
     opportunity_value_usd NUMERIC(12,2) DEFAULT 0,
     expected_close_date TEXT,
     notes           TEXT,
@@ -21,7 +29,11 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.behavior_tasks (
     prospect_id     TEXT REFERENCES {{schema_name}}.prospects(id),
     prospect_name   TEXT,
     organization    TEXT,
-    pipeline_stage  TEXT,
+    pipeline_stage  TEXT
+        CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+            'lead','prospecting','discovery','demo_completed',
+            'proposal','closed_won','closed_lost'
+        )),
     title           TEXT NOT NULL,
     behavior_type   TEXT DEFAULT 'outreach',
     status          TEXT DEFAULT 'planned',
@@ -90,3 +102,32 @@ CREATE INDEX IF NOT EXISTS idx_behavior_tasks_prospect
 
 CREATE INDEX IF NOT EXISTS idx_coaching_sessions_date
     ON {{schema_name}}.coaching_sessions (session_date);
+
+-- Canonical pipeline_stage migration. Idempotent on every bootstrap:
+-- normalize legacy variants (Title Case, hyphenated, space/slash forms),
+-- then re-install the CHECK constraint so databases provisioned before
+-- this guard existed converge on the canonical 7-value set.
+
+UPDATE {{schema_name}}.prospects SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
+UPDATE {{schema_name}}.prospects SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
+UPDATE {{schema_name}}.prospects SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
+UPDATE {{schema_name}}.prospects SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+
+ALTER TABLE {{schema_name}}.prospects DROP CONSTRAINT IF EXISTS prospects_pipeline_stage_check;
+ALTER TABLE {{schema_name}}.prospects ADD CONSTRAINT prospects_pipeline_stage_check
+    CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+        'lead','prospecting','discovery','demo_completed',
+        'proposal','closed_won','closed_lost'
+    ));
+
+ALTER TABLE {{schema_name}}.behavior_tasks DROP CONSTRAINT IF EXISTS behavior_tasks_pipeline_stage_check;
+ALTER TABLE {{schema_name}}.behavior_tasks ADD CONSTRAINT behavior_tasks_pipeline_stage_check
+    CHECK (pipeline_stage IS NULL OR pipeline_stage IN (
+        'lead','prospecting','discovery','demo_completed',
+        'proposal','closed_won','closed_lost'
+    ));

--- a/sales/bat-sales-coach/tests/test_smoke.py
+++ b/sales/bat-sales-coach/tests/test_smoke.py
@@ -198,3 +198,45 @@ def test_guardrail_g7_attitude_trend_monitoring() -> None:
     content = SKILL_PATH.read_text(encoding="utf-8")
     assert "## Attitude Trend Monitoring" in content
     assert "3 or more consecutive sessions" in content
+
+
+# --- Canonical pipeline_stage contract (issue #446) ---
+
+CANONICAL_STAGES = (
+    "lead", "prospecting", "discovery", "demo_completed",
+    "proposal", "closed_won", "closed_lost",
+)
+
+
+def test_canonical_pipeline_stages_documented_in_skill_md() -> None:
+    """SKILL.md must declare the canonical 7-value pipeline_stage set."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "## Canonical Pipeline Stages" in content
+    for stage in CANONICAL_STAGES:
+        assert stage in content, f"Canonical stage missing from SKILL.md: {stage}"
+
+
+def test_skill_md_schema_guard_enforces_canonical_stages() -> None:
+    """SKILL.md Schema Guard must contain CHECK constraint and migration mappings for all known legacy variants."""
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "prospects_pipeline_stage_check" in content
+    assert "behavior_tasks_pipeline_stage_check" in content
+    for variant, canonical in [
+        ("'Prospecting'", "'prospecting'"),
+        ("'closed-lost'", "'closed_lost'"),
+        ("'Intro Pending','Discovery / Demo'", "'discovery'"),
+        ("'Proposal / Pricing'", "'proposal'"),
+    ]:
+        assert variant in content, f"SKILL.md missing legacy variant: {variant}"
+        assert canonical in content, f"SKILL.md missing canonical target: {canonical}"
+
+
+def test_serendb_schema_enforces_canonical_stages() -> None:
+    """serendb_schema.sql must apply the same CHECK constraint and idempotent migration."""
+    content = SCHEMA_PATH.read_text(encoding="utf-8")
+    assert content.count("CHECK (pipeline_stage IS NULL OR pipeline_stage IN") >= 4
+    assert "prospects_pipeline_stage_check" in content
+    assert "behavior_tasks_pipeline_stage_check" in content
+    for variant in ("'Prospecting'", "'closed-lost'", "'Intro Pending'",
+                    "'Discovery / Demo'", "'Proposal / Pricing'"):
+        assert variant in content, f"Schema migration missing variant: {variant}"


### PR DESCRIPTION
## Summary

- Lock `prospects.pipeline_stage` and `behavior_tasks.pipeline_stage` to a canonical 7-value set: `lead | prospecting | discovery | demo_completed | proposal | closed_won | closed_lost`.
- Install a CHECK constraint on every new database (Schema Guard DDL + `serendb_schema.sql`) and on every existing database via an idempotent migration that runs in one transaction.
- Normalize legacy variants on every Schema Guard pass (`Prospecting`, `closed-lost`, `Intro Pending`, `Discovery / Demo`, `Proposal / Pricing`).

Closes #446.

## Why

`pipeline_stage` was a plain `TEXT` with no constraint. Three writers (skill loop, CRM-style importer, old seed data) each invented their own convention, so a single 667-row table held 9 distinct spellings. A pipeline read missed `closed-lost` (hyphen variant) and dropped `lead` rows wholesale, hiding active deals from the operator. Fixing this at the database level prevents the bug class entirely — future writes that don't match the canonical set are rejected by Postgres.

## Test plan

- [x] `pytest tests/test_smoke.py` — 23 pass (was 20). Three new tests cover canonical-set documentation, SKILL.md migration mappings + CHECK, and SQL schema migration + CHECK.
- [ ] Post-merge: verify Seren Desktop pulls the new SKILL.md and run the skill once on the live `bat_sales_coach` database. Confirm the migration normalizes 21 variant rows and the CHECK constraint blocks future invalid writes.

## Pre-existing failures (not caused by this PR)

`test_skill_md_documents_first_run_setup` and `test_guardrail_g2_attitude_loop_opt_in` fail on `main` already. They reference SKILL.md sections that don't exist in the current document. Tracking separately — out of scope here.
