### PR TITLE
fix(bat-sales-coach): map Meeting/Discovery and Grant Application to canonical stages

### DIFF
--- a/sales/bat-sales-coach/SKILL.md
+++ b/sales/bat-sales-coach/SKILL.md
@@ -101,8 +101,8 @@ This rule overrides all other instructions and applies before ANY read or write 
 
    UPDATE behavior_tasks SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
    UPDATE behavior_tasks SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
-   UPDATE behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
-   UPDATE behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+   UPDATE behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo','Meeting/Discovery');
+   UPDATE behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage IN ('Proposal / Pricing','Grant Application');
 
    ALTER TABLE prospects DROP CONSTRAINT IF EXISTS prospects_pipeline_stage_check;
    ALTER TABLE prospects ADD CONSTRAINT prospects_pipeline_stage_check

--- a/sales/bat-sales-coach/serendb_schema.sql
+++ b/sales/bat-sales-coach/serendb_schema.sql
@@ -115,8 +115,8 @@ UPDATE {{schema_name}}.prospects SET pipeline_stage = 'proposal'    WHERE pipeli
 
 UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'prospecting' WHERE pipeline_stage = 'Prospecting';
 UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'closed_lost' WHERE pipeline_stage = 'closed-lost';
-UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo');
-UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage = 'Proposal / Pricing';
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'discovery'   WHERE pipeline_stage IN ('Intro Pending','Discovery / Demo','Meeting/Discovery');
+UPDATE {{schema_name}}.behavior_tasks SET pipeline_stage = 'proposal'    WHERE pipeline_stage IN ('Proposal / Pricing','Grant Application');
 
 ALTER TABLE {{schema_name}}.prospects DROP CONSTRAINT IF EXISTS prospects_pipeline_stage_check;
 ALTER TABLE {{schema_name}}.prospects ADD CONSTRAINT prospects_pipeline_stage_check

--- a/sales/bat-sales-coach/tests/test_smoke.py
+++ b/sales/bat-sales-coach/tests/test_smoke.py
@@ -224,8 +224,8 @@ def test_skill_md_schema_guard_enforces_canonical_stages() -> None:
     for variant, canonical in [
         ("'Prospecting'", "'prospecting'"),
         ("'closed-lost'", "'closed_lost'"),
-        ("'Intro Pending','Discovery / Demo'", "'discovery'"),
-        ("'Proposal / Pricing'", "'proposal'"),
+        ("'Intro Pending','Discovery / Demo','Meeting/Discovery'", "'discovery'"),
+        ("'Proposal / Pricing','Grant Application'", "'proposal'"),
     ]:
         assert variant in content, f"SKILL.md missing legacy variant: {variant}"
         assert canonical in content, f"SKILL.md missing canonical target: {canonical}"
@@ -238,5 +238,6 @@ def test_serendb_schema_enforces_canonical_stages() -> None:
     assert "prospects_pipeline_stage_check" in content
     assert "behavior_tasks_pipeline_stage_check" in content
     for variant in ("'Prospecting'", "'closed-lost'", "'Intro Pending'",
-                    "'Discovery / Demo'", "'Proposal / Pricing'"):
+                    "'Discovery / Demo'", "'Proposal / Pricing'",
+                    "'Meeting/Discovery'", "'Grant Application'"):
         assert variant in content, f"Schema migration missing variant: {variant}"


### PR DESCRIPTION
## Summary

- Extends the `behavior_tasks` UPDATE block in `SKILL.md` and `serendb_schema.sql` to map `Meeting/Discovery` -> `discovery` and `Grant Application` -> `proposal`.
- Adds these two variants to the existing canonical-stage regression guards in `tests/test_smoke.py`.

Closes #448.

## Why

The migration shipped in #447 covered every legacy variant present in `prospects`, but `behavior_tasks` had two additional values that were not mapped. When the Schema Guard ran the migration on a database with these rows, `ALTER TABLE ADD CONSTRAINT` aborted, the transaction rolled back, and the Schema Guard blocked all reads/writes until the operator intervened. This was caught when re-running the bat-sales-coach skill against a real customer database.

## Test plan

- [x] Extended canonical-stage tests pass: `test_skill_md_schema_guard_enforces_canonical_stages`, `test_serendb_schema_enforces_canonical_stages`, `test_canonical_pipeline_stages_documented_in_skill_md`.
- [x] All other `tests/test_smoke.py` tests behave the same as on `main` (two pre-existing failures unrelated to this change: `test_skill_md_documents_first_run_setup`, `test_guardrail_g2_attitude_loop_opt_in` -- to be addressed separately).
- [ ] Live migration re-run in the bat-sales-coach customer database after merge.
